### PR TITLE
feat: improve diff stepper to navigate by sequence-flow order

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,6 @@
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
 nodeLinker: node-modules

--- a/apps/bpmn-webview/src/app/diff/DiffMode.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffMode.ts
@@ -1,8 +1,10 @@
 import {
     ApplyDiffHighlightsQuery,
     Command,
+    CursorChangedCommand,
     DiffReadyCommand,
     Query,
+    SyncCursorQuery,
     SyncViewportQuery,
     VsCodeApi,
     ViewportChangedCommand,
@@ -20,12 +22,19 @@ type MessageType = Query | Command;
  * Replaces the full modeler stack with a single {@link DiffViewer} + a
  * {@link DiffLegend} chip.  Handles the viewer-mode message protocol:
  *   - Initial XML handed in by {@link startWith} → import, emit {@link DiffReadyCommand}.
- *   - Incoming {@link ApplyDiffHighlightsQuery} → paint markers, show legend.
+ *   - Incoming {@link ApplyDiffHighlightsQuery} → paint markers, show legend
+ *     on both panes (counts + navigationOrder are symmetric across sides).
  *   - Incoming {@link SyncViewportQuery} → apply partner's viewport.
+ *   - Incoming {@link SyncCursorQuery} → advance local stepper without
+ *     re-emitting (would otherwise ping-pong the two panes forever).
  *   - Outgoing {@link ViewportChangedCommand} on user pan/zoom.
+ *   - Outgoing {@link CursorChangedCommand} on user-driven Next/Prev so the
+ *     partner pane's stepper stays in lockstep.
  *
- * Nav buttons cycle a local cursor over the side's own changed-element ids;
- * the partner pane stays in sync via the normal viewport-sync channel.
+ * Nav buttons cycle a shared cursor over `navigationOrder`; both panes drive
+ * focus locally so changed/layoutChanged elements glow on both sides.
+ * Added/removed ids exist on only one pane; the other anchors via
+ * {@link findAnchor} and follows via the viewport-sync channel.
  */
 export class DiffMode {
     private readonly viewer: DiffViewer;
@@ -48,8 +57,8 @@ export class DiffMode {
     ) {
         this.viewer = new DiffViewer(canvasSelector);
         this.legend = new DiffLegend(legendParent, {
-            onPrevious: () => this.navigate(-1),
-            onNext: () => this.navigate(1),
+            onPrevious: () => this.step(-1),
+            onNext: () => this.step(1),
         });
 
         this.viewer.onViewportChanged((viewport) => {
@@ -80,6 +89,9 @@ export class DiffMode {
             case "SyncViewportQuery":
                 this.viewer.setViewport((message as SyncViewportQuery).viewport);
                 break;
+            case "SyncCursorQuery":
+                this.applyCursor((message as SyncCursorQuery).index, false);
+                break;
         }
     }
 
@@ -100,58 +112,109 @@ export class DiffMode {
         this.viewer.applyHighlights(query.changed, "diff-changed");
         this.viewer.applyHighlights(query.layoutChanged, "diff-layout-changed");
 
-        // Rebuild nav order: removed (before only) / added (after only) first,
-        // then changed, then layoutChanged.  Stable order lets the two panes
-        // iterate in lockstep when the user clicks Next on either side.
-        //
         // Skip connections whose *only* change is `layoutChanged` — that
         // happens when a task moves and its incoming/outgoing flows get new
         // waypoints as a side-effect.  The flow carries no semantic change
         // on its own, and the user already sees it highlighted when the
         // attached shape comes up in the cycle.
-        //
-        // Deduplicate: an edge whose source/target genuinely changes appears
-        // in both `changed` and `layoutChanged`, but should land in the
-        // cycle only once.
         const semanticIds = new Set<string>([
             ...query.removed,
             ...query.added,
             ...query.changed,
         ]);
-        const layoutForNav = query.layoutChanged.filter(
-            (id) => semanticIds.has(id) || !this.viewer.isConnection(id),
-        );
+        const isLayoutOnlyConnection = (id: string): boolean =>
+            !semanticIds.has(id) &&
+            query.layoutChanged.includes(id) &&
+            this.viewer.isConnection(id);
 
+        // Use the host-provided sequence-flow order so the stepper walks
+        // start event → end event instead of in differ insertion order.
         this.changeIds.length = 0;
-        const seen = new Set<string>();
-        for (const id of [
-            ...query.removed,
-            ...query.added,
-            ...query.changed,
-            ...layoutForNav,
-        ]) {
-            if (!seen.has(id)) {
-                seen.add(id);
+        for (const id of query.navigationOrder) {
+            if (!isLayoutOnlyConnection(id)) {
                 this.changeIds.push(id);
             }
         }
         this.cursor = -1;
 
-        // Legend (counts + stepper) lives on the "after" pane only.  The
-        // counts are symmetric so rendering them twice is redundant, and
-        // stepping from the after pane already syncs the before pane via
-        // the viewport channel.
-        if (query.side === "after") {
-            this.legend.update(query.counts);
-        }
+        // Both panes render the legend now: counts are symmetric across
+        // sides, and each pane drives a synced cursor over the same
+        // navigationOrder array, so the user can step from either side.
+        this.legend.update(query.counts);
     }
 
-    private navigate(step: 1 | -1): void {
+    /**
+     * User-driven step from this pane's Next/Prev buttons.  Computes the new
+     * cursor, applies it locally, and posts {@link CursorChangedCommand} so
+     * the host can fan it to the partner pane via {@link SyncCursorQuery}.
+     */
+    private step(direction: 1 | -1): void {
         if (this.changeIds.length === 0) {
             return;
         }
-        this.cursor =
-            (this.cursor + step + this.changeIds.length) % this.changeIds.length;
-        this.viewer.focusElement(this.changeIds[this.cursor]);
+        const next =
+            (this.cursor + direction + this.changeIds.length) %
+            this.changeIds.length;
+        this.applyCursor(next, true, direction);
+    }
+
+    /**
+     * Moves the local stepper to `index` and either focuses (id exists on
+     * this canvas) or anchors on a surviving neighbour (id is partner-only).
+     * Posts {@link CursorChangedCommand} when `emit` is true — set to false
+     * for incoming {@link SyncCursorQuery} to avoid a ping-pong loop.
+     *
+     * `direction` biases the anchor walk towards the user's step direction
+     * when invoked from {@link step}; an incoming sync defaults to forward
+     * search since the partner already chose the canonical direction.
+     */
+    private applyCursor(
+        index: number,
+        emit: boolean,
+        direction: 1 | -1 = 1,
+    ): void {
+        if (this.changeIds.length === 0) {
+            return;
+        }
+        this.cursor = index;
+        const targetId = this.changeIds[this.cursor];
+
+        if (!this.viewer.focusElement(targetId)) {
+            // Target id lives only on the partner pane.  Centre on the
+            // nearest neighbour in `changeIds` that exists on this canvas —
+            // the viewbox move then propagates via viewport-sync so the
+            // partner pane brings the actual element into view with its
+            // diff highlight.  Without this anchoring the stepper appears
+            // frozen whenever the cursor lands on a partner-only id.
+            const anchor = this.findAnchor(this.cursor, direction);
+            if (anchor !== undefined) {
+                this.viewer.centerOnElement(anchor);
+            }
+            this.viewer.clearSelectionMarker();
+        }
+
+        if (emit) {
+            this.vscode.postMessage(new CursorChangedCommand(this.cursor));
+        }
+    }
+
+    /**
+     * Walks outward from `cursor` in `changeIds`, preferring `direction`, to
+     * locate an id that is present on this pane.  Returns `undefined` only
+     * in the degenerate case where every id in the cycle lives exclusively
+     * on the partner pane.
+     */
+    private findAnchor(cursor: number, direction: 1 | -1): string | undefined {
+        const len = this.changeIds.length;
+        for (let i = 1; i < len; i++) {
+            for (const dir of [direction, -direction] as const) {
+                const idx = ((cursor + dir * i) % len + len) % len;
+                const id = this.changeIds[idx];
+                if (this.viewer.hasElement(id)) {
+                    return id;
+                }
+            }
+        }
+        return undefined;
     }
 }

--- a/apps/bpmn-webview/src/app/diff/DiffViewer.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffViewer.ts
@@ -122,8 +122,9 @@ export class DiffViewer {
     }
 
     /**
-     * Centres the viewport on the element with the given id, preserving the
-     * current zoom level.  Returns `true` if the element was found.
+     * Centres the viewport on the element with the given id and marks it as
+     * the stepper's current selection.  Returns `true` if the element was
+     * found on this canvas.
      *
      * Shapes carry `x/y/width/height`; connections (sequence flows, message
      * flows, associations) carry `waypoints` instead — in that case the
@@ -131,6 +132,32 @@ export class DiffViewer {
      * would centre at (0, 0) and produce a visible "reset" jump.
      */
     focusElement(id: string): boolean {
+        if (!this.centerOnElement(id)) {
+            return false;
+        }
+        const canvas = this.getCanvas();
+        if (this.selectedId && this.selectedId !== id) {
+            canvas.removeMarker(this.selectedId, DIFF_SELECTED_CLASS);
+        }
+        canvas.addMarker(id, DIFF_SELECTED_CLASS);
+        this.selectedId = id;
+        return true;
+    }
+
+    /**
+     * Centres the viewport on `id` without touching the selection marker.
+     * Used by the diff stepper to anchor the viewport on a surviving
+     * neighbour when the target id only exists on the partner pane (e.g. a
+     * removed element when this is the after pane).
+     *
+     * Sets {@link suppressNextChangeEvent} so the resulting viewbox change
+     * does NOT emit `ViewportChangedCommand`.  The cursor-sync channel
+     * already keeps the partner pane positioned (each pane independently
+     * resolves the cursor against its own registry), so re-emitting via
+     * viewport-sync would race the cursor sync and overwrite the partner's
+     * correctly-focused viewbox with this pane's anchor position.
+     */
+    centerOnElement(id: string): boolean {
         const registry = this.viewer.get<any>("elementRegistry");
         const element = registry.get(id);
         if (!element) {
@@ -142,18 +169,34 @@ export class DiffViewer {
         }
         const canvas = this.getCanvas();
         const viewbox = canvas.viewbox();
+        this.suppressNextChangeEvent = true;
         canvas.viewbox({
             x: centre.x - viewbox.width / 2,
             y: centre.y - viewbox.height / 2,
             width: viewbox.width,
             height: viewbox.height,
         });
-        if (this.selectedId && this.selectedId !== id) {
-            canvas.removeMarker(this.selectedId, DIFF_SELECTED_CLASS);
-        }
-        canvas.addMarker(id, DIFF_SELECTED_CLASS);
-        this.selectedId = id;
         return true;
+    }
+
+    /** Returns `true` when `id` is present in this pane's element registry. */
+    hasElement(id: string): boolean {
+        const registry = this.viewer.get<any>("elementRegistry");
+        return !!registry.get(id);
+    }
+
+    /**
+     * Removes the stepper-selection marker from whatever element currently
+     * carries it.  Called when the stepper lands on an id that does not exist
+     * on this pane: leaving the marker on the previous element would mislead
+     * the user into thinking it is still the active step.
+     */
+    clearSelectionMarker(): void {
+        if (!this.selectedId) {
+            return;
+        }
+        this.getCanvas().removeMarker(this.selectedId, DIFF_SELECTED_CLASS);
+        this.selectedId = undefined;
     }
 
     /**

--- a/apps/bpmn-webview/src/app/vscode.ts
+++ b/apps/bpmn-webview/src/app/vscode.ts
@@ -2,14 +2,18 @@ import {
     ApplyDiffHighlightsQuery,
     BpmnFileQuery,
     BpmnModelerSettingQuery,
+    buildFlowOrder,
+    buildRemovedAnchors,
     ClipboardQuery,
     Command,
+    CursorChangedCommand,
     DiffCounts,
     DiffSide,
     ElementTemplatesQuery,
     LogErrorCommand,
     LogInfoCommand,
     Query,
+    sortIdsByOrder,
     SyncDocumentCommand,
     VsCodeApi,
     VsCodeImpl,
@@ -152,6 +156,8 @@ interface CachedDiff {
         layoutChanged: string[];
     };
     counts: DiffCounts;
+    /** Pre-merged sequence-flow order shared by both panes. */
+    navigationOrder: string[];
 }
 
 function readDevMode(): DevMode {
@@ -281,6 +287,14 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
                 );
                 break;
             }
+            case message.type === "CursorChangedCommand": {
+                // Single-pane preview: stepper advances locally only.
+                console.debug(
+                    "[DEBUG] CursorChangedCommand (no partner in dev)",
+                    (message as CursorChangedCommand).index,
+                );
+                break;
+            }
             default: {
                 throw new Error(
                     `Unknown message type: ${(message as MessageType).type}`,
@@ -348,6 +362,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
                 slice.changed,
                 slice.layoutChanged,
                 cached.counts,
+                cached.navigationOrder,
             ),
         );
     }
@@ -395,15 +410,53 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
         const changed = Object.keys(result._changed);
         const layoutChanged = Object.keys(result._layoutChanged);
 
+        const afterOrder = buildFlowOrder(afterDefs as never);
+        const removedAnchors = buildRemovedAnchors(
+            removed,
+            beforeDefs as never,
+            afterOrder,
+        );
+        const sortedAdded = sortIdsByOrder(added, afterOrder);
+        const sortedRemoved = sortIdsByOrder(removed, removedAnchors);
+        const sortedChanged = sortIdsByOrder(changed, afterOrder);
+        const sortedLayoutChanged = sortIdsByOrder(layoutChanged, afterOrder);
+        const merged: string[] = [];
+        const seen = new Set<string>();
+        for (const id of [
+            ...sortedAdded,
+            ...sortedRemoved,
+            ...sortedChanged,
+            ...sortedLayoutChanged,
+        ]) {
+            if (!seen.has(id)) {
+                seen.add(id);
+                merged.push(id);
+            }
+        }
+        const navigationOrder = sortIdsByOrder(
+            merged,
+            afterOrder,
+            removedAnchors,
+        );
+
         this.cachedDiff = {
-            before: { removed, changed, layoutChanged },
-            after: { added, changed, layoutChanged },
+            before: {
+                removed: sortedRemoved,
+                changed: sortedChanged,
+                layoutChanged: sortedLayoutChanged,
+            },
+            after: {
+                added: sortedAdded,
+                changed: sortedChanged,
+                layoutChanged: sortedLayoutChanged,
+            },
             counts: {
                 added: added.length,
                 removed: removed.length,
                 changed: changed.length,
                 layoutChanged: layoutChanged.length,
             },
+            navigationOrder,
         };
         return this.cachedDiff;
     }

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -12,9 +12,14 @@ import { diff } from "bpmn-js-differ";
 import {
     ApplyDiffHighlightsQuery,
     BpmnFileQuery,
+    buildFlowOrder,
+    buildRemovedAnchors,
     Command,
+    CursorChangedCommand,
     DiffCounts,
     DiffSide,
+    sortIdsByOrder,
+    SyncCursorQuery,
     SyncViewportQuery,
     ViewportChangedCommand,
 } from "@bpmn-modeler/shared";
@@ -56,12 +61,12 @@ interface DiffPaneEntry {
  *      custom-editor-backed diff tabs and no typed signal is available.
  *   2. Bootstrap the webview for a newly-resolved diff pane, wire up the
  *      narrow viewer-mode message protocol (`GetBpmnFileCommand`,
- *      `DiffReadyCommand`, `ViewportChangedCommand`), and link the pane to
- *      its partner by shared file path.
+ *      `DiffReadyCommand`, `ViewportChangedCommand`, `CursorChangedCommand`),
+ *      and link the pane to its partner by shared file path.
  *   3. Once both panes of a pair are ready, run `bpmn-js-differ` on the
  *      parsed XMLs and broadcast per-side {@link ApplyDiffHighlightsQuery}.
- *   4. Forward viewport-change messages from one pane to its partner so
- *      panning and zooming stay in sync.
+ *   4. Forward viewport-change and cursor-change messages from one pane to
+ *      its partner so panning, zooming, and stepper navigation stay in sync.
  */
 export class BpmnDiffService {
     /** Every live diff pane, keyed by its {@link WebviewPanel} reference. */
@@ -219,6 +224,12 @@ export class BpmnDiffService {
                     (message as ViewportChangedCommand).viewport,
                 );
                 break;
+            case "CursorChangedCommand":
+                await this.forwardCursor(
+                    entry,
+                    (message as CursorChangedCommand).index,
+                );
+                break;
         }
     }
 
@@ -274,6 +285,28 @@ export class BpmnDiffService {
         } catch (error) {
             this.vsUI.logInfo(
                 `syncViewport dropped: ${(error as Error).message}`,
+            );
+        }
+    }
+
+    /**
+     * Posts the partner's stepper cursor change so both panes' Next/Prev
+     * navigation stays in lockstep.  Mirrors {@link forwardViewport} — same
+     * partner lookup, same drop-silently-on-failure semantics.
+     */
+    private async forwardCursor(
+        entry: DiffPaneEntry,
+        index: number,
+    ): Promise<void> {
+        const partner = entry.partner;
+        if (!partner) {
+            return;
+        }
+        try {
+            await partner.panel.webview.postMessage(new SyncCursorQuery(index));
+        } catch (error) {
+            this.vsUI.logInfo(
+                `syncCursor dropped: ${(error as Error).message}`,
             );
         }
     }
@@ -338,26 +371,62 @@ export class BpmnDiffService {
             layoutChanged: layoutChanged.length,
         };
 
+        // Order all id arrays by sequence-flow position so the diff stepper
+        // walks from start event to end event instead of in the differ's
+        // arbitrary insertion order.  Removed elements live only on the
+        // before canvas; anchor each one next to a surviving neighbour in the
+        // after order so it appears near where it used to be in the flow.
+        const afterOrder = buildFlowOrder(afterDefs as never);
+        const removedAnchors = buildRemovedAnchors(
+            removed,
+            beforeDefs as never,
+            afterOrder,
+        );
+        const sortedAdded = sortIdsByOrder(added, afterOrder);
+        const sortedRemoved = sortIdsByOrder(removed, removedAnchors);
+        const sortedChanged = sortIdsByOrder(changed, afterOrder);
+        const sortedLayoutChanged = sortIdsByOrder(layoutChanged, afterOrder);
+
+        // Merged navigation order: dedup across categories, then sort once
+        // more so removed elements interleave with added/changed at their
+        // anchored positions instead of sitting in their own block.
+        const merged: string[] = [];
+        const seen = new Set<string>();
+        for (const id of [
+            ...sortedAdded,
+            ...sortedRemoved,
+            ...sortedChanged,
+            ...sortedLayoutChanged,
+        ]) {
+            if (!seen.has(id)) {
+                seen.add(id);
+                merged.push(id);
+            }
+        }
+        const navigationOrder = sortIdsByOrder(merged, afterOrder, removedAnchors);
+
         await this.postHighlights(
             before.panel,
             new ApplyDiffHighlightsQuery(
                 "before",
                 [],
-                removed,
-                changed,
-                layoutChanged,
+                sortedRemoved,
+                sortedChanged,
+                sortedLayoutChanged,
                 counts,
+                navigationOrder,
             ),
         );
         await this.postHighlights(
             after.panel,
             new ApplyDiffHighlightsQuery(
                 "after",
-                added,
+                sortedAdded,
                 [],
-                changed,
-                layoutChanged,
+                sortedChanged,
+                sortedLayoutChanged,
                 counts,
+                navigationOrder,
             ),
         );
     }

--- a/docs/features/bpmn-diff.md
+++ b/docs/features/bpmn-diff.md
@@ -25,16 +25,21 @@ Colours intentionally match the bpmn.io/diff demo so users familiar with that UI
 
 ## Legend Chip
 
-The floating legend sits at the top-centre of the **after pane only**; counts are symmetric across the diff, so rendering them twice would be redundant, and hosting the stepper on a single pane keeps a single input path — the before pane follows via viewport sync. The chip reveals itself once the differ has reported its results:
+The floating legend sits at the top-centre of **both panes**.  Each pane reveals its chip once the differ has reported its results:
 
-- Four count slots — Added / Removed / Changed / Moved — each with its colour swatch.
-- A **Prev change** / **Next change** navigator that cycles through the change ids on the after pane (`added → changed → layoutChanged`), filtered to skip connections whose *only* classification is `layoutChanged` — those are waypoint side-effects of a moved shape and carry no semantic change.
-- Clicking a nav button centres the viewport on the target at the current zoom and paints a gold glow (`.diff-selected`, implemented via `filter: drop-shadow` so it layers on top of any category stroke). The previous glow is removed before the next is added, so exactly one element is marked at a time. `clearHighlights` strips `diff-selected` alongside the category markers, so repaints start from a clean slate.
+- Four count slots — Added / Removed / Changed / Moved — each with its colour swatch.  Counts are symmetric across the two sides; both panes show the same numbers.
+- A **Prev change** / **Next change** navigator that cycles through the shared `navigationOrder` array (sequence-flow ordered, with `removed` ids anchored next to surviving neighbours), filtered to skip connections whose *only* classification is `layoutChanged` — those are waypoint side-effects of a moved shape and carry no semantic change.
+- Clicking a nav button on either pane advances **both** cursors via the [cursor-sync channel](#viewport-and-cursor-sync).  The pane that owns the current id paints a gold glow (`.diff-selected`, implemented via `filter: drop-shadow` so it layers on top of any category stroke); the other pane anchors its viewport on the nearest neighbour that does exist locally and clears its own selection marker so the user is not misled.  For `changed` and `layoutChanged` ids the element exists on both panes, so both glow simultaneously.
+- The previous glow is removed before the next is added, so exactly one element is marked per pane at any time.  `clearHighlights` strips `diff-selected` alongside the category markers, so repaints start from a clean slate.
 - Buttons are disabled when there are no changes at all.
 
-## Viewport Sync
+## Viewport and Cursor Sync
 
-Each pane emits a `ViewportChangedCommand` (debounced 80 ms) whenever the user pans or zooms. The extension host forwards it to the partner pane as a `SyncViewportQuery`, which calls `canvas.viewbox()` on the partner. A suppression guard on the receiving side prevents the resulting `canvas.viewbox.changed` event from echoing back and creating a feedback loop.
+Two parallel cross-pane channels keep the panes coordinated:
+
+**Viewport sync.** Each pane emits a `ViewportChangedCommand` (debounced 80 ms) whenever the user pans or zooms. The extension host forwards it to the partner pane as a `SyncViewportQuery`, which calls `canvas.viewbox()` on the partner. A suppression guard on the receiving side prevents the resulting `canvas.viewbox.changed` event from echoing back and creating a feedback loop.
+
+**Cursor sync.** Each pane emits a `CursorChangedCommand { index }` after the user clicks Next/Prev. The host forwards it to the partner pane as a `SyncCursorQuery { index }`, which calls the receiving pane's internal `applyCursor(index, false)`.  The `false` flag suppresses re-emission — without it the two panes would ping-pong indefinitely.  No DOM-event guard is needed because the partner applies the cursor passively (`focusElement` / `centerOnElement` only); it never originates a `CursorChangedCommand` of its own from a sync.
 
 ## Developer Preview
 
@@ -73,6 +78,9 @@ sequenceDiagram
 
     BeforePane->>Diff: ViewportChangedCommand (pan/zoom)
     Diff->>AfterPane: SyncViewportQuery
+
+    AfterPane->>Diff: CursorChangedCommand (Next/Prev)
+    Diff->>BeforePane: SyncCursorQuery
 ```
 
 Key design decisions:
@@ -95,52 +103,17 @@ The webview's `main.ts` inspects the first `BpmnFileQuery` and branches on `view
 
 All types are defined in `libs/shared/src/lib/modeler.ts`.
 
-| Message                      | Direction          | Payload                                                      |
-|------------------------------|--------------------|--------------------------------------------------------------|
-| `BpmnFileQuery`              | host → webview     | `{ content, engine, viewerMode: "modeler" \| "viewer" }`     |
-| `DiffReadyCommand`           | webview → host     | `{}` — signals the pane has imported its XML.                |
-| `ApplyDiffHighlightsQuery`   | host → webview     | `{ side, added, removed, changed, layoutChanged, counts }`   |
-| `ViewportChangedCommand`     | webview → host     | `{ viewport: { x, y, width, height } }`                      |
-| `SyncViewportQuery`          | host → webview     | `{ viewport }` — applied to the partner pane.                |
+| Message                      | Direction          | Payload                                                                          |
+|------------------------------|--------------------|----------------------------------------------------------------------------------|
+| `BpmnFileQuery`              | host → webview     | `{ content, engine, viewerMode: "modeler" \| "viewer" }`                         |
+| `DiffReadyCommand`           | webview → host     | `{}` — signals the pane has imported its XML.                                    |
+| `ApplyDiffHighlightsQuery`   | host → webview     | `{ side, added, removed, changed, layoutChanged, counts, navigationOrder }`      |
+| `ViewportChangedCommand`     | webview → host     | `{ viewport: { x, y, width, height } }`                                          |
+| `SyncViewportQuery`          | host → webview     | `{ viewport }` — applied to the partner pane.                                    |
+| `CursorChangedCommand`       | webview → host     | `{ index }` — current position in the shared `navigationOrder`.                  |
+| `SyncCursorQuery`            | host → webview     | `{ index }` — applied to the partner pane via `applyCursor(index, false)`.       |
 
-Each pane receives only the ids that exist on its canvas: the before side sees `removed / changed / layoutChanged`, the after side sees `added / changed / layoutChanged`. This means `applyHighlights` does not need a per-pane filter pass.
-
-## Future Work: Cross-Pane Selection Sync
-
-The `diff-selected` glow currently lives only on the pane whose stepper the user clicks — the after pane. The before pane follows via `SyncViewportQuery` but gives no cue about *which* element inside the incoming viewbox is the one under inspection. For elements that exist on both sides (`changed` and `layoutChanged`) we could mirror the glow.
-
-### Proposed protocol
-
-Add a new cross-pane channel analogous to viewport sync:
-
-- `SelectionChangedCommand { elementId: string | undefined }` — webview → host, posted by `DiffMode.navigate()` alongside the existing `viewer.focusElement` call.
-- `SyncSelectionQuery { elementId: string | undefined }` — host → partner webview, fanned out by `BpmnDiffService` through `DiffPair.getPartner()` (the same lookup used for viewport sync).
-- An `undefined` payload clears the marker — useful for future states (e.g. "no change selected" on first paint) without inventing a second command.
-
-### Webview changes
-
-- Extract the marker bookkeeping out of `DiffViewer.focusElement` into a standalone `markSelected(id: string | undefined)` that toggles the class without moving the viewbox. `focusElement` then composes `pan + markSelected`; the partner pane calls `markSelected` only — its viewport is already driven by the separate `SyncViewportQuery` path.
-- `DiffMode.onMessage` gains a case for `SyncSelectionQuery` that resolves the id against `elementRegistry`. If the element is absent on this side (i.e. `added` on after / `removed` on before) `markSelected(undefined)` simply clears any existing marker.
-
-### Host changes
-
-- `BpmnDiffService` gains a forwarder that mirrors its viewport handler: receive `SelectionChangedCommand`, look up the partner in the pair, post `SyncSelectionQuery`.
-- The viewer branch in `BpmnEditorController` (currently wiring only `DiffReadyCommand` + `ViewportChangedCommand`) subscribes additionally to the new command. No routing change to the modeler branch.
-
-### Edge cases
-
-- **Element absent on partner.** The query arrives with an id that has no entry in the partner's `elementRegistry`; `markSelected` must accept that and clear any existing marker rather than throwing. This happens for every `added`/`removed` selection, which is the majority of diff categories.
-- **Repaint race.** `clearHighlights` (invoked at the top of every `paint`) already strips `diff-selected` and resets `selectedId`. A stray in-flight `SyncSelectionQuery` could reinstate the glow on a stale id after a fresh paint. Mitigation: gate the query handler on "have I received my initial `ApplyDiffHighlightsQuery`?" and drop pre-paint selection messages.
-- **Partner not yet ready.** If the user steps between `DiffReadyCommand` on one pane and the other, the partner has no XML imported yet. Either queue the latest selection server-side and flush on the partner's `DiffReadyCommand`, or drop it silently — the user will step again.
-- **Suppression-on-echo.** Unlike the viewport guard (which suppresses a bounce-back from `canvas.viewbox.changed`), selection changes don't emit a partner event, so no guard is needed. The partner applies the marker passively.
-
-### Files to touch
-
-- `libs/shared/src/lib/modeler.ts` — add `SelectionChangedCommand` + `SyncSelectionQuery`.
-- `apps/modeler-plugin/src/service/BpmnDiffService.ts` — forwarder.
-- `apps/modeler-plugin/src/controller/BpmnEditorController.ts` — wire the new command in the viewer branch.
-- `apps/bpmn-webview/src/app/diff/DiffMode.ts` — emit the command from `navigate()`, handle the query in `onMessage`.
-- `apps/bpmn-webview/src/app/diff/DiffViewer.ts` — split `markSelected(id)` out of `focusElement`.
+Each pane receives only the ids that exist on its canvas: the before side sees `removed / changed / layoutChanged`, the after side sees `added / changed / layoutChanged`. The `counts` and `navigationOrder` fields are symmetric and shipped to both sides — they drive the dual-Legend and the cursor-sync stepper. This means `applyHighlights` does not need a per-pane filter pass.
 
 ## Key Files
 

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -4,3 +4,4 @@ export * from "./lib/asyncDebounce";
 export * from "./lib/utils";
 export * from "./lib/messages";
 export * from "./lib/modeler";
+export * from "./lib/bpmnFlowOrder";

--- a/libs/shared/src/lib/bpmnFlowOrder.ts
+++ b/libs/shared/src/lib/bpmnFlowOrder.ts
@@ -1,0 +1,396 @@
+/**
+ * Builds a navigation order for diff highlights based on BPMN sequence-flow
+ * direction.
+ *
+ * The diff stepper used to walk ids in the order `bpmn-js-differ` happened to
+ * report them — effectively undefined.  This module produces a deterministic
+ * "Start Event → End Event" ordering by traversing the parsed `bpmn-moddle`
+ * definitions:
+ *
+ *   1. Collect every FlowElementsContainer (Process, SubProcess) recursively
+ *      and index its FlowElements by id.
+ *   2. BFS from each StartEvent following outgoing SequenceFlows.  Sequence
+ *      flows themselves get an index immediately after their source so they
+ *      slot between the two shapes they connect.
+ *   3. Use BPMNDI bounds (visual `y` then `x`) as the tiebreaker for parallel
+ *      branches and as the key for orphan nodes that the BFS never reaches.
+ *
+ * Removed elements only exist on the *before* canvas, so the after-pane order
+ * has no slot for them.  {@link buildRemovedAnchors} walks the before graph
+ * for each removed id, picks a surviving neighbour (incoming source first,
+ * outgoing target as fallback), and assigns the removed id a fractional index
+ * adjacent to that anchor's position in the after order.  This places removed
+ * nodes near where they used to live in the flow rather than at the end.
+ *
+ * The ordering is a heuristic — multi-pool collaborations, complex parallel
+ * gateway fan-outs, and disconnected nodes all have known limitations
+ * documented inline.  It will not always match a human's mental walk of every
+ * diagram, but it is far more recognisable than the previous insertion-order
+ * cycle.
+ */
+
+/** Minimal subset of a parsed bpmn-moddle element used by this module. */
+interface ModdleElement {
+    $type: string;
+    id?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * Position assigned to one BPMN element in the canonical traversal.
+ *
+ * `flowIndex` is the BFS visit index (fractional values are used to wedge
+ * removed elements between two surviving siblings).  `y`/`x` come from BPMNDI
+ * bounds and are tiebreakers for elements that share an index — most
+ * commonly a parallel-gateway fork where two branches start at the same depth.
+ */
+export interface FlowPosition {
+    flowIndex: number;
+    y: number;
+    x: number;
+}
+
+/**
+ * Builds the `id → FlowPosition` map for one set of parsed definitions.
+ *
+ * The returned map covers every FlowElement reachable through `rootElements`
+ * (including nested SubProcesses), plus orphan nodes appended at the end in
+ * visual top-left → bottom-right order.
+ */
+export function buildFlowOrder(
+    root: ModdleElement,
+): Map<string, FlowPosition> {
+    const containers = collectContainers(root);
+    const bounds = collectBounds(root);
+
+    const flowElementsById = new Map<string, ModdleElement>();
+    const startEvents: ModdleElement[] = [];
+    for (const container of containers) {
+        const fes = readArray<ModdleElement>(container.flowElements);
+        for (const fe of fes) {
+            if (!fe.id) continue;
+            flowElementsById.set(fe.id, fe);
+            if (fe.$type === "bpmn:StartEvent") {
+                startEvents.push(fe);
+            }
+        }
+    }
+
+    // `bpmn-moddle` does not auto-populate `incoming`/`outgoing` on FlowNodes
+    // when references resolve via the `references` companion array — different
+    // call paths return different shapes.  Build an outgoing index from
+    // SequenceFlow.sourceRef/targetRef ourselves so the BFS works regardless.
+    const outgoingBySource = new Map<string, ModdleElement[]>();
+    for (const fe of flowElementsById.values()) {
+        if (fe.$type !== "bpmn:SequenceFlow") continue;
+        const sourceId = refId(fe.sourceRef);
+        if (!sourceId) continue;
+        const list = outgoingBySource.get(sourceId);
+        if (list) {
+            list.push(fe);
+        } else {
+            outgoingBySource.set(sourceId, [fe]);
+        }
+    }
+
+    const order = new Map<string, FlowPosition>();
+    let counter = 0;
+    const visited = new Set<string>();
+    const queue: ModdleElement[] = [];
+
+    const enqueue = (node: ModdleElement | undefined): void => {
+        if (!node?.id || visited.has(node.id)) return;
+        visited.add(node.id);
+        queue.push(node);
+    };
+
+    sortByPosition(startEvents, bounds);
+    for (const se of startEvents) enqueue(se);
+
+    while (queue.length > 0) {
+        const node = queue.shift()!;
+        const id = node.id!;
+        const b = bounds.get(id) ?? { x: 0, y: 0 };
+        order.set(id, { flowIndex: counter++, y: b.y, x: b.x });
+
+        const outgoing = outgoingBySource.get(id) ?? [];
+        // Visit parallel branches top-to-bottom, left-to-right.
+        const sorted = [...outgoing].sort((a, b) => {
+            const ta = refId(a.targetRef);
+            const tb = refId(b.targetRef);
+            const pa = (ta ? bounds.get(ta) : undefined) ?? { x: 0, y: 0 };
+            const pb = (tb ? bounds.get(tb) : undefined) ?? { x: 0, y: 0 };
+            return pa.y - pb.y || pa.x - pb.x;
+        });
+
+        for (const flow of sorted) {
+            if (flow.id && !order.has(flow.id)) {
+                const fb = bounds.get(flow.id) ?? { x: b.x, y: b.y };
+                order.set(flow.id, {
+                    flowIndex: counter++,
+                    y: fb.y,
+                    x: fb.x,
+                });
+            }
+            const targetId = refId(flow.targetRef);
+            if (targetId) enqueue(flowElementsById.get(targetId));
+        }
+    }
+
+    // Orphans: sub-graphs without a reachable start event (e.g. event
+    // sub-processes triggered by error/escalation, or genuinely disconnected
+    // nodes).  Append in visual reading order so they at least step
+    // predictably even though the flow position is unknown.
+    const orphans: ModdleElement[] = [];
+    for (const [id, fe] of flowElementsById) {
+        if (!order.has(id)) orphans.push(fe);
+    }
+    sortByPosition(orphans, bounds);
+    for (const fe of orphans) {
+        const b = bounds.get(fe.id!) ?? { x: 0, y: 0 };
+        order.set(fe.id!, { flowIndex: counter++, y: b.y, x: b.x });
+    }
+
+    return order;
+}
+
+/**
+ * For each removed id, returns the position it should occupy in the *after*
+ * order.  The anchor is found by walking the before graph for a neighbour
+ * that survived the diff:
+ *
+ *   - incoming source → place removed just after that node (`+0.5`)
+ *   - outgoing target → place removed just before that node (`-0.5`)
+ *   - flow's own source/target if the removed element is itself a sequence flow
+ *
+ * Removed ids without any surviving neighbour are omitted from the map; the
+ * caller's sort then drops them to the end via the fallback index.
+ */
+export function buildRemovedAnchors(
+    removedIds: readonly string[],
+    beforeRoot: ModdleElement,
+    afterOrder: ReadonlyMap<string, FlowPosition>,
+): Map<string, FlowPosition> {
+    const anchors = new Map<string, FlowPosition>();
+    if (removedIds.length === 0) return anchors;
+
+    const containers = collectContainers(beforeRoot);
+    const flowElementsById = new Map<string, ModdleElement>();
+    for (const c of containers) {
+        for (const fe of readArray<ModdleElement>(c.flowElements)) {
+            if (fe.id) flowElementsById.set(fe.id, fe);
+        }
+    }
+
+    const incomingByTarget = new Map<string, ModdleElement[]>();
+    const outgoingBySource = new Map<string, ModdleElement[]>();
+    for (const fe of flowElementsById.values()) {
+        if (fe.$type !== "bpmn:SequenceFlow") continue;
+        const sourceId = refId(fe.sourceRef);
+        const targetId = refId(fe.targetRef);
+        if (sourceId) {
+            const list = outgoingBySource.get(sourceId);
+            if (list) list.push(fe);
+            else outgoingBySource.set(sourceId, [fe]);
+        }
+        if (targetId) {
+            const list = incomingByTarget.get(targetId);
+            if (list) list.push(fe);
+            else incomingByTarget.set(targetId, [fe]);
+        }
+    }
+
+    const anchorAfter = (
+        baseId: string,
+        offset: number,
+    ): FlowPosition | undefined => {
+        const p = afterOrder.get(baseId);
+        return p && { flowIndex: p.flowIndex + offset, y: p.y, x: p.x };
+    };
+
+    for (const removedId of removedIds) {
+        const node = flowElementsById.get(removedId);
+        if (!node) continue;
+
+        let anchor: FlowPosition | undefined;
+
+        // 1. Removed shape: prefer the surviving predecessor.
+        for (const flow of incomingByTarget.get(removedId) ?? []) {
+            const sourceId = refId(flow.sourceRef);
+            if (sourceId && afterOrder.has(sourceId)) {
+                anchor = anchorAfter(sourceId, 0.5);
+                break;
+            }
+            if (flow.id && afterOrder.has(flow.id)) {
+                anchor = anchorAfter(flow.id, 0.25);
+                break;
+            }
+        }
+        // 2. Otherwise the surviving successor.
+        if (!anchor) {
+            for (const flow of outgoingBySource.get(removedId) ?? []) {
+                const targetId = refId(flow.targetRef);
+                if (targetId && afterOrder.has(targetId)) {
+                    anchor = anchorAfter(targetId, -0.5);
+                    break;
+                }
+                if (flow.id && afterOrder.has(flow.id)) {
+                    anchor = anchorAfter(flow.id, -0.25);
+                    break;
+                }
+            }
+        }
+        // 3. Removed sequence flow: anchor on its own endpoints.
+        if (!anchor && node.$type === "bpmn:SequenceFlow") {
+            const sourceId = refId(node.sourceRef);
+            const targetId = refId(node.targetRef);
+            if (sourceId && afterOrder.has(sourceId)) {
+                anchor = anchorAfter(sourceId, 0.5);
+            } else if (targetId && afterOrder.has(targetId)) {
+                anchor = anchorAfter(targetId, -0.5);
+            }
+        }
+
+        if (anchor) anchors.set(removedId, anchor);
+    }
+
+    return anchors;
+}
+
+/**
+ * Returns `ids` sorted by their position in `primary`, falling back to
+ * `secondary` (typically the removed-anchor map) for ids missing from
+ * `primary`.  Ids not in either map are appended at the end in their input
+ * order.
+ */
+export function sortIdsByOrder(
+    ids: readonly string[],
+    primary: ReadonlyMap<string, FlowPosition>,
+    secondary?: ReadonlyMap<string, FlowPosition>,
+): string[] {
+    const positionOf = (id: string): FlowPosition | undefined =>
+        primary.get(id) ?? secondary?.get(id);
+
+    return [...ids].sort((a, b) => {
+        const pa = positionOf(a);
+        const pb = positionOf(b);
+        if (pa && pb) {
+            return (
+                pa.flowIndex - pb.flowIndex ||
+                pa.y - pb.y ||
+                pa.x - pb.x
+            );
+        }
+        // Unknown ids sink to the end while keeping their relative order.
+        if (pa) return -1;
+        if (pb) return 1;
+        return 0;
+    });
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+function collectContainers(root: ModdleElement): ModdleElement[] {
+    const containers: ModdleElement[] = [];
+    const visit = (el: ModdleElement): void => {
+        const fes = readArray<ModdleElement>(el.flowElements);
+        if (fes.length > 0 || isContainer(el)) {
+            containers.push(el);
+            for (const child of fes) visit(child);
+        }
+        // Collaboration → walk participants → processRef.
+        for (const p of readArray<ModdleElement>(el.participants)) {
+            const proc = p.processRef as ModdleElement | undefined;
+            if (proc) visit(proc);
+        }
+    };
+
+    for (const re of readArray<ModdleElement>(root.rootElements)) {
+        visit(re);
+    }
+    return containers;
+}
+
+function isContainer(el: ModdleElement): boolean {
+    return (
+        el.$type === "bpmn:Process" ||
+        el.$type === "bpmn:SubProcess" ||
+        el.$type === "bpmn:AdHocSubProcess" ||
+        el.$type === "bpmn:Transaction"
+    );
+}
+
+/**
+ * Reads BPMNDI bounds keyed by `bpmnElement.id`, using waypoint midpoints as
+ * a fallback for edges (which carry `waypoint` instead of `bounds`).
+ */
+function collectBounds(
+    root: ModdleElement,
+): Map<string, { x: number; y: number }> {
+    const result = new Map<string, { x: number; y: number }>();
+    for (const diagram of readArray<ModdleElement>(root.diagrams)) {
+        const plane = diagram.plane as ModdleElement | undefined;
+        if (!plane) continue;
+        for (const pe of readArray<ModdleElement>(plane.planeElement)) {
+            const target = pe.bpmnElement as ModdleElement | undefined;
+            const id = target?.id;
+            if (!id) continue;
+
+            const b = pe.bounds as
+                | { x?: number; y?: number }
+                | undefined;
+            if (
+                b &&
+                typeof b.x === "number" &&
+                typeof b.y === "number"
+            ) {
+                result.set(id, { x: b.x, y: b.y });
+                continue;
+            }
+
+            const wps = readArray<{ x: number; y: number }>(pe.waypoint);
+            if (wps.length > 0) {
+                let sumX = 0;
+                let sumY = 0;
+                for (const w of wps) {
+                    sumX += w.x;
+                    sumY += w.y;
+                }
+                result.set(id, {
+                    x: sumX / wps.length,
+                    y: sumY / wps.length,
+                });
+            }
+        }
+    }
+    return result;
+}
+
+/**
+ * Returns the id of a moddle reference, accepting either a resolved object
+ * reference (`{$type, id, ...}`) or a raw string id — `bpmn-moddle` returns
+ * different shapes depending on how the file was parsed.
+ */
+function refId(ref: unknown): string | undefined {
+    if (typeof ref === "string") return ref;
+    if (ref && typeof ref === "object" && "id" in ref) {
+        const id = (ref as { id?: unknown }).id;
+        if (typeof id === "string") return id;
+    }
+    return undefined;
+}
+
+function readArray<T>(value: unknown): T[] {
+    return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function sortByPosition(
+    nodes: ModdleElement[],
+    bounds: ReadonlyMap<string, { x: number; y: number }>,
+): void {
+    nodes.sort((a, b) => {
+        const ba = (a.id ? bounds.get(a.id) : undefined) ?? { x: 0, y: 0 };
+        const bb = (b.id ? bounds.get(b.id) : undefined) ?? { x: 0, y: 0 };
+        return ba.y - bb.y || ba.x - bb.x;
+    });
+}

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -452,6 +452,14 @@ export class ApplyDiffHighlightsQuery extends Query {
 
     public readonly counts: DiffCounts;
 
+    /**
+     * Pre-merged, sequence-flow-ordered list of all ids the stepper should
+     * cycle through (start event → end event order, with removed elements
+     * anchored next to surviving neighbours).  Both panes receive the same
+     * array so Next/Prev keeps the two cursors in lockstep.
+     */
+    public readonly navigationOrder: string[];
+
     constructor(
         side: DiffSide,
         added: string[],
@@ -459,6 +467,7 @@ export class ApplyDiffHighlightsQuery extends Query {
         changed: string[],
         layoutChanged: string[],
         counts: DiffCounts,
+        navigationOrder: string[],
     ) {
         super("ApplyDiffHighlightsQuery");
         this.side = side;
@@ -467,6 +476,7 @@ export class ApplyDiffHighlightsQuery extends Query {
         this.changed = changed;
         this.layoutChanged = layoutChanged;
         this.counts = counts;
+        this.navigationOrder = navigationOrder;
     }
 }
 
@@ -494,6 +504,36 @@ export class ViewportChangedCommand extends Command {
     constructor(viewport: Viewport) {
         super("ViewportChangedCommand");
         this.viewport = viewport;
+    }
+}
+
+/**
+ * Sent from a viewer pane after the user advances the diff stepper.  The host
+ * forwards the new cursor index to the partner pane via {@link SyncCursorQuery}
+ * so both panes' steppers stay in lockstep.  The index refers to a position in
+ * the shared `navigationOrder` array carried on {@link ApplyDiffHighlightsQuery}.
+ */
+export class CursorChangedCommand extends Command {
+    public readonly index: number;
+
+    constructor(index: number) {
+        super("CursorChangedCommand");
+        this.index = index;
+    }
+}
+
+/**
+ * Sent from the host to a pane to apply the partner pane's stepper cursor.
+ * The receiving pane focuses (or anchors) the element at the given index in
+ * its local `navigationOrder` and must NOT re-emit `CursorChangedCommand`,
+ * otherwise the two panes would ping-pong indefinitely.
+ */
+export class SyncCursorQuery extends Query {
+    public readonly index: number;
+
+    constructor(index: number) {
+        super("SyncCursorQuery");
+        this.index = index;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -90,5 +90,5 @@
     "resolutions": {
         "preact": "10.28.4"
     },
-    "packageManager": "yarn@4.13.0"
+    "packageManager": "yarn@4.14.1"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@ampproject/remapping@npm:^2.2.0":


### PR DESCRIPTION
**Issue**

The diff stepper previously cycled through changed elements in the arbitrary
order reported by bpmn-js-differ, making navigation unpredictable.

**Description**

This change introduces sequence-flow-based ordering so users step from start event to end
event.

Both panes now render the legend and drive a shared cursor via a new cursor-sync
channel (CursorChangedCommand / SyncCursorQuery), keeping Next/Prev navigation
in lockstep. Removed elements are anchored next to surviving neighbours in the
after-pane order so they appear near where they lived in the flow rather than
at the end. When the cursor lands on an id that exists only on the partner pane,
the local pane anchors its viewport on the nearest neighbour and clears its
selection marker to avoid misleading the user.

A new bpmnFlowOrder module exports buildFlowOrder, buildRemovedAnchors, and
sortIdsByOrder to compute deterministic traversal positions from parsed
bpmn-moddle definitions, handling orphans, parallel branches, and
sequence-flow endpoint fallbacks.

**Checklist**

- Code is easy to understand
- No obvious errors or bugs
- CI/CD Pipelines did run successfully
- Tests were implemented
- Documentation was created
