### PR TITLE
fix: dark theme and append menu layout issues

### DIFF
--- a/apps/bpmn-webview/src/styles/dark-theme/colors.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/colors.css
@@ -34,8 +34,10 @@
 
     --dt-color-red-a10: var(--vscode-errorForeground, #E65C57);
     --dt-color-red-a10-invert-opacity-60: color-mix(in srgb, #15999e 60%, transparent);
-    /** No VS Code equivalent for error background — keep hardcoded */
-    --dt-color-red-a20: hsl(360, 100%, 92%);
+    /** Dark-mode error background: a muted red tinted surface, not the
+     *  near-white pink used in light mode. Mixes the error foreground with
+     *  the editor background so it stays readable behind the error text. */
+    --dt-color-red-a20: color-mix(in srgb, var(--vscode-errorForeground, #E65C57) 22%, var(--vscode-editor-background, #121212));
 
     --dt-color-blue-a50: var(--vscode-textLink-foreground, hsl(205, 100%, 50%));
 }

--- a/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
@@ -24,7 +24,7 @@
     --palette-entry-color: var(--dt-primary-a40);
     --palette-entry-hover-color: var(--dt-primary-a50);
     --palette-entry-selected-color: var(--dt-primary-a0);
-    --palette-separator-color: var(--dt-surface-tonal-a40);
+    --palette-separator-color: var(--dt-surface-a30);
     --palette-toggle-hover-background-color: var(--dt-surface-a60);
     --palette-background-color: var(--dt-surface-a10);
     --palette-border-color: var(--dt-surface-tonal-a40);
@@ -142,15 +142,22 @@ defs marker > circle {
 /**
  * Popup
  */
-.djs-popup-entry-name {
-    filter: invert(1) !important;
-}
-
 .djs-popup-title {
     color: var(--dt-surface-a70) !important;
 }
 
 .djs-popup-header-group > li > button {
     color: var(--dt-primary-a50) !important;
+}
+
+/**
+ * "Powered by bpmn.io" attribution logo.
+ *
+ * bpmn-js hardcodes `color: #404040` as an inline style and the SVG uses
+ * `fill="currentColor"`, so the logo is nearly invisible on dark backgrounds.
+ * Override with a light muted grey that stays subtle but readable.
+ */
+.bjs-powered-by {
+    color: var(--dt-surface-a50) !important;
 }
 

--- a/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
@@ -207,3 +207,37 @@
         color: var(--dt-surface-a70) !important;
     }
 }
+
+/* Dark-theme layout overrides for the host page.
+ *
+ * default.css paints html/body white and the panel dividers light grey.
+ * Any 1-px rounding gap in the flex layout (e.g. when the properties panel
+ * is collapsed to width 0) lets the white body show through, producing the
+ * bright vertical strip that was reported on the dark theme. */
+html,
+body {
+    background-color: var(--dt-surface-a0);
+    color: var(--dt-surface-a70);
+}
+
+.panel-resizer {
+    border-left-color: var(--dt-surface-a20);
+}
+
+.panel-resizer:hover {
+    background-color: var(--dt-primary-a0-opacity-30);
+    border-left-color: var(--dt-primary-a10);
+}
+
+.panel-resizer.collapsed {
+    border-left-color: transparent;
+}
+
+.panel-resizer.collapsed:hover {
+    background-color: var(--dt-primary-a0-opacity-30);
+    border-left-color: var(--dt-primary-a10);
+}
+
+.properties-panel-parent {
+    border-left-color: var(--dt-surface-a30);
+}

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -75,15 +75,18 @@ export function AppendMenuOverlay({
     onSelect,
     onCancel,
 }: AppendMenuOverlayProps) {
+    const hasTemplates = templateEntries.length > 0;
+
     const [search, setSearch] = useState("");
     const [activeCategory, setActiveCategory] = useState<string | null>(null);
     const [selectedTemplate, setSelectedTemplate] = useState<EnrichedTemplateEntry | null>(null);
-    const [paletteExpanded, setPaletteExpanded] = useState(false);
+    // When the workspace has no element templates, default to the expanded
+    // palette so users see the full BPMN element list instead of an awkward
+    // icon-only column next to an empty template panel.
+    const [paletteExpanded, setPaletteExpanded] = useState(!hasTemplates);
     const searchRef = useRef<HTMLInputElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const [panelStyle, setPanelStyle] = useState<{ left: number; top: number } | null>(null);
-
-    const hasTemplates = templateEntries.length > 0;
 
     // The set of BPMN types the selected multi-type template applies to.
     const appliesToFilter = useMemo<Set<string> | null>(() => {


### PR DESCRIPTION
**Issue**

Closes: #899, #900 

**Description**

Improve dark theme consistency and usability by updating error background
colors to work properly on dark surfaces, fixing the powered-by attribution
logo visibility, adjusting panel divider colors, and defaulting the palette
to expanded when no element templates are available to avoid showing an
awkward empty template panel.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
