### PR TITLE
feat: add toggle button to reopen collapsed properties panel

### DIFF
--- a/apps/bpmn-webview/src/app/resizer.ts
+++ b/apps/bpmn-webview/src/app/resizer.ts
@@ -9,6 +9,49 @@ const MAX_PANEL_WIDTH = 1600;
 /** CSS class applied to the panel when it is collapsed (width 0, hidden). */
 const COLLAPSED_CLASS = "collapsed";
 
+/** English fallback label for the toggle button, used as the translation key. */
+const OPEN_PANEL_LABEL = "Open properties panel";
+
+/**
+ * Chevron-left SVG used as the toggle button icon.
+ * Inline so no additional icon dependency is required.
+ */
+const CHEVRON_LEFT_SVG = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="10" height="14" viewBox="0 0 10 14" aria-hidden="true" focusable="false">
+    <path d="M7.5 2 2 7l5.5 5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+`;
+
+/**
+ * Holds references to the toggle button and a translate function so the label
+ * can be refreshed when the user switches language after init.
+ */
+let toggleButton: HTMLButtonElement | undefined;
+let translateFn: (key: string) => string = (key) => key;
+
+/**
+ * Applies the current translation to the toggle button's `aria-label` and
+ * `title` attributes. Safe to call before the button has been created.
+ */
+function applyToggleButtonTranslation(): void {
+    if (!toggleButton) {
+        return;
+    }
+    const label = translateFn(OPEN_PANEL_LABEL);
+    toggleButton.setAttribute("aria-label", label);
+    toggleButton.title = label;
+}
+
+/**
+ * Registers the translate function used for the toggle button's accessible
+ * label and tooltip. Call this once the bpmn-js DI container is ready, and
+ * again after every language switch to refresh the label.
+ */
+export function setResizerTranslate(translate: (key: string) => string): void {
+    translateFn = translate;
+    applyToggleButtonTranslation();
+}
+
 /**
  * Attaches mouse-drag listeners to the `.panel-resizer` element so the user
  * can resize the properties panel by dragging the divider.
@@ -48,6 +91,36 @@ export function initResizer(): void {
     let targetWidth = 0;
     /** Whether the panel is currently collapsed (zero width). */
     let isCollapsed = false;
+
+    /**
+     * Create the toggle button and append it to the resizer. The button is
+     * hidden via CSS (`.panel-resizer-toggle` is only shown while the resizer
+     * carries the `collapsed` class) so we do not need to toggle its
+     * visibility from JavaScript.
+     */
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "panel-resizer-toggle";
+    button.innerHTML = CHEVRON_LEFT_SVG;
+    // Prevent the click from starting a resize drag on the surrounding resizer.
+    button.addEventListener("mousedown", (e: MouseEvent) => {
+        e.stopPropagation();
+    });
+    button.addEventListener("click", (e: MouseEvent) => {
+        e.stopPropagation();
+        if (!isCollapsed) {
+            return;
+        }
+        expand();
+        // Open to twice the drag-to-collapse threshold so the panel appears
+        // with enough room to read its contents without immediate resizing.
+        const openWidth = MIN_PANEL_WIDTH * 2;
+        targetWidth = openWidth;
+        panel.style.width = `${openWidth}px`;
+    });
+    resizer.appendChild(button);
+    toggleButton = button;
+    applyToggleButtonTranslation();
 
     /**
      * Collapse the panel to zero width and mark both the panel and the resizer

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -37,6 +37,7 @@ import {
     BpmnModeler,
     getVsCodeApi,
     initResizer,
+    setResizerTranslate,
     installContentEditableClipboardPolyfill,
     UnsupportedEngineError,
     initTheme,
@@ -163,6 +164,11 @@ window.onload = async function () {
         extraModules,
     );
     modelerIsInitialized = true;
+
+    // Resizer is created before the modeler, so wire up translation now that
+    // the bpmn-js DI container (and therefore the shared translator) is ready.
+    const translator = bpmnModeler.getService<CustomTranslator>("customTranslator");
+    setResizerTranslate((key) => translator.translate(key));
 
     console.debug("[DEBUG] Modeler is initialized...");
 
@@ -313,6 +319,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                 const query = message.data as LanguageQuery;
                 const translator = bpmnModeler.getService<CustomTranslator>("customTranslator");
                 translator.setLanguage(query.locale as SupportedLocale);
+                setResizerTranslate((key) => translator.translate(key));
                 await refreshDiagram();
             } catch (error: any) {
                 vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));

--- a/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
@@ -229,13 +229,37 @@ body {
     border-left-color: var(--dt-primary-a10);
 }
 
+/* Override the accent colors used by the collapsed resizer's pseudo-element
+ * line segments. default.css exposes `--panel-resizer-accent-color` and
+ * `--panel-resizer-accent-hover-color`, so overriding the custom properties
+ * here wins regardless of stylesheet load order. */
 .panel-resizer.collapsed {
-    border-left-color: transparent;
+    --panel-resizer-accent-color: var(--dt-surface-a30);
+    --panel-resizer-accent-hover-color: var(--dt-primary-a10);
 }
 
 .panel-resizer.collapsed:hover {
     background-color: var(--dt-primary-a0-opacity-30);
-    border-left-color: var(--dt-primary-a10);
+}
+
+.panel-resizer.collapsed:has(.panel-resizer-toggle:hover) {
+    background-color: transparent;
+}
+
+.panel-resizer-toggle {
+    background-color: var(--dt-surface-a10);
+    border-color: var(--dt-surface-a30);
+    color: var(--dt-surface-a70);
+}
+
+.panel-resizer-toggle:hover {
+    background-color: var(--dt-primary-a0-opacity-30);
+    border-color: var(--dt-primary-a10);
+    color: var(--dt-primary-a10);
+}
+
+.panel-resizer-toggle:focus-visible {
+    outline-color: var(--dt-primary-a10);
 }
 
 .properties-panel-parent {

--- a/apps/bpmn-webview/src/styles/default.css
+++ b/apps/bpmn-webview/src/styles/default.css
@@ -97,6 +97,12 @@ a:link {
     border-left: 1px solid #e0e0e0;
     transition: background-color 0.15s ease, width 0.15s ease;
     position: relative;
+    /* Default accent colors for the collapsed-state line segments. Declared
+     * at `.panel-resizer` (specificity 0,1,0) so that a theme override placed
+     * on `.panel-resizer.collapsed` (specificity 0,2,0) always wins,
+     * regardless of stylesheet load order. */
+    --panel-resizer-accent-color: rgba(0, 120, 212, 0.4);
+    --panel-resizer-accent-hover-color: rgba(0, 120, 212, 0.8);
 }
 
 .panel-resizer:hover {
@@ -106,12 +112,114 @@ a:link {
 
 .panel-resizer.collapsed {
     width: 8px;
-    border-left-color: rgba(0, 120, 212, 0.4);
+    /* The blue accent line is drawn by the `::before` / `::after`
+     * pseudo-elements below instead of `border-left`. A real border is
+     * rendered at the parent's border-box edge, and the absolutely-
+     * positioned toggle button inside the resizer does not reliably cover
+     * it (Chromium paints the border above the button's background in some
+     * layer configurations). Splitting the line into two pseudo-element
+     * segments that physically stop above and resume below the button
+     * guarantees a clean interruption without relying on stacking/compositing
+     * behavior.
+     *
+     * The accent colors are themed via `--panel-resizer-accent-color` and
+     * `--panel-resizer-accent-hover-color`, which are declared on
+     * `.panel-resizer` above.
+     *
+     * Zero the border width outright instead of just setting the color to
+     * transparent — otherwise the generic `.panel-resizer:hover` rule (here
+     * or in the dark theme) can recolor a still-present 1 px border back to
+     * a visible value on hover, reintroducing the through-button bleed. */
+    border-left-width: 0;
+}
+
+/* Two segments of the blue accent line: one above the toggle button, one
+ * below. The gap between them is calculated from the button's fixed 40 px
+ * height (20 px half-height + 2 px visual breathing room). */
+.panel-resizer.collapsed::before,
+.panel-resizer.collapsed::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 1px;
+    background-color: var(--panel-resizer-accent-color);
+    pointer-events: none;
+}
+
+.panel-resizer.collapsed::before {
+    top: 0;
+    bottom: calc(50% + 22px);
+}
+
+.panel-resizer.collapsed::after {
+    top: calc(50% + 22px);
+    bottom: 0;
 }
 
 .panel-resizer.collapsed:hover {
     background-color: rgba(0, 120, 212, 0.2);
-    border-left-color: rgba(0, 120, 212, 0.8);
+}
+
+.panel-resizer.collapsed:hover::before,
+.panel-resizer.collapsed:hover::after {
+    background-color: var(--panel-resizer-accent-hover-color);
+}
+
+/* When the pointer is over the toggle button the button supplies its own
+ * hover styling. Suppress the resizer's collapsed-hover tint so the two do
+ * not stack into a halo effect around the button. */
+.panel-resizer.collapsed:has(.panel-resizer-toggle:hover) {
+    background-color: transparent;
+}
+
+.panel-resizer.collapsed:has(.panel-resizer-toggle:hover)::before,
+.panel-resizer.collapsed:has(.panel-resizer-toggle:hover)::after {
+    background-color: var(--panel-resizer-accent-color);
+}
+
+/* Toggle button shown only when the panel is collapsed.
+ * The button sits in the middle of the collapsed resizer bar and protrudes
+ * slightly to the left over the canvas, mirroring the Camunda Modeler pattern
+ * so users have an obvious affordance to reopen the panel. */
+.panel-resizer-toggle {
+    display: none;
+    position: absolute;
+    /* Vertical centering via top + margin instead of `transform: translateY(-50%)`.
+     * A transform places the button in its own compositor layer, which in
+     * Chromium causes the resizer's `border-left` to bleed through the
+     * button's opaque background. Plain top + negative margin keeps the
+     * button in the parent's paint layer so the background correctly
+     * interrupts the resizer's blue accent line where the pill sits. */
+    top: 50%;
+    margin-top: -20px;
+    right: 0;
+    width: 14px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid rgba(0, 120, 212, 0.4);
+    border-right: none;
+    border-radius: 4px 0 0 4px;
+    background-color: #f5f5f5;
+    color: #555;
+    cursor: pointer;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+    transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.panel-resizer.collapsed .panel-resizer-toggle {
+    display: flex;
+}
+
+.panel-resizer-toggle:hover {
+    background-color: rgba(0, 120, 212, 0.15);
+    color: rgba(0, 120, 212, 0.9);
+}
+
+.panel-resizer-toggle:focus-visible {
+    outline: 2px solid rgba(0, 120, 212, 0.8);
+    outline-offset: 1px;
 }
 
 .properties-panel-parent {

--- a/libs/bpmn-i18n/src/languages/de/other.ts
+++ b/libs/bpmn-i18n/src/languages/de/other.ts
@@ -152,6 +152,7 @@ const translations: Record<string, string> = {
     "Must provide a standard event": "Muss ein Standardereignis bereitstellen",
     "Not found": "Nicht gefunden",
     "Open minimap": "Minikarte öffnen",
+    "Open properties panel": "Eigenschaften-Panel öffnen",
     "Output Expression": "Ausgangsausdruck",
     "Output Label": "Ausgabebezeichnung",
     "Output Name": "Ausgabename",

--- a/libs/bpmn-i18n/src/languages/en/other.ts
+++ b/libs/bpmn-i18n/src/languages/en/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "Open minimap",
+    "Open properties panel": "Open properties panel",
     "This maps to the process definition key.": "This maps to the process definition key.",
     "Key": "Key",
     "Intermediate Throw Event": "Intermediate Throw Event",

--- a/libs/bpmn-i18n/src/languages/es/other.ts
+++ b/libs/bpmn-i18n/src/languages/es/other.ts
@@ -148,6 +148,7 @@ const translations: Record<string, string> = {
     "Must provide a standard event": "Debe proporcionar un evento estándar",
     "Not found": "No encontrado",
     "Open minimap": "Abrir minimapa",
+    "Open properties panel": "Abrir panel de propiedades",
     "Output Expression": "Expresión de salida",
     "Output Label": "Etiqueta de salida",
     "Output Name": "Nombre de salida",

--- a/libs/bpmn-i18n/src/languages/fr/other.ts
+++ b/libs/bpmn-i18n/src/languages/fr/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "Ouvrir la mini-carte",
+    "Open properties panel": "Ouvrir le panneau de propriétés",
     "This maps to the process definition key.": "Cela correspond à la clé de définition du processus.",
     "Key": "Clé",
     "Intermediate Throw Event": "Événement de lancement intermédiaire",

--- a/libs/bpmn-i18n/src/languages/nl-nl/other.ts
+++ b/libs/bpmn-i18n/src/languages/nl-nl/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "Open minimap",
+    "Open properties panel": "Eigenschappenpaneel openen",
     "This maps to the process definition key.": "Dit wordt vertaald naar de process definition key.",
     "Key": "Key",
     "Intermediate Throw Event": "Intermediate-Throw-Event",

--- a/libs/bpmn-i18n/src/languages/pt-br/other.ts
+++ b/libs/bpmn-i18n/src/languages/pt-br/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "Abrir mini-mapa",
+    "Open properties panel": "Abrir painel de propriedades",
     "This maps to the process definition key.": "Aponta para a chave de definição do processo.",
     "Key": "Chave",
     "Intermediate Throw Event": "Evento Intermediário de Lançamento",

--- a/libs/bpmn-i18n/src/languages/ru/other.ts
+++ b/libs/bpmn-i18n/src/languages/ru/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "Открыть миникарту",
+    "Open properties panel": "Открыть панель свойств",
     "This maps to the process definition key.": "Это соответствует ключу процесса.",
     "Key": "Ключ",
     "Intermediate Throw Event": "Промежуточное событие отправления",

--- a/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "打开缩略图",
+    "Open properties panel": "打开属性面板",
     "This maps to the process definition key.": "映射为流程定义Key.",
     "Key": "Key",
     "Intermediate Throw Event": "中间抛出事件",

--- a/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
@@ -19,6 +19,7 @@
  */
 const translations: Record<string, string> = {
     "Open minimap": "打開縮略圖",
+    "Open properties panel": "打開屬性面板",
     "This maps to the process definition key.": "映射為流程定義Key.",
     "Key": "Key",
     "Intermediate Throw Event": "中間抛出事件",


### PR DESCRIPTION
**Issue**

Closes: #903

**Description**

The collapsed resizer now displays a chevron button that allows users to quickly  reopen the properties panel. The button is positioned in the middle of the collapsed resizer bar and includes accessible labeling with multi-language support. 
CSS pseudo-elements create the accent line segments above and below the button to maintain visual continuity without border bleeding issues. 
Translation function is wired up both at initialization and on language switches.


**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
