### PR TITLE
feat: add BPMN diff view with side-by-side canvas comparison

### DIFF
--- a/apps/bpmn-webview/src/app/__fixtures__/mock-diff.ts
+++ b/apps/bpmn-webview/src/app/__fixtures__/mock-diff.ts
@@ -1,0 +1,171 @@
+/**
+ * Fixture BPMN XMLs for the dev-mode diff preview.
+ *
+ * Used exclusively by the `MockedVsCodeApi` in `vscode.ts` when the webview
+ * is booted with `?mode=diff-before` or `?mode=diff-after`.  The two diagrams
+ * differ in every category `bpmn-js-differ` reports:
+ *
+ *   - `_changed`        — `ServiceTask_1` renames from "Fetch Data" to
+ *                         "Fetch Customer Data" (attribute change).
+ *   - `_added`          — `Gateway_1` ("Approve?") is present in *after* only.
+ *   - `_removed`        — `UserTask_ToRemove` ("Obsolete Step") is present in
+ *                         *before* only.
+ *   - `_layoutChanged`  — `ServiceTask_2` keeps its id and attributes but
+ *                         moves on the canvas (y shifts from 128 to 280).
+ *
+ * These fixtures exist only in development and are tree-shaken out of the
+ * production webview bundle; do not reference them from non-dev code paths.
+ */
+
+export const MOCK_DIFF_BEFORE_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_1"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ServiceTask_1" name="Fetch Data">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:userTask id="UserTask_ToRemove" name="Obsolete Step">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="ServiceTask_2" name="Persist">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="UserTask_ToRemove" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="UserTask_ToRemove" targetRef="ServiceTask_2" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="ServiceTask_2" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="100" y="150" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="106" y="193" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="200" y="128" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_ToRemove_di" bpmnElement="UserTask_ToRemove">
+        <dc:Bounds x="350" y="128" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_2_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="500" y="128" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="650" y="150" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="658" y="193" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="136" y="168" />
+        <di:waypoint x="200" y="168" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="300" y="168" />
+        <di:waypoint x="350" y="168" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="450" y="168" />
+        <di:waypoint x="500" y="168" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="600" y="168" />
+        <di:waypoint x="650" y="168" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+export const MOCK_DIFF_AFTER_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_1"
+                  targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="ServiceTask_1" name="Fetch Customer Data">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_1" name="Approve?">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:serviceTask id="ServiceTask_2" name="Persist">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="ServiceTask_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="ServiceTask_1" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="Gateway_1" targetRef="ServiceTask_2" />
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="ServiceTask_2" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="100" y="150" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="106" y="193" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="200" y="128" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1_di" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="355" y="143" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="349" y="116" width="61" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_2_di" bpmnElement="ServiceTask_2">
+        <dc:Bounds x="500" y="280" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="650" y="150" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="658" y="193" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="136" y="168" />
+        <di:waypoint x="200" y="168" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="300" y="168" />
+        <di:waypoint x="355" y="168" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="380" y="193" />
+        <di:waypoint x="380" y="320" />
+        <di:waypoint x="500" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_4_di" bpmnElement="Flow_4">
+        <di:waypoint x="600" y="320" />
+        <di:waypoint x="650" y="320" />
+        <di:waypoint x="650" y="186" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;

--- a/apps/bpmn-webview/src/app/diff/DiffLegend.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffLegend.ts
@@ -1,0 +1,103 @@
+import { DiffCounts } from "@bpmn-modeler/shared";
+
+export interface DiffLegendCallbacks {
+    onPrevious: () => void;
+    onNext: () => void;
+}
+
+/**
+ * Floating legend chip anchored to the top of the canvas.
+ *
+ * Shows per-category counts with matching colour swatches plus prev/next
+ * navigation buttons that step through the diff's changed elements.  Stays
+ * hidden until {@link update} is called so the canvas isn't cluttered while
+ * the diagram is still importing.
+ */
+export class DiffLegend {
+    private readonly root: HTMLElement;
+
+    private readonly addedCount: HTMLElement;
+
+    private readonly removedCount: HTMLElement;
+
+    private readonly changedCount: HTMLElement;
+
+    private readonly layoutCount: HTMLElement;
+
+    private readonly prevButton: HTMLButtonElement;
+
+    private readonly nextButton: HTMLButtonElement;
+
+    constructor(parent: HTMLElement, callbacks: DiffLegendCallbacks) {
+        this.root = document.createElement("div");
+        this.root.className = "diff-legend";
+        this.root.style.display = "none";
+
+        this.addedCount = this.makeCountSlot("added", "Added");
+        this.removedCount = this.makeCountSlot("removed", "Removed");
+        this.changedCount = this.makeCountSlot("changed", "Changed");
+        this.layoutCount = this.makeCountSlot("layout", "Moved");
+
+        this.prevButton = this.makeNavButton("‹ Prev change", callbacks.onPrevious);
+        this.nextButton = this.makeNavButton("Next change ›", callbacks.onNext);
+
+        const nav = document.createElement("div");
+        nav.className = "diff-legend__nav";
+        nav.append(this.prevButton, this.nextButton);
+        this.root.append(nav);
+
+        parent.append(this.root);
+    }
+
+    /**
+     * Reveals the legend and renders the given counts.  Disables the nav
+     * buttons when there are no changes at all.
+     */
+    update(counts: DiffCounts): void {
+        this.setCount(this.addedCount, counts.added);
+        this.setCount(this.removedCount, counts.removed);
+        this.setCount(this.changedCount, counts.changed);
+        this.setCount(this.layoutCount, counts.layoutChanged);
+
+        const total =
+            counts.added + counts.removed + counts.changed + counts.layoutChanged;
+        const hasChanges = total > 0;
+        this.prevButton.disabled = !hasChanges;
+        this.nextButton.disabled = !hasChanges;
+
+        this.root.style.display = "flex";
+    }
+
+    // ─── Private helpers ─────────────────────────────────────────────────────
+
+    private makeCountSlot(kind: string, label: string): HTMLElement {
+        const slot = document.createElement("div");
+        slot.className = `diff-legend__slot diff-legend__slot--${kind}`;
+
+        const swatch = document.createElement("span");
+        swatch.className = `diff-legend__swatch diff-legend__swatch--${kind}`;
+        slot.append(swatch);
+
+        const text = document.createElement("span");
+        text.className = "diff-legend__label";
+        text.textContent = `${label}: 0`;
+        text.dataset.label = label;
+        slot.append(text);
+
+        this.root.append(slot);
+        return text;
+    }
+
+    private setCount(slot: HTMLElement, count: number): void {
+        slot.textContent = `${slot.dataset.label}: ${count}`;
+    }
+
+    private makeNavButton(label: string, onClick: () => void): HTMLButtonElement {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.className = "diff-legend__nav-btn";
+        btn.textContent = label;
+        btn.addEventListener("click", onClick);
+        return btn;
+    }
+}

--- a/apps/bpmn-webview/src/app/diff/DiffMode.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffMode.ts
@@ -1,0 +1,157 @@
+import {
+    ApplyDiffHighlightsQuery,
+    Command,
+    DiffReadyCommand,
+    Query,
+    SyncViewportQuery,
+    VsCodeApi,
+    ViewportChangedCommand,
+} from "@bpmn-modeler/shared";
+
+import { WebviewState } from "../vscode";
+import { DiffLegend } from "./DiffLegend";
+import { DiffViewer } from "./DiffViewer";
+
+type MessageType = Query | Command;
+
+/**
+ * Entry point for a webview running as one side of a BPMN diff view.
+ *
+ * Replaces the full modeler stack with a single {@link DiffViewer} + a
+ * {@link DiffLegend} chip.  Handles the viewer-mode message protocol:
+ *   - Initial XML handed in by {@link startWith} → import, emit {@link DiffReadyCommand}.
+ *   - Incoming {@link ApplyDiffHighlightsQuery} → paint markers, show legend.
+ *   - Incoming {@link SyncViewportQuery} → apply partner's viewport.
+ *   - Outgoing {@link ViewportChangedCommand} on user pan/zoom.
+ *
+ * Nav buttons cycle a local cursor over the side's own changed-element ids;
+ * the partner pane stays in sync via the normal viewport-sync channel.
+ */
+export class DiffMode {
+    private readonly viewer: DiffViewer;
+
+    private readonly legend: DiffLegend;
+
+    /**
+     * Ordered ids this pane can navigate to.  Populated from
+     * {@link ApplyDiffHighlightsQuery}.  For the `before` side this excludes
+     * added elements (they don't exist here); for `after` it excludes removed.
+     */
+    private readonly changeIds: string[] = [];
+
+    private cursor = -1;
+
+    constructor(
+        canvasSelector: string,
+        legendParent: HTMLElement,
+        private readonly vscode: VsCodeApi<WebviewState, MessageType>,
+    ) {
+        this.viewer = new DiffViewer(canvasSelector);
+        this.legend = new DiffLegend(legendParent, {
+            onPrevious: () => this.navigate(-1),
+            onNext: () => this.navigate(1),
+        });
+
+        this.viewer.onViewportChanged((viewport) => {
+            this.vscode.postMessage(new ViewportChangedCommand(viewport));
+        });
+    }
+
+    /**
+     * Entry point.  Accepts the initial XML content the caller already
+     * received from the host (main.ts peeks at the first
+     * {@link BpmnFileQuery} to decide between modeler and viewer mode, so
+     * by the time we get here the XML is in hand — no need to re-request).
+     */
+    async startWith(initialContent: string): Promise<void> {
+        window.addEventListener("message", (event: MessageEvent<MessageType>) => {
+            void this.onMessage(event.data);
+        });
+        await this.loadInitial(initialContent);
+    }
+
+    // ─── Private ─────────────────────────────────────────────────────────────
+
+    private async onMessage(message: MessageType): Promise<void> {
+        switch (message.type) {
+            case "ApplyDiffHighlightsQuery":
+                this.paint(message as ApplyDiffHighlightsQuery);
+                break;
+            case "SyncViewportQuery":
+                this.viewer.setViewport((message as SyncViewportQuery).viewport);
+                break;
+        }
+    }
+
+    private async loadInitial(content: string): Promise<void> {
+        try {
+            await this.viewer.importXML(content);
+        } catch (error) {
+            console.error("DiffViewer import failed", error);
+            return;
+        }
+        this.vscode.postMessage(new DiffReadyCommand());
+    }
+
+    private paint(query: ApplyDiffHighlightsQuery): void {
+        this.viewer.clearHighlights();
+        this.viewer.applyHighlights(query.added, "diff-added");
+        this.viewer.applyHighlights(query.removed, "diff-removed");
+        this.viewer.applyHighlights(query.changed, "diff-changed");
+        this.viewer.applyHighlights(query.layoutChanged, "diff-layout-changed");
+
+        // Rebuild nav order: removed (before only) / added (after only) first,
+        // then changed, then layoutChanged.  Stable order lets the two panes
+        // iterate in lockstep when the user clicks Next on either side.
+        //
+        // Skip connections whose *only* change is `layoutChanged` — that
+        // happens when a task moves and its incoming/outgoing flows get new
+        // waypoints as a side-effect.  The flow carries no semantic change
+        // on its own, and the user already sees it highlighted when the
+        // attached shape comes up in the cycle.
+        //
+        // Deduplicate: an edge whose source/target genuinely changes appears
+        // in both `changed` and `layoutChanged`, but should land in the
+        // cycle only once.
+        const semanticIds = new Set<string>([
+            ...query.removed,
+            ...query.added,
+            ...query.changed,
+        ]);
+        const layoutForNav = query.layoutChanged.filter(
+            (id) => semanticIds.has(id) || !this.viewer.isConnection(id),
+        );
+
+        this.changeIds.length = 0;
+        const seen = new Set<string>();
+        for (const id of [
+            ...query.removed,
+            ...query.added,
+            ...query.changed,
+            ...layoutForNav,
+        ]) {
+            if (!seen.has(id)) {
+                seen.add(id);
+                this.changeIds.push(id);
+            }
+        }
+        this.cursor = -1;
+
+        // Legend (counts + stepper) lives on the "after" pane only.  The
+        // counts are symmetric so rendering them twice is redundant, and
+        // stepping from the after pane already syncs the before pane via
+        // the viewport channel.
+        if (query.side === "after") {
+            this.legend.update(query.counts);
+        }
+    }
+
+    private navigate(step: 1 | -1): void {
+        if (this.changeIds.length === 0) {
+            return;
+        }
+        this.cursor =
+            (this.cursor + step + this.changeIds.length) % this.changeIds.length;
+        this.viewer.focusElement(this.changeIds[this.cursor]);
+    }
+}

--- a/apps/bpmn-webview/src/app/diff/DiffViewer.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffViewer.ts
@@ -1,0 +1,212 @@
+import NavigatedViewer from "bpmn-js/lib/NavigatedViewer";
+import { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
+
+import { Viewport } from "@bpmn-modeler/shared";
+
+/** CSS class applied to each element category on the canvas. */
+export type DiffMarkerClass =
+    | "diff-added"
+    | "diff-removed"
+    | "diff-changed"
+    | "diff-layout-changed";
+
+/** CSS class applied to the element currently targeted by the stepper. */
+const DIFF_SELECTED_CLASS = "diff-selected";
+
+/**
+ * Readonly BPMN canvas for one side of a diff view.
+ *
+ * Wraps `bpmn-js/lib/NavigatedViewer` so the pane supports mouse + keyboard
+ * pan/zoom but not editing.  Exposes:
+ *   - {@link importXML} — load the diagram and fit to viewport.
+ *   - {@link applyHighlights} — mark elements with per-category CSS classes.
+ *   - {@link getViewport} / {@link setViewport} — read/write canvas viewbox.
+ *   - {@link onViewportChanged} — subscribe to user-driven viewport changes,
+ *     with a suppression guard so programmatic `setViewport` calls don't
+ *     re-emit (avoids feedback loops across synced panes).
+ *   - {@link focusElement} — centre the viewport on a given element.
+ */
+export class DiffViewer {
+    private readonly viewer: NavigatedViewer;
+
+    /**
+     * When `true`, the next viewbox-change event is ignored.  Set by
+     * {@link setViewport} so an incoming viewport sync doesn't bounce back.
+     */
+    private suppressNextChangeEvent = false;
+
+    /**
+     * Id of the element currently highlighted as the stepper's focus, or
+     * `undefined` when nothing is selected.  Tracked so {@link focusElement}
+     * can remove the marker from the previous target before adding it to
+     * the new one.
+     */
+    private selectedId: string | undefined;
+
+    constructor(container: string) {
+        this.viewer = new NavigatedViewer({ container });
+    }
+
+    async importXML(xml: string): Promise<ImportXMLResult> {
+        const result = await this.viewer.importXML(xml);
+        this.getCanvas().zoom("fit-viewport", "auto");
+        return result;
+    }
+
+    /**
+     * Applies a marker CSS class to each id in `ids`.  Silently skips ids
+     * that do not exist on this canvas (the partner pane may have deliveries
+     * specific to its side).
+     */
+    applyHighlights(ids: readonly string[], klass: DiffMarkerClass): void {
+        const canvas = this.getCanvas();
+        const registry = this.viewer.get<any>("elementRegistry");
+        for (const id of ids) {
+            if (registry.get(id)) {
+                canvas.addMarker(id, klass);
+            }
+        }
+    }
+
+    /** Removes all diff markers (including the stepper selection) from the canvas. */
+    clearHighlights(): void {
+        const canvas = this.getCanvas();
+        const registry = this.viewer.get<any>("elementRegistry");
+        const classes: string[] = [
+            "diff-added",
+            "diff-removed",
+            "diff-changed",
+            "diff-layout-changed",
+            DIFF_SELECTED_CLASS,
+        ];
+        registry.forEach((element: { id: string }) => {
+            for (const c of classes) {
+                canvas.removeMarker(element.id, c);
+            }
+        });
+        this.selectedId = undefined;
+    }
+
+    getViewport(): Viewport {
+        const { x, y, width, height } = this.getCanvas().viewbox();
+        return { x, y, width, height };
+    }
+
+    setViewport(viewport: Viewport): void {
+        this.suppressNextChangeEvent = true;
+        this.getCanvas().viewbox({ ...viewport });
+    }
+
+    /**
+     * Subscribes to user-driven viewport changes.  Calls to
+     * {@link setViewport} are filtered out by the internal suppression
+     * guard so the partner pane doesn't bounce the sync back.
+     */
+    onViewportChanged(cb: (viewport: Viewport) => void): void {
+        let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+        this.viewer.get<any>("eventBus").on(
+            "canvas.viewbox.changed",
+            (event: any) => {
+                if (this.suppressNextChangeEvent) {
+                    this.suppressNextChangeEvent = false;
+                    return;
+                }
+                const { x, y, width, height } = event.viewbox;
+                clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(
+                    () => cb({ x, y, width, height }),
+                    80,
+                );
+            },
+        );
+    }
+
+    /**
+     * Centres the viewport on the element with the given id, preserving the
+     * current zoom level.  Returns `true` if the element was found.
+     *
+     * Shapes carry `x/y/width/height`; connections (sequence flows, message
+     * flows, associations) carry `waypoints` instead — in that case the
+     * midpoint of the waypoint bbox is used.  Without this distinction edges
+     * would centre at (0, 0) and produce a visible "reset" jump.
+     */
+    focusElement(id: string): boolean {
+        const registry = this.viewer.get<any>("elementRegistry");
+        const element = registry.get(id);
+        if (!element) {
+            return false;
+        }
+        const centre = centreOf(element);
+        if (!centre) {
+            return false;
+        }
+        const canvas = this.getCanvas();
+        const viewbox = canvas.viewbox();
+        canvas.viewbox({
+            x: centre.x - viewbox.width / 2,
+            y: centre.y - viewbox.height / 2,
+            width: viewbox.width,
+            height: viewbox.height,
+        });
+        if (this.selectedId && this.selectedId !== id) {
+            canvas.removeMarker(this.selectedId, DIFF_SELECTED_CLASS);
+        }
+        canvas.addMarker(id, DIFF_SELECTED_CLASS);
+        this.selectedId = id;
+        return true;
+    }
+
+    /**
+     * Returns `true` if the element with the given id is a connection
+     * (sequence flow, message flow, association) — i.e. carries waypoints
+     * instead of shape bounds.  Used by the diff nav to filter out edges
+     * whose only change is a waypoint adjustment, which are visually
+     * redundant with the attached shape's change.
+     */
+    isConnection(id: string): boolean {
+        const registry = this.viewer.get<any>("elementRegistry");
+        const element = registry.get(id);
+        return !!element && Array.isArray(element.waypoints);
+    }
+
+    private getCanvas(): any {
+        return this.viewer.get<any>("canvas");
+    }
+}
+
+/**
+ * Returns the geometric centre of a bpmn-js element, or `undefined` when the
+ * element has neither shape bounds nor waypoints to derive a position from.
+ */
+function centreOf(
+    element: {
+        x?: number;
+        y?: number;
+        width?: number;
+        height?: number;
+        waypoints?: ReadonlyArray<{ x: number; y: number }>;
+    },
+): { x: number; y: number } | undefined {
+    if (typeof element.x === "number" && typeof element.y === "number") {
+        return {
+            x: element.x + (element.width ?? 0) / 2,
+            y: element.y + (element.height ?? 0) / 2,
+        };
+    }
+    const wps = element.waypoints;
+    if (wps && wps.length > 0) {
+        let minX = wps[0].x;
+        let maxX = wps[0].x;
+        let minY = wps[0].y;
+        let maxY = wps[0].y;
+        for (let i = 1; i < wps.length; i++) {
+            const p = wps[i];
+            if (p.x < minX) minX = p.x;
+            if (p.x > maxX) maxX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.y > maxY) maxY = p.y;
+        }
+        return { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+    }
+    return undefined;
+}

--- a/apps/bpmn-webview/src/app/vscode.ts
+++ b/apps/bpmn-webview/src/app/vscode.ts
@@ -1,8 +1,11 @@
 import {
+    ApplyDiffHighlightsQuery,
     BpmnFileQuery,
     BpmnModelerSettingQuery,
     ClipboardQuery,
     Command,
+    DiffCounts,
+    DiffSide,
     ElementTemplatesQuery,
     LogErrorCommand,
     LogInfoCommand,
@@ -11,10 +14,12 @@ import {
     VsCodeApi,
     VsCodeImpl,
     VsCodeMock,
+    ViewportChangedCommand,
 } from "@bpmn-modeler/shared";
 
 import c7Samples from "./__fixtures__/c7-samples.json";
 import c8Samples from "./__fixtures__/c8-samples.json";
+import { MOCK_DIFF_AFTER_XML, MOCK_DIFF_BEFORE_XML } from "./__fixtures__/mock-diff";
 
 declare const process: { env: { NODE_ENV: string } };
 
@@ -125,10 +130,68 @@ export function getVsCodeApi(): VsCodeApi<StateType, MessageType> {
 }
 
 /**
+ * Dev-only mode selector, driven by `?mode=` in the URL.
+ *
+ * `modeler` (default) — serves the full editable modeler, matches pre-existing
+ *   dev behaviour.
+ * `diff-before` / `diff-after` — serves the left or right pane of a diff view
+ *   with real `bpmn-js-differ` highlights computed from two fixture XMLs.
+ */
+type DevMode = "modeler" | "diff-before" | "diff-after";
+
+/** Pre-computed diff sliced per side — cached on the mock instance. */
+interface CachedDiff {
+    before: {
+        removed: string[];
+        changed: string[];
+        layoutChanged: string[];
+    };
+    after: {
+        added: string[];
+        changed: string[];
+        layoutChanged: string[];
+    };
+    counts: DiffCounts;
+}
+
+function readDevMode(): DevMode {
+    const raw = new URLSearchParams(window.location.search).get("mode");
+    if (raw === "diff-before" || raw === "diff-after" || raw === "modeler") {
+        return raw;
+    }
+    if (raw !== null && raw !== "") {
+        console.warn(
+            `[dev] Unknown ?mode=${raw}; falling back to "modeler". ` +
+                `Known values: modeler, diff-before, diff-after.`,
+        );
+    }
+    return "modeler";
+}
+
+/**
  * Development-only mock that simulates the VS Code extension host by
  * dispatching synthetic `MessageEvent`s in response to outbound commands.
+ *
+ * Selects behaviour from a {@link DevMode} derived from the URL.  Diff modes
+ * lazily import `bpmn-moddle` + `bpmn-js-differ` on the first
+ * `DiffReadyCommand` so those dependencies stay out of the production bundle
+ * (dead-code-eliminated along with the whole class when `NODE_ENV` is
+ * production).
  */
 class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
+    private readonly devMode: DevMode = readDevMode();
+
+    private cachedDiff: CachedDiff | undefined;
+
+    constructor() {
+        super();
+        console.info(
+            "[dev] bpmn-webview mock ready.  Mode:",
+            this.devMode,
+            "\nURL variants: /, /?mode=diff-before, /?mode=diff-after",
+        );
+    }
+
     /**
      * Merges `state` into the current mock state, initialising it when no
      * state has been set yet (i.e. when {@link getState} would throw).
@@ -153,7 +216,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
         switch (true) {
             case message.type === "GetBpmnFileCommand": {
                 console.debug("[DEBUG] GetBpmnFileCommand", message);
-                dispatchEvent(new BpmnFileQuery(MOCK_BPMN_XML, "c7"));
+                this.handleGetBpmnFile();
                 break;
             }
             case message.type === "GetElementTemplatesCommand": {
@@ -205,6 +268,19 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
                 console.debug("[DEBUG] LanguageQuery", message);
                 break;
             }
+            case message.type === "DiffReadyCommand": {
+                console.debug("[DEBUG] DiffReadyCommand");
+                void this.handleDiffReady();
+                break;
+            }
+            case message.type === "ViewportChangedCommand": {
+                // Single-pane preview: there's no partner to sync with.
+                console.debug(
+                    "[DEBUG] ViewportChangedCommand (no partner in dev)",
+                    (message as ViewportChangedCommand).viewport,
+                );
+                break;
+            }
             default: {
                 throw new Error(
                     `Unknown message type: ${(message as MessageType).type}`,
@@ -220,4 +296,119 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
             );
         }
     }
+
+    // ─── Private — mode-aware handlers ───────────────────────────────────────
+
+    private handleGetBpmnFile(): void {
+        switch (this.devMode) {
+            case "diff-before":
+                dispatch(new BpmnFileQuery(MOCK_DIFF_BEFORE_XML, "c7", "viewer"));
+                return;
+            case "diff-after":
+                dispatch(new BpmnFileQuery(MOCK_DIFF_AFTER_XML, "c7", "viewer"));
+                return;
+            case "modeler":
+                dispatch(new BpmnFileQuery(MOCK_BPMN_XML, "c7"));
+                return;
+        }
+    }
+
+    private async handleDiffReady(): Promise<void> {
+        const side: DiffSide | undefined =
+            this.devMode === "diff-before"
+                ? "before"
+                : this.devMode === "diff-after"
+                    ? "after"
+                    : undefined;
+        if (!side) {
+            // DiffReadyCommand arrived in modeler mode — ignore.
+            return;
+        }
+
+        let cached: CachedDiff;
+        try {
+            cached = await this.ensureCachedDiff();
+        } catch (error) {
+            console.error(
+                "[dev] Failed to compute mock diff; diff highlights unavailable.",
+                error,
+            );
+            return;
+        }
+
+        const slice = cached[side];
+        const added = side === "after" ? (slice as { added: string[] }).added : [];
+        const removed = side === "before" ? (slice as { removed: string[] }).removed : [];
+
+        dispatch(
+            new ApplyDiffHighlightsQuery(
+                side,
+                added,
+                removed,
+                slice.changed,
+                slice.layoutChanged,
+                cached.counts,
+            ),
+        );
+    }
+
+    private async ensureCachedDiff(): Promise<CachedDiff> {
+        if (this.cachedDiff) {
+            return this.cachedDiff;
+        }
+
+        // Dynamic imports keep these ~200 KB of dev-only dependencies out of
+        // the production webview bundle (Rollup emits them as separate chunks
+        // that the dead-code-eliminated MockedVsCodeApi never loads).
+        //
+        // `bpmn-moddle`'s default export is the `simple` factory, not a class —
+        // it must be called without `new` (call it as a plain function).
+        // Under Vite's ESM interop the `.default` lives on the module
+        // namespace, while some bundlers place it on a nested `.default` —
+        // handle both shapes.
+        // Vite's dep optimizer pre-bundles `bpmn-moddle` such that the
+        // factory is exposed as a named export `BpmnModdle`, while the
+        // webpack/CJS shape exposes it as `.default`.  Accept both.
+        const moddleMod = (await import("bpmn-moddle")) as unknown as {
+            default?: () => { fromXML: (xml: string) => Promise<{ rootElement: unknown }> };
+            BpmnModdle?: () => { fromXML: (xml: string) => Promise<{ rootElement: unknown }> };
+        };
+        const createBpmnModdle = moddleMod.default ?? moddleMod.BpmnModdle;
+        if (typeof createBpmnModdle !== "function") {
+            throw new Error(
+                "bpmn-moddle did not expose a factory under `default` or `BpmnModdle`.",
+            );
+        }
+
+        const { diff } = await import("bpmn-js-differ");
+
+        const moddle = createBpmnModdle();
+        const beforeDefs = (await moddle.fromXML(MOCK_DIFF_BEFORE_XML)).rootElement;
+        const afterDefs = (await moddle.fromXML(MOCK_DIFF_AFTER_XML)).rootElement;
+        const result = diff(
+            beforeDefs as Parameters<typeof diff>[0],
+            afterDefs as Parameters<typeof diff>[1],
+        );
+
+        const added = Object.keys(result._added);
+        const removed = Object.keys(result._removed);
+        const changed = Object.keys(result._changed);
+        const layoutChanged = Object.keys(result._layoutChanged);
+
+        this.cachedDiff = {
+            before: { removed, changed, layoutChanged },
+            after: { added, changed, layoutChanged },
+            counts: {
+                added: added.length,
+                removed: removed.length,
+                changed: changed.length,
+                layoutChanged: layoutChanged.length,
+            },
+        };
+        return this.cachedDiff;
+    }
+}
+
+function dispatch(event: MessageType): void {
+    window.dispatchEvent(new MessageEvent("message", { data: event }));
 }

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -2,6 +2,7 @@
 import { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
 // css
 import "./styles/default.css";
+import "./styles/diff.css";
 
 import {
     asyncDebounce,
@@ -42,6 +43,7 @@ import {
     UnsupportedEngineError,
     initTheme,
 } from "./app";
+import { DiffMode } from "./app/diff/DiffMode";
 import { WebviewStateManager } from "./app/state";
 
 const vscode = getVsCodeApi();
@@ -95,8 +97,12 @@ let stateManager: WebviewStateManager;
  */
 window.onload = async function () {
     window.addEventListener("message", onReceiveMessage);
-    initResizer();
     initTheme();
+
+    // Viewer mode (one side of a diff view) skips the resizer + properties
+    // panel + palette, so we don't call initResizer() here — the chrome is
+    // hidden by .viewer-mode CSS once we confirm the mode below.  For the
+    // modeler path, initResizer() is called after the branch check.
 
     // Build clipboard DI modules conditionally.
     // In development (plain browser) NativeCopyPaste handles clipboard natively.
@@ -157,6 +163,23 @@ window.onload = async function () {
     vscode.postMessage(new GetBpmnFileCommand());
 
     const bpmnFileQuery = await bpmnFileResolver.wait();
+
+    // Diff view: host told us this pane is one half of a diff, so bootstrap
+    // the readonly DiffMode and skip the editable modeler entirely.
+    if (bpmnFileQuery?.viewerMode === "viewer") {
+        document.body.classList.add("viewer-mode");
+        const canvas = document.getElementById("js-canvas");
+        const dropZone = document.getElementById("js-drop-zone");
+        if (!canvas || !dropZone) {
+            console.error("Diff mode: missing #js-canvas or #js-drop-zone");
+            return;
+        }
+        const diffMode = new DiffMode("#js-canvas", dropZone, vscode);
+        await diffMode.startWith(bpmnFileQuery.content);
+        return;
+    }
+
+    initResizer();
     const extraModules = [TranslateModule, ...(clipboardModules ?? [])];
     await initializeModeler(
         bpmnFileQuery?.content,

--- a/apps/bpmn-webview/src/styles/diff.css
+++ b/apps/bpmn-webview/src/styles/diff.css
@@ -1,0 +1,166 @@
+/*
+ * BPMN diff view styles.
+ *
+ * Applied only when the webview initialises in `viewer` mode (the `body` gains
+ * the `.viewer-mode` class). The selectors below target canvas elements that
+ * DiffViewer.applyHighlights marks with per-category classes, plus the
+ * floating legend chip rendered by DiffLegend.
+ *
+ * Element marker colours intentionally match the bpmn.io/diff demo so users
+ * familiar with that UI see the same visual cues.
+ */
+
+/* Hide editor chrome that only makes sense when editing. */
+body.viewer-mode #js-panel-resizer,
+body.viewer-mode .properties-panel-parent {
+    display: none !important;
+}
+
+body.viewer-mode #js-canvas {
+    width: 100%;
+}
+
+/* ─── Element markers ──────────────────────────────────────────────────── */
+
+.djs-element.diff-added .djs-visual > :nth-child(1) {
+    stroke: #52b415 !important;
+    stroke-width: 3px !important;
+}
+
+.djs-element.diff-removed .djs-visual > :nth-child(1) {
+    stroke: #cc0000 !important;
+    stroke-width: 3px !important;
+}
+
+.djs-element.diff-changed .djs-visual > :nth-child(1) {
+    stroke: #316fbe !important;
+    stroke-width: 3px !important;
+}
+
+.djs-element.diff-layout-changed .djs-visual > :nth-child(1) {
+    stroke-dasharray: 5 3 !important;
+    stroke-width: 2px !important;
+}
+
+/* Sequence-flow edges carry their colour on the marker (arrowhead) too, so
+   we override the path stroke directly. */
+.djs-connection.diff-added .djs-visual path {
+    stroke: #52b415 !important;
+}
+.djs-connection.diff-removed .djs-visual path {
+    stroke: #cc0000 !important;
+}
+.djs-connection.diff-changed .djs-visual path {
+    stroke: #316fbe !important;
+}
+
+/* Stepper selection — a warm glow layered on top of whichever category
+   colour the element already carries.  `filter: drop-shadow` leaves the
+   stroke intact so both shapes and edges light up uniformly. */
+.djs-element.diff-selected .djs-visual {
+    filter: drop-shadow(0 0 6px #ffbe00) drop-shadow(0 0 3px #ffbe00);
+}
+
+/* ─── Floating legend chip ─────────────────────────────────────────────── */
+
+.diff-legend {
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 12px;
+    background: rgba(255, 255, 255, 0.96);
+    border: 1px solid #d0d0d0;
+    border-radius: 6px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    font-size: 12px;
+    color: #1f1f1f;
+    z-index: 100;
+    user-select: none;
+}
+
+.diff-legend__slot {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.diff-legend__swatch {
+    display: inline-block;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+}
+
+.diff-legend__swatch--added {
+    background: #52b415;
+}
+.diff-legend__swatch--removed {
+    background: #cc0000;
+}
+.diff-legend__swatch--changed {
+    background: #316fbe;
+}
+.diff-legend__swatch--layout {
+    background: repeating-linear-gradient(
+        135deg,
+        #888,
+        #888 3px,
+        transparent 3px,
+        transparent 6px
+    );
+    border-color: #888;
+}
+
+.diff-legend__nav {
+    display: inline-flex;
+    gap: 4px;
+    margin-left: 4px;
+    padding-left: 12px;
+    border-left: 1px solid #d0d0d0;
+}
+
+.diff-legend__nav-btn {
+    font: inherit;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid #c0c0c0;
+    background: #fafafa;
+    color: #1f1f1f;
+    cursor: pointer;
+}
+
+.diff-legend__nav-btn:hover:not(:disabled) {
+    background: #eee;
+}
+
+.diff-legend__nav-btn:disabled {
+    opacity: 0.45;
+    cursor: default;
+}
+
+/* Dark-theme tweaks — mirror the webview's light/dark stylesheet pattern. */
+body.dark .diff-legend {
+    background: rgba(40, 40, 40, 0.96);
+    border-color: #555;
+    color: #e8e8e8;
+}
+
+body.dark .diff-legend__nav {
+    border-left-color: #555;
+}
+
+body.dark .diff-legend__nav-btn {
+    background: #2b2b2b;
+    border-color: #555;
+    color: #e8e8e8;
+}
+
+body.dark .diff-legend__nav-btn:hover:not(:disabled) {
+    background: #3a3a3a;
+}

--- a/apps/bpmn-webview/src/types/bpmn-js-differ.d.ts
+++ b/apps/bpmn-webview/src/types/bpmn-js-differ.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Ambient type declarations for `bpmn-js-differ`, which ships without its own
+ * `.d.ts`.  The dev-only `MockedVsCodeApi` runs the differ in the browser to
+ * preview the diff UI; outside of dev the library is dead-code-eliminated.
+ */
+declare module "bpmn-js-differ" {
+    interface ModdleElement {
+        $type: string;
+        id?: string;
+        [key: string]: unknown;
+    }
+
+    interface ChangedEntry {
+        model: ModdleElement;
+        attrs: Record<string, { oldValue: unknown; newValue: unknown }>;
+    }
+
+    interface DiffResult {
+        _added: Record<string, ModdleElement>;
+        _removed: Record<string, ModdleElement>;
+        _changed: Record<string, ChangedEntry>;
+        _layoutChanged: Record<string, ModdleElement>;
+    }
+
+    export function diff(
+        before: ModdleElement,
+        after: ModdleElement,
+    ): DiffResult;
+}

--- a/apps/bpmn-webview/src/types/bpmn-moddle.d.ts
+++ b/apps/bpmn-webview/src/types/bpmn-moddle.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Ambient type declaration for `bpmn-moddle`.  The published package ships
+ * without `.d.ts` files, and we only consume two surfaces — the factory and
+ * the shape of `fromXML`'s result — so a minimal shim is enough.
+ *
+ * The real package exports `SimpleBpmnModdle` under the name `BpmnModdle`
+ * (ESM named export) and has no `default` export.  Consumers call it as a
+ * plain function, not with `new`.  We also declare `default` here so callers
+ * that go through a bundler's ESM→CJS interop can still compile — at runtime
+ * they must tolerate `default` being `undefined`.
+ */
+declare module "bpmn-moddle" {
+    interface ParseResult {
+        rootElement: {
+            $type: string;
+            [key: string]: unknown;
+        };
+        references: unknown[];
+        warnings: unknown[];
+    }
+
+    interface BpmnModdleInstance {
+        fromXML(xml: string): Promise<ParseResult>;
+    }
+
+    type BpmnModdleFactory = (
+        additionalPackages?: Record<string, unknown>,
+        options?: unknown,
+    ) => BpmnModdleInstance;
+
+    export const BpmnModdle: BpmnModdleFactory;
+
+    const _default: BpmnModdleFactory | undefined;
+    export default _default;
+}

--- a/apps/modeler-plugin/package.json
+++ b/apps/modeler-plugin/package.json
@@ -36,6 +36,9 @@
     "engines": {
         "vscode": "^1.76.0"
     },
+    "extensionDependencies": [
+        "vscode.git"
+    ],
     "icon": "assets/miragon-logo.png",
     "categories": [
         "Visualization",

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -19,6 +19,7 @@ import { EditorStore } from "../infrastructure/EditorStore";
 import { VsCodeStatusBar } from "../infrastructure/VsCodeStatusBar";
 import { VsCodeUI } from "../infrastructure/VsCodeUI";
 import { BpmnModelerService } from "../service/BpmnModelerService";
+import { BpmnDiffService } from "../service/BpmnDiffService";
 import { ArtifactService } from "../service/ArtifactService";
 import { detectExecutionPlatform, detectExecutionPlatformVersion } from "../service/bpmnUtils";
 import { VsCodeDocument } from "../infrastructure/VsCodeDocument";
@@ -37,6 +38,8 @@ export class BpmnEditorController implements CustomTextEditorProvider {
     /**
      * @param editorStore Central registry for open editor panels and subscriptions.
      * @param bpmnService BPMN-specific business logic and session management.
+     * @param diffService Diff coordinator — queried on resolve to decide
+     *   whether to take the readonly viewer branch.
      * @param artifactSvc Workspace artifact discovery and watcher creation.
      * @param vsUI User-facing message and logging helper.
      * @param vsDocument Active-document read helper (for status bar version detection).
@@ -45,6 +48,7 @@ export class BpmnEditorController implements CustomTextEditorProvider {
     constructor(
         private readonly editorStore: EditorStore,
         private readonly bpmnService: BpmnModelerService,
+        private readonly diffService: BpmnDiffService,
         private readonly artifactSvc: ArtifactService,
         private readonly vsUI: VsCodeUI,
         private readonly vsDocument: VsCodeDocument,
@@ -78,7 +82,28 @@ export class BpmnEditorController implements CustomTextEditorProvider {
         _token: CancellationToken,
     ): Promise<void> {
         try {
-            const editorId = document.uri.path;
+            // `git:`-scheme documents are always readonly (Git extension's
+            // FileSystemProvider owns their content).  `file:` documents that
+            // belong to an open diff view are also readonly here — editing
+            // them through the diff pane would race with the built-in diff
+            // editor's change detection.  For `file:` URIs we also guard
+            // against a *second* resolve for a URI that already has a diff
+            // viewer: when the user opens the SCM diff and then opens the
+            // same working-tree file in a normal editor group, VS Code fires
+            // `resolveCustomTextEditor` again and the label-based heuristic
+            // still matches — so we also require that no diff pane has been
+            // registered for this URI yet.
+            const isGitScheme = document.uri.scheme === "git";
+            const isNewDiffPane =
+                this.diffService.isPartOfDiff(document.uri) &&
+                !this.diffService.hasPaneForUri(document.uri);
+            if (isGitScheme || isNewDiffPane) {
+                this.diffService.resolveDiffPane(webviewPanel, document);
+                return;
+            }
+
+            const editorId = document.uri.toString();
+
             this.editorStore.createEditor(
                 BPMN_VIEW_TYPE,
                 editorId,
@@ -184,8 +209,8 @@ export class BpmnEditorController implements CustomTextEditorProvider {
             (event: TextDocumentChangeEvent) => {
                 if (
                     event.contentChanges.length !== 0 &&
-                    editorId.split(".").pop() === "bpmn" &&
-                    editorId === event.document.uri.path
+                    event.document.uri.path.endsWith(".bpmn") &&
+                    editorId === event.document.uri.toString()
                 ) {
                     this.vsUI.logInfo("OnDidChangeTextDocument -> display");
                     this.bpmnService.display(editorId);

--- a/apps/modeler-plugin/src/controller/DmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/DmnEditorController.ts
@@ -61,7 +61,7 @@ export class DmnEditorController implements CustomTextEditorProvider {
         _token: CancellationToken,
     ): void | Thenable<void> {
         try {
-            const editorId = document.uri.path;
+            const editorId = document.uri.toString();
             this.editorStore.createEditor(DMN_VIEW_TYPE, editorId, webviewPanel, document);
             this.dmnService.registerSession(editorId);
 
@@ -120,8 +120,8 @@ export class DmnEditorController implements CustomTextEditorProvider {
             (event: TextDocumentChangeEvent) => {
                 if (
                     event.contentChanges.length !== 0 &&
-                    editorId.split(".").pop() === "dmn" &&
-                    editorId === event.document.uri.path
+                    event.document.uri.path.endsWith(".dmn") &&
+                    editorId === event.document.uri.toString()
                 ) {
                     this.vsUI.logInfo("OnDidChangeTextDocument -> display");
                     this.dmnService.display(editorId);

--- a/apps/modeler-plugin/src/infrastructure/EditorStore.ts
+++ b/apps/modeler-plugin/src/infrastructure/EditorStore.ts
@@ -10,15 +10,10 @@ import {
     workspace,
 } from "vscode";
 
-import { getContext } from "./extensionContext";
 import { Command, Query } from "@bpmn-modeler/shared";
 
-import { bpmnEditorUi, dmnModelerHtml } from "./WebviewHtml";
+import { bootstrapWebview } from "./bootstrapWebview";
 
-/** VS Code view-type identifier for the BPMN custom editor. */
-const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
-/** VS Code view-type identifier for the DMN custom editor. */
-const DMN_VIEW_TYPE = "bpmn-modeler.dmn";
 /** VS Code `setContext` command key used by keybinding/menu `when` clauses. */
 const OPEN_EDITORS_COUNTER_KEY = "bpmn-modeler.openCustomEditors";
 
@@ -38,7 +33,16 @@ type EditorEntry = {
  * `adapter/out/editor.ts`.
  */
 export class EditorStore implements Disposable {
-    /** All currently open editors, keyed by document URI path. */
+    /**
+     * All currently open editors, keyed by the stringified document URI
+     * (`document.uri.toString()`).
+     *
+     * Keying on the full URI — scheme included — is essential: VS Code opens
+     * diff editors as two independent `resolveCustomTextEditor` calls, one for
+     * a `git:` URI and one for a `file:` URI that share the same fs path.  If
+     * we keyed by path alone the second registration would clobber the first
+     * and one pane would render empty.
+     */
     private readonly editors: Map<string, EditorEntry> = new Map();
 
     /** VS Code event-subscription disposables, keyed by editorId. */
@@ -72,35 +76,12 @@ export class EditorStore implements Disposable {
         webviewPanel: WebviewPanel,
         document: TextDocument,
     ): WebviewPanel {
-        const panel = this.initWebviewHtml(viewType, webviewPanel);
+        const panel = bootstrapWebview(viewType, webviewPanel);
         this.editors.set(editorId, { id: editorId, ui: panel, document });
         this.disposables.set(editorId, []);
         this.setActiveEditor(editorId);
         this.updateOpenEditorCounter(this.editors.size);
         return panel;
-    }
-
-    /**
-     * Sets the webview HTML content on the panel based on the view type.
-     *
-     * @param viewType VS Code view-type identifier.
-     * @param webviewPanel The panel whose HTML is to be set.
-     * @returns The configured WebviewPanel.
-     * @throws {Error} If the viewType is not supported.
-     */
-    initWebviewHtml(viewType: string, webviewPanel: WebviewPanel): WebviewPanel {
-        const webview = webviewPanel.webview;
-        webview.options = { enableScripts: true };
-
-        if (viewType === BPMN_VIEW_TYPE) {
-            webview.html = bpmnEditorUi(webview, getContext().extensionUri);
-        } else if (viewType === DMN_VIEW_TYPE) {
-            webview.html = dmnModelerHtml(webview, getContext().extensionUri);
-        } else {
-            throw new Error(`Unsupported view type: ${viewType}`);
-        }
-
-        return webviewPanel;
     }
 
     // ─── Active editor ────────────────────────────────────────────────────────
@@ -142,15 +123,24 @@ export class EditorStore implements Disposable {
     }
 
     /**
-     * Finds the editor id for a file that is currently open, identified by its
-     * absolute file system path.
+     * Finds the editor id for an editable file that is currently open,
+     * identified by its absolute URI path.
      *
-     * @param filePath Absolute file system path to look up.
-     * @returns The editor id (document URI path), or `undefined` if the file is not open.
+     * Only `file:`-scheme editors are returned — callers expect a session they
+     * can write to, never the readonly `git:` counterpart that may be open
+     * alongside it in a diff view.
+     *
+     * @param filePath Absolute URI path (as produced by `Uri.file(...).path`)
+     *   to look up.
+     * @returns The editor id (stringified URI), or `undefined` if the file
+     *   is not open in an editable editor.
      */
     findEditorIdByPath(filePath: string): string | undefined {
         for (const [, entry] of this.editors) {
-            if (entry.document.uri.path === filePath) {
+            if (
+                entry.document.uri.scheme === "file" &&
+                entry.document.uri.path === filePath
+            ) {
                 return entry.id;
             }
         }

--- a/apps/modeler-plugin/src/infrastructure/VsCodeDocument.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeDocument.ts
@@ -44,13 +44,26 @@ export class VsCodeDocument {
      * Replaces the entire content of the specified editor's document with the
      * given string.
      *
-     * @param editorId Document URI path of the target editor.
+     * Refuses non-`file:` schemes (e.g. `git:`) — those TextDocuments are
+     * owned by a FileSystemProvider and any `applyEdit` against them either
+     * silently no-ops or bubbles a confusing error from the provider.
+     * Callers that reach here with a non-file document indicate a missing
+     * viewer-mode branch upstream; fail loudly so the bug is visible.
+     *
+     * @param editorId Stringified URI of the target editor.
      * @param content New document content.
      * @returns `true` if the edit was applied, `false` if content was unchanged.
-     * @throws {Error} If no editor with the given id is registered.
+     * @throws {Error} If the editor is not registered or is not a `file:` document.
      */
     async write(editorId: string, content: string): Promise<boolean> {
         const doc = this.editorStore.getDocumentForEditor(editorId);
+
+        if (doc.uri.scheme !== "file") {
+            throw new Error(
+                `Refusing to write to a ${doc.uri.scheme}: document (${doc.uri.toString()}). ` +
+                    `Only file:-scheme documents are editable.`,
+            );
+        }
 
         if (doc.getText() === content) {
             return false;
@@ -65,10 +78,21 @@ export class VsCodeDocument {
     /**
      * Saves the specified editor's document to disk.
      *
-     * @param editorId Document URI path of the target editor.
-     * @throws {Error} If no editor with the given id is registered.
+     * Refuses non-`file:` schemes for the same reason as {@link write}.
+     *
+     * @param editorId Stringified URI of the target editor.
+     * @throws {Error} If the editor is not registered or is not a `file:` document.
      */
     async save(editorId: string): Promise<boolean> {
-        return this.editorStore.getDocumentForEditor(editorId).save();
+        const doc = this.editorStore.getDocumentForEditor(editorId);
+
+        if (doc.uri.scheme !== "file") {
+            throw new Error(
+                `Refusing to save a ${doc.uri.scheme}: document (${doc.uri.toString()}). ` +
+                    `Only file:-scheme documents are persistable.`,
+            );
+        }
+
+        return doc.save();
     }
 }

--- a/apps/modeler-plugin/src/infrastructure/bootstrapWebview.ts
+++ b/apps/modeler-plugin/src/infrastructure/bootstrapWebview.ts
@@ -1,0 +1,37 @@
+import { WebviewPanel } from "vscode";
+
+import { getContext } from "./extensionContext";
+import { bpmnEditorUi, dmnModelerHtml } from "./WebviewHtml";
+
+/** VS Code view-type identifier for the BPMN custom editor. */
+const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
+/** VS Code view-type identifier for the DMN custom editor. */
+const DMN_VIEW_TYPE = "bpmn-modeler.dmn";
+
+/**
+ * Enables scripting and installs the correct HTML on the given webview panel
+ * based on its view type.
+ *
+ * Pure helper with no persistent state: safe for both `EditorStore`
+ * (editable editors) and `BpmnDiffService` (readonly diff panes) to invoke
+ * without going through each other.
+ *
+ * @throws {Error} if `viewType` is unknown.
+ */
+export function bootstrapWebview(
+    viewType: string,
+    webviewPanel: WebviewPanel,
+): WebviewPanel {
+    const webview = webviewPanel.webview;
+    webview.options = { enableScripts: true };
+
+    if (viewType === BPMN_VIEW_TYPE) {
+        webview.html = bpmnEditorUi(webview, getContext().extensionUri);
+    } else if (viewType === DMN_VIEW_TYPE) {
+        webview.html = dmnModelerHtml(webview, getContext().extensionUri);
+    } else {
+        throw new Error(`Unsupported view type: ${viewType}`);
+    }
+
+    return webviewPanel;
+}

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -9,6 +9,7 @@ import { VsCodeSettings } from "./infrastructure/VsCodeSettings";
 import { VsCodeStatusBar } from "./infrastructure/VsCodeStatusBar";
 import { VsCodeUI } from "./infrastructure/VsCodeUI";
 import { ArtifactService } from "./service/ArtifactService";
+import { BpmnDiffService } from "./service/BpmnDiffService";
 import { BpmnModelerService } from "./service/BpmnModelerService";
 import { DmnModelerService } from "./service/DmnModelerService";
 import { CommandController } from "./controller/CommandController";
@@ -72,6 +73,7 @@ export function activate(context: ExtensionContext): void {
         vsWorkspace,
     );
     const dmnService = new DmnModelerService(editorStore, vsDocument, vsUI);
+    const diffService = new BpmnDiffService(vsUI);
     const deploymentSvc = new DeploymentService(
         vsDocument,
         vsWorkspace,
@@ -91,9 +93,15 @@ export function activate(context: ExtensionContext): void {
 
     // 4. Controllers
     const commandController = new CommandController(editorStore, vsDocument, vsUI, bpmnService);
-    new BpmnEditorController(editorStore, bpmnService, artifactSvc, vsUI, vsDocument, statusBar).register(
-        context,
-    );
+    new BpmnEditorController(
+        editorStore,
+        bpmnService,
+        diffService,
+        artifactSvc,
+        vsUI,
+        vsDocument,
+        statusBar,
+    ).register(context);
     new DmnEditorController(editorStore, dmnService, vsUI).register(context);
     commandController.register(context);
     new DeploymentController(editorStore, vsDocument, deploymentSvc, startInstanceSvc, vsUI).register(context);

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -1,0 +1,382 @@
+// Bundler (webpack + ts-loader) does not pick up ambient module declarations
+// from `src/types/*.d.ts` via tsconfig `include` alone — it honours explicit
+// triple-slash references though.  `tsc --noEmit` handles both, but the
+// bundler path is the one that ships the extension, so the references are
+// required for the production build.
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../types/bpmn-js-differ.d.ts" />
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../types/bpmn-moddle.d.ts" />
+import { diff } from "bpmn-js-differ";
+
+import {
+    ApplyDiffHighlightsQuery,
+    BpmnFileQuery,
+    Command,
+    DiffCounts,
+    DiffSide,
+    SyncViewportQuery,
+    ViewportChangedCommand,
+} from "@bpmn-modeler/shared";
+
+import { TextDocument, Uri, WebviewPanel, window } from "vscode";
+
+import { bootstrapWebview } from "../infrastructure/bootstrapWebview";
+import { VsCodeUI } from "../infrastructure/VsCodeUI";
+import { detectExecutionPlatform } from "./bpmnUtils";
+
+const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
+
+/**
+ * Mutable state for one side of an open diff.  Two entries — one per pane —
+ * form a pair via their mutual `partner` back-pointers; the pair fires its
+ * highlight computation as soon as both sides have reported ready.
+ */
+interface DiffPaneEntry {
+    readonly panel: WebviewPanel;
+    readonly document: TextDocument;
+    readonly side: DiffSide;
+    ready: boolean;
+    partner?: DiffPaneEntry;
+}
+
+/**
+ * Owns every BPMN diff viewer pane from resolution through disposal.
+ *
+ * Keying on {@link WebviewPanel} rather than a string id solves the identity
+ * problem that the URI-keyed `EditorStore` cannot: VS Code happily creates
+ * two panels for the same `file:` URI (the working-tree pane of a diff and
+ * a normal editor tab) and both need independent message routing, disposal
+ * handling, and document access.  Diff panes never touch `EditorStore`, so
+ * there is no collision to work around.
+ *
+ * Responsibilities:
+ *   1. Detect whether a URI belongs to an open `.bpmn` diff tab — purely by
+ *      tab label, because VS Code exposes `tab.input === undefined` for
+ *      custom-editor-backed diff tabs and no typed signal is available.
+ *   2. Bootstrap the webview for a newly-resolved diff pane, wire up the
+ *      narrow viewer-mode message protocol (`GetBpmnFileCommand`,
+ *      `DiffReadyCommand`, `ViewportChangedCommand`), and link the pane to
+ *      its partner by shared file path.
+ *   3. Once both panes of a pair are ready, run `bpmn-js-differ` on the
+ *      parsed XMLs and broadcast per-side {@link ApplyDiffHighlightsQuery}.
+ *   4. Forward viewport-change messages from one pane to its partner so
+ *      panning and zooming stay in sync.
+ */
+export class BpmnDiffService {
+    /** Every live diff pane, keyed by its {@link WebviewPanel} reference. */
+    private readonly panes = new Map<WebviewPanel, DiffPaneEntry>();
+
+    /**
+     * @param vsUI Logging helper for parse failures and dropped posts.
+     */
+    constructor(private readonly vsUI: VsCodeUI) {}
+
+    /**
+     * Returns `true` when `uri` belongs to an open BPMN diff tab.
+     *
+     * Label-based heuristic: when a file type has a `CustomTextEditorProvider`
+     * registered as default, VS Code's diff tabs surface as `Tab` objects with
+     * `input === undefined` — there is no `TabInputTextDiff` / `TabInputCustom`
+     * variant to branch on.  The only structural signal left is the label,
+     * which every diff annotates with a parenthetical (e.g.
+     * `"my-bpmn.bpmn (Working Tree)"`, `"… (HEAD)"`, `"… (HEAD~1 ↔ HEAD)"`).
+     */
+    isPartOfDiff(uri: Uri): boolean {
+        const basename = basenameOfUri(uri);
+        if (!basename.endsWith(".bpmn")) {
+            return false;
+        }
+        for (const group of window.tabGroups.all) {
+            for (const tab of group.tabs) {
+                if (
+                    tab.input === undefined &&
+                    tab.label.startsWith(`${basename} (`)
+                ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns `true` when a diff pane has already been resolved for the given
+     * URI.  Used by the editor controller to distinguish "this URI is part of
+     * a diff and has not yet resolved a viewer pane" from "this URI already
+     * has a diff viewer and the current resolve is a second, editable tab".
+     */
+    hasPaneForUri(uri: Uri): boolean {
+        const needle = uri.toString();
+        for (const entry of this.panes.values()) {
+            if (entry.document.uri.toString() === needle) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Bootstraps a freshly-resolved diff pane: installs the webview HTML,
+     * registers the viewer-mode message and dispose listeners, and pairs the
+     * pane with its partner if one already resolved for the same file path.
+     *
+     * The controller hands the `WebviewPanel` and `TextDocument` directly —
+     * nothing about the diff pane flows through `EditorStore`, which keeps
+     * the two "same URI" panels (viewer + editable modeler) from colliding.
+     */
+    resolveDiffPane(panel: WebviewPanel, document: TextDocument): void {
+        // Register listeners *before* we hand HTML to the webview: VS Code
+        // drops webview-originated messages that arrive before the extension
+        // has subscribed, and bootstrapping triggers an immediate
+        // `GetBpmnFileCommand` as soon as the webview's scripts run.
+        const entry: DiffPaneEntry = {
+            panel,
+            document,
+            side: this.sideFor(document.uri),
+            ready: false,
+        };
+        this.panes.set(panel, entry);
+        this.linkPartner(entry);
+
+        panel.webview.onDidReceiveMessage((message: Command) =>
+            this.onMessage(entry, message),
+        );
+        panel.onDidDispose(() => this.disposePane(entry));
+
+        bootstrapWebview(BPMN_VIEW_TYPE, panel);
+    }
+
+    // ─── Private ─────────────────────────────────────────────────────────────
+
+    /**
+     * Assigns a diff side to a freshly-resolved URI.
+     *
+     * `file:` URIs always represent the working tree, i.e. the "after" side.
+     * `git:` URIs are the before side in the common working-tree diff
+     * (`git: ↔ file:`).  For ref-vs-ref diffs both URIs are `git:`: the one
+     * that resolves first gets `"before"` and the second gets `"after"`.
+     * Which ref is "really" before in that case is arbitrary — VS Code's
+     * diff command decides the visual order and we follow it.
+     */
+    private sideFor(uri: Uri): DiffSide {
+        if (uri.scheme !== "git") {
+            return "after";
+        }
+        for (const existing of this.panes.values()) {
+            if (
+                existing.document.uri.path === uri.path &&
+                existing.side === "before"
+            ) {
+                return "after";
+            }
+        }
+        return "before";
+    }
+
+    /**
+     * Links `entry` with any existing unpartnered pane that shares its file
+     * path and sits on the opposite diff side.
+     */
+    private linkPartner(entry: DiffPaneEntry): void {
+        for (const candidate of this.panes.values()) {
+            if (candidate === entry) {
+                continue;
+            }
+            if (
+                candidate.document.uri.path === entry.document.uri.path &&
+                candidate.side !== entry.side &&
+                candidate.partner === undefined
+            ) {
+                entry.partner = candidate;
+                candidate.partner = entry;
+                return;
+            }
+        }
+    }
+
+    private disposePane(entry: DiffPaneEntry): void {
+        if (entry.partner) {
+            entry.partner.partner = undefined;
+        }
+        this.panes.delete(entry.panel);
+    }
+
+    private async onMessage(
+        entry: DiffPaneEntry,
+        message: Command,
+    ): Promise<void> {
+        switch (message.type) {
+            case "GetBpmnFileCommand":
+                await this.sendViewerFile(entry);
+                break;
+            case "DiffReadyCommand":
+                await this.markReady(entry);
+                break;
+            case "ViewportChangedCommand":
+                await this.forwardViewport(
+                    entry,
+                    (message as ViewportChangedCommand).viewport,
+                );
+                break;
+        }
+    }
+
+    /**
+     * Replies to the webview's initial `GetBpmnFileCommand` with the pane's
+     * XML in viewer mode.  Engine detection is best-effort — diagrams without
+     * an execution-platform attribute fall back to `"c7"`, since viewer mode
+     * does not render engine-specific extensions anyway.
+     */
+    private async sendViewerFile(entry: DiffPaneEntry): Promise<void> {
+        try {
+            const content = entry.document.getText();
+            let engine: "c7" | "c8";
+            try {
+                engine = detectExecutionPlatform(content);
+            } catch {
+                engine = "c7";
+            }
+            await entry.panel.webview.postMessage(
+                new BpmnFileQuery(content, engine, "viewer"),
+            );
+        } catch (error) {
+            this.vsUI.logError(error as Error);
+        }
+    }
+
+    private async markReady(entry: DiffPaneEntry): Promise<void> {
+        entry.ready = true;
+        const partner = entry.partner;
+        if (partner?.ready) {
+            const [before, after] =
+                entry.side === "before" ? [entry, partner] : [partner, entry];
+            await this.computeAndBroadcast(before, after);
+        }
+    }
+
+    /**
+     * Posts the partner's viewport change to this pane so panning/zoom stays
+     * in lockstep.  Silently drops posts when the partner is hidden or gone.
+     */
+    private async forwardViewport(
+        entry: DiffPaneEntry,
+        viewport: ViewportChangedCommand["viewport"],
+    ): Promise<void> {
+        const partner = entry.partner;
+        if (!partner) {
+            return;
+        }
+        try {
+            await partner.panel.webview.postMessage(
+                new SyncViewportQuery(viewport),
+            );
+        } catch (error) {
+            this.vsUI.logInfo(
+                `syncViewport dropped: ${(error as Error).message}`,
+            );
+        }
+    }
+
+    /**
+     * Parses both panes' XML, runs `bpmn-js-differ`, and posts a side-targeted
+     * {@link ApplyDiffHighlightsQuery} to each webview.  Each side receives
+     * only the ids present on its own canvas:
+     *   - `_removed` elements exist only on `before`.
+     *   - `_added` elements exist only on `after`.
+     *   - `_changed` and `_layoutChanged` elements exist on both.
+     */
+    private async computeAndBroadcast(
+        before: DiffPaneEntry,
+        after: DiffPaneEntry,
+    ): Promise<void> {
+        const beforeXml = before.document.getText();
+        const afterXml = after.document.getText();
+
+        let beforeDefs: unknown;
+        let afterDefs: unknown;
+        try {
+            // `bpmn-moddle` has no `default` export — its ESM dist only
+            // re-exports the factory as `BpmnModdle`.  Webpack's ESM→CJS
+            // interop does not synthesize `.default`, so we accept both
+            // shapes for forward-compat across bundler upgrades.
+            const moddleMod = (await import("bpmn-moddle")) as unknown as {
+                default?: () => {
+                    fromXML: (xml: string) => Promise<{ rootElement: unknown }>;
+                };
+                BpmnModdle?: () => {
+                    fromXML: (xml: string) => Promise<{ rootElement: unknown }>;
+                };
+            };
+            const createBpmnModdle = moddleMod.default ?? moddleMod.BpmnModdle;
+            if (typeof createBpmnModdle !== "function") {
+                throw new Error(
+                    "bpmn-moddle did not expose a factory under `default` or `BpmnModdle`.",
+                );
+            }
+            const moddle = createBpmnModdle();
+            beforeDefs = (await moddle.fromXML(beforeXml)).rootElement;
+            afterDefs = (await moddle.fromXML(afterXml)).rootElement;
+        } catch (error) {
+            this.vsUI.logError(error as Error);
+            return;
+        }
+
+        const result = diff(
+            beforeDefs as Parameters<typeof diff>[0],
+            afterDefs as Parameters<typeof diff>[1],
+        );
+
+        const added = Object.keys(result._added);
+        const removed = Object.keys(result._removed);
+        const changed = Object.keys(result._changed);
+        const layoutChanged = Object.keys(result._layoutChanged);
+        const counts: DiffCounts = {
+            added: added.length,
+            removed: removed.length,
+            changed: changed.length,
+            layoutChanged: layoutChanged.length,
+        };
+
+        await this.postHighlights(
+            before.panel,
+            new ApplyDiffHighlightsQuery(
+                "before",
+                [],
+                removed,
+                changed,
+                layoutChanged,
+                counts,
+            ),
+        );
+        await this.postHighlights(
+            after.panel,
+            new ApplyDiffHighlightsQuery(
+                "after",
+                added,
+                [],
+                changed,
+                layoutChanged,
+                counts,
+            ),
+        );
+    }
+
+    private async postHighlights(
+        panel: WebviewPanel,
+        query: ApplyDiffHighlightsQuery,
+    ): Promise<void> {
+        try {
+            await panel.webview.postMessage(query);
+        } catch (error) {
+            this.vsUI.logInfo(
+                `ApplyDiffHighlights dropped: ${(error as Error).message}`,
+            );
+        }
+    }
+}
+
+function basenameOfUri(uri: Uri): string {
+    const parts = uri.path.split("/");
+    return parts[parts.length - 1] ?? "";
+}

--- a/apps/modeler-plugin/src/types/bpmn-js-differ.d.ts
+++ b/apps/modeler-plugin/src/types/bpmn-js-differ.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Ambient type declarations for `bpmn-js-differ`, which ships without its own
+ * `.d.ts`.  Covers only the subset used by the BPMN diff feature — `diff()`
+ * and the shape of its return value.
+ */
+declare module "bpmn-js-differ" {
+    /**
+     * A bpmn-moddle element reference — opaque here because the differ only
+     * consumes objects produced by `bpmn-moddle` and we never inspect them
+     * beyond reading `$type` and `id`.
+     */
+    interface ModdleElement {
+        $type: string;
+        id?: string;
+        [key: string]: unknown;
+    }
+
+    interface ChangedEntry {
+        model: ModdleElement;
+        attrs: Record<string, { oldValue: unknown; newValue: unknown }>;
+    }
+
+    interface DiffResult {
+        _added: Record<string, ModdleElement>;
+        _removed: Record<string, ModdleElement>;
+        _changed: Record<string, ChangedEntry>;
+        _layoutChanged: Record<string, ModdleElement>;
+    }
+
+    export function diff(
+        before: ModdleElement,
+        after: ModdleElement,
+    ): DiffResult;
+}

--- a/apps/modeler-plugin/src/types/bpmn-moddle.d.ts
+++ b/apps/modeler-plugin/src/types/bpmn-moddle.d.ts
@@ -1,0 +1,35 @@
+/**
+ * Ambient type declaration for `bpmn-moddle`.  The published package ships
+ * without `.d.ts` files, and we only consume two surfaces — the factory and
+ * the shape of `fromXML`'s result — so a minimal shim is enough.
+ *
+ * The real package exports `SimpleBpmnModdle` under the name `BpmnModdle`
+ * (ESM named export) and has no `default` export.  Consumers call it as a
+ * plain function, not with `new`.  We also declare `default` here so callers
+ * that go through a bundler's ESM→CJS interop can still compile — at runtime
+ * they must tolerate `default` being `undefined`.
+ */
+declare module "bpmn-moddle" {
+    interface ParseResult {
+        rootElement: {
+            $type: string;
+            [key: string]: unknown;
+        };
+        references: unknown[];
+        warnings: unknown[];
+    }
+
+    interface BpmnModdleInstance {
+        fromXML(xml: string): Promise<ParseResult>;
+    }
+
+    type BpmnModdleFactory = (
+        additionalPackages?: Record<string, unknown>,
+        options?: unknown,
+    ) => BpmnModdleInstance;
+
+    export const BpmnModdle: BpmnModdleFactory;
+
+    const _default: BpmnModdleFactory | undefined;
+    export default _default;
+}

--- a/apps/modeler-plugin/tsconfig.app.json
+++ b/apps/modeler-plugin/tsconfig.app.json
@@ -7,5 +7,5 @@
     "noFallthroughCasesInSwitch": false,
   },
   "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/docs/development.md
+++ b/docs/development.md
@@ -70,6 +70,30 @@ yarn workspace vs-code-bpmn-modeler build
 yarn workspace bpmn-webview build
 ```
 
+### Preview the BPMN webview in a plain browser
+
+The BPMN webview can run standalone against a mocked VS Code host. This avoids
+reloading the Extension Development Host while iterating on webview UI.
+
+```bash
+yarn serve:bpmn-webview
+# → http://localhost:5173/
+```
+
+A URL query parameter selects what the mock serves:
+
+| URL                                      | What renders                                                                                 |
+|------------------------------------------|----------------------------------------------------------------------------------------------|
+| `/` (or `?mode=modeler`)                 | Full editable Camunda modeler with a hardcoded sample diagram — matches the production modeler experience. |
+| `/?mode=diff-before`                     | Readonly **before** (left) pane of a diff view, with highlights for removed / changed / moved elements.    |
+| `/?mode=diff-after`                      | Readonly **after** (right) pane, with highlights for added / changed / moved elements.                     |
+
+The diff modes run `bpmn-js-differ` against two fixture XMLs
+(`apps/bpmn-webview/src/app/__fixtures__/mock-diff.ts`) so highlights reflect
+the real differ's output. All mock code and its dependencies are gated on
+`NODE_ENV === "development"` and tree-shaken out of the production webview
+bundle.
+
 ## Testing & Linting
 
 ```bash

--- a/docs/features/bpmn-diff.md
+++ b/docs/features/bpmn-diff.md
@@ -1,0 +1,166 @@
+# BPMN Diff View
+
+The BPMN Modeler extension replaces VS Code's default text-based diff for `.bpmn` files with two side-by-side readonly BPMN canvases. Element-level changes are highlighted with colour-coded markers driven by [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ) — the same library that powers [demo.bpmn.io/diff](https://demo.bpmn.io/diff) — and panning/zooming in one pane is mirrored to the other.
+
+## Usage
+
+1. Open the **Source Control** panel in VS Code.
+2. Click any modified `.bpmn` file, or open a diff from `git diff`, `git log`, or a pull-request review.
+3. VS Code opens the diff pair in a split editor; both sides render as BPMN canvases instead of XML text.
+
+The left pane shows the **before** version (e.g. `HEAD` or the merge-base) and the right pane shows the **after** version (e.g. the working tree). Each pane is a `NavigatedViewer` — read-only but fully navigable with mouse wheel, drag, and keyboard.
+
+## Highlights
+
+`bpmn-js-differ` classifies every element into one of four categories. Each category has its own marker style applied via `canvas.addMarker`:
+
+| Category        | Stroke colour      | Visible on     | Meaning                                                            |
+|-----------------|--------------------|----------------|--------------------------------------------------------------------|
+| **Added**       | Green (`#52b415`)  | After pane     | Element does not exist in the before diagram.                      |
+| **Removed**     | Red (`#cc0000`)    | Before pane    | Element was deleted in the after diagram.                          |
+| **Changed**     | Blue (`#316fbe`)   | Both panes     | An attribute changed (name, condition, implementation, …).         |
+| **Moved**       | Dashed stroke      | Both panes     | Only the layout (`x`, `y`, waypoints) changed — semantics are identical. |
+
+Colours intentionally match the bpmn.io/diff demo so users familiar with that UI see the same visual cues. Sequence flows receive the same stroke colour on their path and arrowhead.
+
+## Legend Chip
+
+The floating legend sits at the top-centre of the **after pane only**; counts are symmetric across the diff, so rendering them twice would be redundant, and hosting the stepper on a single pane keeps a single input path — the before pane follows via viewport sync. The chip reveals itself once the differ has reported its results:
+
+- Four count slots — Added / Removed / Changed / Moved — each with its colour swatch.
+- A **Prev change** / **Next change** navigator that cycles through the change ids on the after pane (`added → changed → layoutChanged`), filtered to skip connections whose *only* classification is `layoutChanged` — those are waypoint side-effects of a moved shape and carry no semantic change.
+- Clicking a nav button centres the viewport on the target at the current zoom and paints a gold glow (`.diff-selected`, implemented via `filter: drop-shadow` so it layers on top of any category stroke). The previous glow is removed before the next is added, so exactly one element is marked at a time. `clearHighlights` strips `diff-selected` alongside the category markers, so repaints start from a clean slate.
+- Buttons are disabled when there are no changes at all.
+
+## Viewport Sync
+
+Each pane emits a `ViewportChangedCommand` (debounced 80 ms) whenever the user pans or zooms. The extension host forwards it to the partner pane as a `SyncViewportQuery`, which calls `canvas.viewbox()` on the partner. A suppression guard on the receiving side prevents the resulting `canvas.viewbox.changed` event from echoing back and creating a feedback loop.
+
+## Developer Preview
+
+You can preview either pane of the diff UI in a plain browser — no Extension Development Host required. See [development.md](../development.md#preview-the-bpmn-webview-in-a-plain-browser) for the URL table. Highlights come from running the real `bpmn-js-differ` in the browser against two fixture XMLs, so the preview stays honest even when the differ is upgraded.
+
+## Architecture
+
+### Extension Host
+
+The `git:`-scheme document (before) and the `file:`-scheme document (after) are resolved by the same `BpmnEditorController`, but routed through a readonly viewer branch when either URI belongs to a diff pair.
+
+```mermaid
+sequenceDiagram
+    participant VSCode as VS Code
+    participant Tracker as DiffTabTracker
+    participant Diff as BpmnDiffService
+    participant BeforePane as Before Webview
+    participant AfterPane as After Webview
+
+    VSCode->>Tracker: onDidChangeTabs (diff opened)
+    Tracker->>Diff: onDidOpen(pair)
+    Diff->>Diff: register DiffPair (armed=false)
+
+    VSCode->>BeforePane: resolveCustomTextEditor (git:)
+    BeforePane->>Diff: DiffReadyCommand
+    Diff->>Diff: pair.markReady(before)
+
+    VSCode->>AfterPane: resolveCustomTextEditor (file:)
+    AfterPane->>Diff: DiffReadyCommand
+    Diff->>Diff: pair.markReady(after) → isArmed()
+
+    Diff->>Diff: bpmn-moddle.fromXML(before + after)
+    Diff->>Diff: bpmn-js-differ.diff(defs, defs)
+    Diff->>BeforePane: ApplyDiffHighlightsQuery(removed, changed, moved, counts)
+    Diff->>AfterPane: ApplyDiffHighlightsQuery(added, changed, moved, counts)
+
+    BeforePane->>Diff: ViewportChangedCommand (pan/zoom)
+    Diff->>AfterPane: SyncViewportQuery
+```
+
+Key design decisions:
+
+- **Editor id is the full URI string**, not just the path. `git:` and `file:` URIs for the same file produce different editor ids, so the `EditorStore` can hold both panes side by side without collision.
+- **`DiffTabTracker.isInDiff(uri)` scans the current tab tree** rather than trusting cached state. Custom-editor resolution can race ahead of the `onDidChangeTabs` event, and a fresh scan avoids the race.
+- **The pair is armed only when both panes signal ready.** The differ runs exactly once per pair; subsequent document edits from Git (e.g. checkout of another ref) retire and re-register the pair.
+- **`bpmn-moddle` is loaded via dynamic `import()`.** This keeps it in its own webpack chunk so the extension host doesn't pay the parse cost until a diff actually opens. The package's default export is a factory function (not a class) — it must be called without `new`.
+
+### Webview
+
+The webview's `main.ts` inspects the first `BpmnFileQuery` and branches on `viewerMode`:
+
+- `viewerMode === "modeler"` — the existing `BpmnModeler` bootstrapping runs unchanged.
+- `viewerMode === "viewer"` — skips the modeler entirely and starts a `DiffMode` instance. The body gets a `.viewer-mode` class that hides the properties panel and panel resizer, so a bare canvas fills the viewport.
+
+`DiffMode` owns a single `DiffViewer` (readonly `NavigatedViewer` wrapper) and a `DiffLegend`, and translates between webview DOM events and the message protocol in `libs/shared`.
+
+## Message Protocol
+
+All types are defined in `libs/shared/src/lib/modeler.ts`.
+
+| Message                      | Direction          | Payload                                                      |
+|------------------------------|--------------------|--------------------------------------------------------------|
+| `BpmnFileQuery`              | host → webview     | `{ content, engine, viewerMode: "modeler" \| "viewer" }`     |
+| `DiffReadyCommand`           | webview → host     | `{}` — signals the pane has imported its XML.                |
+| `ApplyDiffHighlightsQuery`   | host → webview     | `{ side, added, removed, changed, layoutChanged, counts }`   |
+| `ViewportChangedCommand`     | webview → host     | `{ viewport: { x, y, width, height } }`                      |
+| `SyncViewportQuery`          | host → webview     | `{ viewport }` — applied to the partner pane.                |
+
+Each pane receives only the ids that exist on its canvas: the before side sees `removed / changed / layoutChanged`, the after side sees `added / changed / layoutChanged`. This means `applyHighlights` does not need a per-pane filter pass.
+
+## Future Work: Cross-Pane Selection Sync
+
+The `diff-selected` glow currently lives only on the pane whose stepper the user clicks — the after pane. The before pane follows via `SyncViewportQuery` but gives no cue about *which* element inside the incoming viewbox is the one under inspection. For elements that exist on both sides (`changed` and `layoutChanged`) we could mirror the glow.
+
+### Proposed protocol
+
+Add a new cross-pane channel analogous to viewport sync:
+
+- `SelectionChangedCommand { elementId: string | undefined }` — webview → host, posted by `DiffMode.navigate()` alongside the existing `viewer.focusElement` call.
+- `SyncSelectionQuery { elementId: string | undefined }` — host → partner webview, fanned out by `BpmnDiffService` through `DiffPair.getPartner()` (the same lookup used for viewport sync).
+- An `undefined` payload clears the marker — useful for future states (e.g. "no change selected" on first paint) without inventing a second command.
+
+### Webview changes
+
+- Extract the marker bookkeeping out of `DiffViewer.focusElement` into a standalone `markSelected(id: string | undefined)` that toggles the class without moving the viewbox. `focusElement` then composes `pan + markSelected`; the partner pane calls `markSelected` only — its viewport is already driven by the separate `SyncViewportQuery` path.
+- `DiffMode.onMessage` gains a case for `SyncSelectionQuery` that resolves the id against `elementRegistry`. If the element is absent on this side (i.e. `added` on after / `removed` on before) `markSelected(undefined)` simply clears any existing marker.
+
+### Host changes
+
+- `BpmnDiffService` gains a forwarder that mirrors its viewport handler: receive `SelectionChangedCommand`, look up the partner in the pair, post `SyncSelectionQuery`.
+- The viewer branch in `BpmnEditorController` (currently wiring only `DiffReadyCommand` + `ViewportChangedCommand`) subscribes additionally to the new command. No routing change to the modeler branch.
+
+### Edge cases
+
+- **Element absent on partner.** The query arrives with an id that has no entry in the partner's `elementRegistry`; `markSelected` must accept that and clear any existing marker rather than throwing. This happens for every `added`/`removed` selection, which is the majority of diff categories.
+- **Repaint race.** `clearHighlights` (invoked at the top of every `paint`) already strips `diff-selected` and resets `selectedId`. A stray in-flight `SyncSelectionQuery` could reinstate the glow on a stale id after a fresh paint. Mitigation: gate the query handler on "have I received my initial `ApplyDiffHighlightsQuery`?" and drop pre-paint selection messages.
+- **Partner not yet ready.** If the user steps between `DiffReadyCommand` on one pane and the other, the partner has no XML imported yet. Either queue the latest selection server-side and flush on the partner's `DiffReadyCommand`, or drop it silently — the user will step again.
+- **Suppression-on-echo.** Unlike the viewport guard (which suppresses a bounce-back from `canvas.viewbox.changed`), selection changes don't emit a partner event, so no guard is needed. The partner applies the marker passively.
+
+### Files to touch
+
+- `libs/shared/src/lib/modeler.ts` — add `SelectionChangedCommand` + `SyncSelectionQuery`.
+- `apps/modeler-plugin/src/service/BpmnDiffService.ts` — forwarder.
+- `apps/modeler-plugin/src/controller/BpmnEditorController.ts` — wire the new command in the viewer branch.
+- `apps/bpmn-webview/src/app/diff/DiffMode.ts` — emit the command from `navigate()`, handle the query in `onMessage`.
+- `apps/bpmn-webview/src/app/diff/DiffViewer.ts` — split `markSelected(id)` out of `focusElement`.
+
+## Key Files
+
+| File                                                                 | Purpose                                                                             |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| `apps/modeler-plugin/src/infrastructure/DiffTabTracker.ts`           | Observes `vscode.window.tabGroups` and emits open/close events for BPMN diff tabs.  |
+| `apps/modeler-plugin/src/domain/DiffPair.ts`                         | State machine for a single diff pair (armed flag, side resolution, partner lookup). |
+| `apps/modeler-plugin/src/service/BpmnDiffService.ts`                 | Runs `bpmn-js-differ`, broadcasts highlights, forwards viewport-sync messages.      |
+| `apps/modeler-plugin/src/controller/BpmnEditorController.ts`         | Branches between editable modeler and readonly viewer based on URI scheme / diff.   |
+| `apps/modeler-plugin/src/types/bpmn-js-differ.d.ts`                  | Ambient shim for the untyped `bpmn-js-differ` package.                              |
+| `apps/modeler-plugin/src/types/bpmn-moddle.d.ts`                     | Ambient shim for `bpmn-moddle` (factory function, not a class).                     |
+| `apps/bpmn-webview/src/app/diff/DiffMode.ts`                         | Webview entry point for viewer mode — wires viewer + legend + message handlers.     |
+| `apps/bpmn-webview/src/app/diff/DiffViewer.ts`                       | Thin wrapper over `NavigatedViewer` adding marker helpers and viewport sync guard.  |
+| `apps/bpmn-webview/src/app/diff/DiffLegend.ts`                       | Floating chip with per-category counts and prev/next nav.                           |
+| `apps/bpmn-webview/src/styles/diff.css`                              | Marker colours, dashed stroke, legend chip layout (light + dark theme).             |
+| `apps/bpmn-webview/src/app/__fixtures__/mock-diff.ts`                | Dev-only fixture XMLs that feed the browser preview.                                |
+| `libs/shared/src/lib/modeler.ts`                                     | Message types (`BpmnViewerMode`, `DiffSide`, `DiffCounts`, `Viewport`, Query/Command classes). |
+
+## Related
+
+- [Development guide — browser preview](../development.md#preview-the-bpmn-webview-in-a-plain-browser)
+- [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ) — upstream differ library
+- [demo.bpmn.io/diff](https://demo.bpmn.io/diff) — reference UI

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -25,15 +25,32 @@
 import { Command, Query } from "./messages";
 
 // =================================== Queries ==================================>
+/**
+ * The webview can either host the full editable modeler or a readonly viewer
+ * used for side-by-side diff rendering.
+ */
+export type BpmnViewerMode = "modeler" | "viewer";
+
 export class BpmnFileQuery extends Query {
     public readonly content: string;
 
     public readonly engine: "c7" | "c8";
 
-    constructor(content: string, engine: "c7" | "c8") {
+    /**
+     * Rendering mode. Defaults to `"modeler"` for backward compatibility; set
+     * to `"viewer"` when the pane is one half of a git diff view.
+     */
+    public readonly viewerMode: BpmnViewerMode;
+
+    constructor(
+        content: string,
+        engine: "c7" | "c8",
+        viewerMode: BpmnViewerMode = "modeler",
+    ) {
         super("BpmnFileQuery");
         this.content = content;
         this.engine = engine;
+        this.viewerMode = viewerMode;
     }
 }
 
@@ -393,3 +410,102 @@ export class ProcessDefinitionKeyQuery extends Query {
 }
 
 // <================================== Start Instance ===================================
+
+// =================================== BPMN Diff ==================================>
+
+/** Which side of the diff a webview pane represents. */
+export type DiffSide = "before" | "after";
+
+/** Summary counts used for the diff legend chip. */
+export interface DiffCounts {
+    readonly added: number;
+    readonly removed: number;
+    readonly changed: number;
+    readonly layoutChanged: number;
+}
+
+/** Canvas viewbox used for pan/zoom synchronisation between panes. */
+export interface Viewport {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+}
+
+/**
+ * Sent from the extension host to each webview pane once a diff pair is armed
+ * and `bpmn-js-differ` has produced its result.  Each side receives only the
+ * element ids relevant to its canvas (e.g. `_removed` ids on the `before`
+ * side only; `_added` on `after` only; `_changed` and `_layoutChanged` on
+ * both because the elements exist in both versions).
+ */
+export class ApplyDiffHighlightsQuery extends Query {
+    public readonly side: DiffSide;
+
+    public readonly added: string[];
+
+    public readonly removed: string[];
+
+    public readonly changed: string[];
+
+    public readonly layoutChanged: string[];
+
+    public readonly counts: DiffCounts;
+
+    constructor(
+        side: DiffSide,
+        added: string[],
+        removed: string[],
+        changed: string[],
+        layoutChanged: string[],
+        counts: DiffCounts,
+    ) {
+        super("ApplyDiffHighlightsQuery");
+        this.side = side;
+        this.added = added;
+        this.removed = removed;
+        this.changed = changed;
+        this.layoutChanged = layoutChanged;
+        this.counts = counts;
+    }
+}
+
+/**
+ * Sent from the host to a pane to apply the partner pane's viewport.  The
+ * receiving pane must suppress its next outgoing `ViewportChangedCommand` to
+ * avoid a feedback loop.
+ */
+export class SyncViewportQuery extends Query {
+    public readonly viewport: Viewport;
+
+    constructor(viewport: Viewport) {
+        super("SyncViewportQuery");
+        this.viewport = viewport;
+    }
+}
+
+/**
+ * Sent from a viewer pane after a user-initiated pan or zoom.  The host
+ * forwards the viewport to the partner pane via {@link SyncViewportQuery}.
+ */
+export class ViewportChangedCommand extends Command {
+    public readonly viewport: Viewport;
+
+    constructor(viewport: Viewport) {
+        super("ViewportChangedCommand");
+        this.viewport = viewport;
+    }
+}
+
+/**
+ * Sent from a viewer pane once it has finished importing the initial XML
+ * diagram.  The host tracks this per pane to know when a diff pair is armed
+ * (both panes ready) and it can safely post {@link ApplyDiffHighlightsQuery}.
+ */
+export class DiffReadyCommand extends Command {
+    constructor() {
+        super("DiffReadyCommand");
+    }
+}
+
+// <================================== BPMN Diff ===================================

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "@bpmn-io/properties-panel": "3.40.6",
         "bpmn-js": "^18.14.0",
         "bpmn-js-create-append-anything": "^1.2.0",
+        "bpmn-js-differ": "^3.2.0",
         "bpmn-js-native-copy-paste": "^0.3.0",
         "bpmn-js-properties-panel": "^5.53.0",
         "bpmn-js-token-simulation": "^0.39.3",

--- a/resources/example-process/example-process.bpmn
+++ b/resources/example-process/example-process.bpmn
@@ -16,8 +16,13 @@
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1qhfavc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h9cvar</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1qhfavc" sourceRef="Start_Form" targetRef="Activity_1k3cs5s" />
+    <bpmn:endEvent id="Event_1ritf8p">
+      <bpmn:incoming>Flow_0h9cvar</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0h9cvar" sourceRef="Activity_1k3cs5s" targetRef="Event_1ritf8p" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_test-prozess">
     <bpmndi:BPMNPlane id="BPMNPlane_test-prozess" bpmnElement="example-process">
@@ -30,9 +35,16 @@
       <bpmndi:BPMNShape id="Activity_1k3cs5s_di" bpmnElement="Activity_1k3cs5s">
         <dc:Bounds x="240" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ritf8p_di" bpmnElement="Event_1ritf8p">
+        <dc:Bounds x="392" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1qhfavc_di" bpmnElement="Flow_1qhfavc">
         <di:waypoint x="188" y="120" />
         <di:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h9cvar_di" bpmnElement="Flow_0h9cvar">
+        <di:waypoint x="340" y="120" />
+        <di:waypoint x="392" y="120" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3842,6 +3842,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bpmn-js-differ@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "bpmn-js-differ@npm:3.2.0"
+  dependencies:
+    diffpatch: "npm:^0.6.0"
+    min-dash: "npm:^5.0.0"
+  checksum: 10c0/0de9000dbfd014ed14df301e8886c1397a702542f22813ea9189e0473947f9edcfb1d69fa94aaa455c6c55a4a47c1915caea12afe60700defc300a288e166eac
+  languageName: node
+  linkType: hard
+
 "bpmn-js-element-templates@npm:^2.23.0":
   version: 2.23.0
   resolution: "bpmn-js-element-templates@npm:2.23.0"
@@ -3966,6 +3976,7 @@ __metadata:
     "@vitest/ui": "npm:4.1.4"
     bpmn-js: "npm:^18.14.0"
     bpmn-js-create-append-anything: "npm:^1.2.0"
+    bpmn-js-differ: "npm:^3.2.0"
     bpmn-js-native-copy-paste: "npm:^0.3.0"
     bpmn-js-properties-panel: "npm:^5.53.0"
     bpmn-js-token-simulation: "npm:^0.39.3"
@@ -4937,6 +4948,17 @@ __metadata:
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
   checksum: 10c0/81b91f9d39c4eaca068eb0c1eb0e4afbdc5bb2941d197f513dd596b820b956fef43485876226d65d497bebc15666aa2aa82c679e84f65d5f2bfbf14ee46e32c1
+  languageName: node
+  linkType: hard
+
+"diffpatch@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "diffpatch@npm:0.6.0"
+  dependencies:
+    picocolors: "npm:^1.0.1"
+  bin:
+    diffpatch: bin/diffpatch
+  checksum: 10c0/47859a328f100059656d50633e1d2bbf0c87a27a2c54d12f486d6ae471617243861c7ee65ed2c1868b006a2b69c3edf89829bf6d31d03a2e15411da0dee43ad0
   languageName: node
   linkType: hard
 
@@ -8957,7 +8979,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.1.1":
+"picocolors@npm:^1.0.1, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58


### PR DESCRIPTION
**Issue**

Closes: #890

**Description**

Implement side-by-side readonly BPMN canvas diff view using `bpmn-js-differ` for element-level change highlighting. Add `DiffMode`, `DiffViewer`, and `DiffLegend` webview components with synchronized viewport panning/zooming. Integrate `BpmnDiffService` in extension host to detect diff tabs, compute diffs, and route viewer-mode panes. Support browser preview of diff UI via `?mode=diff-before` and `?mode=diff-after` query params in dev builds.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
