### PR TITLE
feat: add compare-files UI for BPMN diffs

### DIFF
--- a/apps/modeler-plugin/package.json
+++ b/apps/modeler-plugin/package.json
@@ -135,6 +135,18 @@
             {
                 "command": "bpmn-modeler.changeLanguage",
                 "title": "BPMN Modeler: Change Modeler Language"
+            },
+            {
+                "command": "bpmn-modeler.selectForCompare",
+                "title": "BPMN Modeler: Select for Compare"
+            },
+            {
+                "command": "bpmn-modeler.compareWithSelected",
+                "title": "BPMN Modeler: Compare with Selected"
+            },
+            {
+                "command": "bpmn-modeler.compareSelected",
+                "title": "BPMN Modeler: Compare Selected"
             }
         ],
         "keybindings": [
@@ -177,6 +189,35 @@
                 {
                     "command": "bpmn-modeler.changeLanguage",
                     "when": "bpmn-modeler.openCustomEditors > 0"
+                },
+                {
+                    "command": "bpmn-modeler.selectForCompare",
+                    "when": "false"
+                },
+                {
+                    "command": "bpmn-modeler.compareWithSelected",
+                    "when": "false"
+                },
+                {
+                    "command": "bpmn-modeler.compareSelected",
+                    "when": "false"
+                }
+            ],
+            "explorer/context": [
+                {
+                    "command": "bpmn-modeler.selectForCompare",
+                    "group": "3_compare",
+                    "when": "resourceExtname == .bpmn && !listDoubleSelection"
+                },
+                {
+                    "command": "bpmn-modeler.compareWithSelected",
+                    "group": "3_compare",
+                    "when": "resourceExtname == .bpmn && bpmn-modeler.compareSelectionActive && !listDoubleSelection"
+                },
+                {
+                    "command": "bpmn-modeler.compareSelected",
+                    "group": "3_compare",
+                    "when": "resourceExtname == .bpmn && listDoubleSelection"
                 }
             ],
             "editor/title": [

--- a/apps/modeler-plugin/src/controller/BpmnCompareController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnCompareController.ts
@@ -1,0 +1,209 @@
+import {
+    commands,
+    ExtensionContext,
+    Uri,
+    window,
+} from "vscode";
+
+import { CompareSelectionStore } from "../infrastructure/CompareSelectionStore";
+import { VsCodeUI } from "../infrastructure/VsCodeUI";
+import { BpmnDiffService } from "../service/BpmnDiffService";
+
+/** VS Code command ID for the first step of a two-file BPMN compare. */
+const SELECT_FOR_COMPARE_CMD = "bpmn-modeler.selectForCompare";
+/** VS Code command ID for the second step — compares the given URI against the stored selection. */
+const COMPARE_WITH_SELECTED_CMD = "bpmn-modeler.compareWithSelected";
+/** VS Code command ID for the single-step compare driven by an Explorer multi-selection of exactly two files. */
+const COMPARE_SELECTED_CMD = "bpmn-modeler.compareSelected";
+
+/** How long the status-bar acknowledgement sits before fading. */
+const STATUS_MESSAGE_TIMEOUT_MS = 3_000;
+
+/**
+ * Bridges VS Code's Explorer context menu to the existing BPMN diff UI.
+ *
+ * Offers two entry points that mirror VS Code's built-in compare UX:
+ *
+ * - **Two-step** (single right-click at a time): "Select for Compare" stores
+ *   the URI in {@link CompareSelectionStore} and activates a context key so
+ *   "Compare with Selected" appears on the next right-click.  The second
+ *   step pre-registers a {@link DiffSession}, invokes `vscode.diff`, and
+ *   clears the selection (one-shot).
+ * - **Single-step** (multi-selection of exactly two files): "Compare Selected"
+ *   receives both URIs at once via the Explorer's `(uri, uris)` callback
+ *   signature, skips the store entirely, and dispatches the same diff-open
+ *   path.
+ *
+ * Both paths funnel through {@link openBpmnDiff} so session registration,
+ * tab-title construction, and error reporting stay in one place.
+ *
+ * Keeping these commands in their own controller (rather than folding them
+ * into {@link CommandController}) respects SRP — compare commands activate
+ * from explorer resources and have a different lifecycle than the other,
+ * modeler-active commands.
+ */
+export class BpmnCompareController {
+    /**
+     * @param selection Cross-command store holding the URI picked by the
+     *   first step of the workflow.
+     * @param diffService Owns diff-session registration; must be notified
+     *   *before* `vscode.diff` is invoked so pane resolution finds the
+     *   session synchronously.
+     * @param vsUI User-facing messages and logging.
+     */
+    constructor(
+        private readonly selection: CompareSelectionStore,
+        private readonly diffService: BpmnDiffService,
+        private readonly vsUI: VsCodeUI,
+    ) {}
+
+    /**
+     * Registers both compare commands with VS Code.  Disposables land on
+     * `context.subscriptions` for automatic release on extension deactivate.
+     */
+    register(context: ExtensionContext): void {
+        context.subscriptions.push(
+            commands.registerCommand(
+                SELECT_FOR_COMPARE_CMD,
+                this.selectForCompare,
+                this,
+            ),
+            commands.registerCommand(
+                COMPARE_WITH_SELECTED_CMD,
+                this.compareWithSelected,
+                this,
+            ),
+            commands.registerCommand(
+                COMPARE_SELECTED_CMD,
+                this.compareSelected,
+                this,
+            ),
+        );
+    }
+
+    /**
+     * Step 1: remember the user's selection as the left-hand side of the
+     * upcoming compare.  Non-modal status-bar feedback confirms the pick
+     * without interrupting the user's flow.
+     */
+    async selectForCompare(uri: Uri | undefined): Promise<void> {
+        if (!isBpmnUri(uri)) {
+            return;
+        }
+        await this.selection.set(uri);
+        window.setStatusBarMessage(
+            `BPMN Modeler: ${basenameOf(uri)} selected for compare`,
+            STATUS_MESSAGE_TIMEOUT_MS,
+        );
+    }
+
+    /**
+     * Step 2: pair `rightUri` with the previously-selected URI and open a
+     * BPMN diff tab.
+     *
+     * Pre-registers a `compare-files` {@link DiffSession} before invoking
+     * `vscode.diff`, so when VS Code resolves each pane through our
+     * `CustomTextEditorProvider` the diff service routes them through the
+     * diff viewer branch via session lookup — no URI-scheme heuristic.
+     *
+     * Clears the selection after a successful dispatch (one-shot UX,
+     * matching VS Code's built-in "Compare with Selected").
+     */
+    async compareWithSelected(rightUri: Uri | undefined): Promise<void> {
+        if (!isBpmnUri(rightUri)) {
+            return;
+        }
+
+        const leftUri = this.selection.get();
+        if (!leftUri) {
+            this.vsUI.showInfo(
+                "No file selected for compare. Right-click a .bpmn file and choose \"Select for Compare\" first.",
+            );
+            return;
+        }
+
+        if (leftUri.toString() === rightUri.toString()) {
+            this.vsUI.showInfo("Cannot compare a file with itself.");
+            return;
+        }
+
+        await this.openBpmnDiff(leftUri, rightUri);
+        await this.selection.clear();
+    }
+
+    /**
+     * Single-step compare driven by an Explorer multi-selection.
+     *
+     * VS Code invokes context-menu commands with `(clickedUri, allSelectedUris)`
+     * when the menu fires over a multi-selected list — we ignore the first
+     * argument and work from `uris` so selection order determines left/right.
+     * The menu is gated on `listDoubleSelection` so there are always exactly
+     * two entries; the runtime filter guards against the edge case where the
+     * other selected item is not `.bpmn` (the built-in `resourceExtname`
+     * `when` clause only evaluates the clicked resource).
+     *
+     * Unlike {@link compareWithSelected} this path never touches
+     * {@link CompareSelectionStore} — both URIs arrive in one call, so a
+     * previously-stored "Select for Compare" pick is intentionally preserved.
+     */
+    async compareSelected(
+        _uri: Uri | undefined,
+        uris: Uri[] | undefined,
+    ): Promise<void> {
+        const bpmnUris = (uris ?? []).filter(isBpmnUri);
+        if (bpmnUris.length !== 2) {
+            this.vsUI.showInfo(
+                "Select exactly two .bpmn files to compare.",
+            );
+            return;
+        }
+
+        const [leftUri, rightUri] = bpmnUris;
+        if (leftUri.toString() === rightUri.toString()) {
+            this.vsUI.showInfo("Cannot compare a file with itself.");
+            return;
+        }
+
+        await this.openBpmnDiff(leftUri, rightUri);
+    }
+
+    /**
+     * Shared diff-open path for every compare entry point.
+     *
+     * The session must be registered *before* `vscode.diff` runs so that when
+     * VS Code resolves each pane through our `CustomTextEditorProvider` the
+     * diff service finds the session synchronously via
+     * {@link BpmnDiffService.findSessionFor} (see
+     * `BpmnDiffService.shouldResolveAsDiff`).  Errors are surfaced to the
+     * user and logged — the caller handles any flow-specific state cleanup
+     * (e.g. clearing the selection store) around this call.
+     */
+    private async openBpmnDiff(leftUri: Uri, rightUri: Uri): Promise<void> {
+        this.diffService.registerCompareFilesSession(leftUri, rightUri);
+
+        const title = `${basenameOf(leftUri)} ↔ ${basenameOf(rightUri)}`;
+        try {
+            await commands.executeCommand(
+                "vscode.diff",
+                leftUri,
+                rightUri,
+                title,
+                { preview: false },
+            );
+        } catch (error) {
+            this.vsUI.logError(error as Error);
+            this.vsUI.showError(
+                `Failed to open compare view: ${(error as Error).message}`,
+            );
+        }
+    }
+}
+
+function isBpmnUri(uri: Uri | undefined): uri is Uri {
+    return uri !== undefined && uri.path.endsWith(".bpmn");
+}
+
+function basenameOf(uri: Uri): string {
+    const parts = uri.path.split("/");
+    return parts[parts.length - 1] ?? uri.path;
+}

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -83,22 +83,15 @@ export class BpmnEditorController implements CustomTextEditorProvider {
         _token: CancellationToken,
     ): Promise<void> {
         try {
-            // `git:`-scheme documents are always readonly (Git extension's
-            // FileSystemProvider owns their content).  `file:` documents that
-            // belong to an open diff view are also readonly here — editing
-            // them through the diff pane would race with the built-in diff
-            // editor's change detection.  For `file:` URIs we also guard
-            // against a *second* resolve for a URI that already has a diff
-            // viewer: when the user opens the SCM diff and then opens the
-            // same working-tree file in a normal editor group, VS Code fires
-            // `resolveCustomTextEditor` again and the label-based heuristic
-            // still matches — so we also require that no diff pane has been
-            // registered for this URI yet.
-            const isGitScheme = document.uri.scheme === "git";
-            const isNewDiffPane =
-                this.diffService.isPartOfDiff(document.uri) &&
-                !this.diffService.hasPaneForUri(document.uri);
-            if (isGitScheme || isNewDiffPane) {
+            // Diff branch: the service decides whether this URI should
+            // resolve as a diff pane.  It checks, in order: a pre-registered
+            // `compare-files` session (our own command), `git:` scheme
+            // (always readonly, always SCM), or the label-based SCM diff
+            // heuristic — while also guarding against a *second* resolve
+            // for a URI that already has a pane (e.g. user opens the
+            // working-tree file in a normal editor tab while the SCM diff
+            // is still open).
+            if (this.diffService.shouldResolveAsDiff(document.uri)) {
                 this.diffService.resolveDiffPane(webviewPanel, document);
                 return;
             }

--- a/apps/modeler-plugin/src/infrastructure/CompareSelectionStore.ts
+++ b/apps/modeler-plugin/src/infrastructure/CompareSelectionStore.ts
@@ -1,0 +1,48 @@
+import { commands, Uri } from "vscode";
+
+/** Context key that gates the "Compare with Selected" menu entry. */
+const CONTEXT_KEY = "bpmn-modeler.compareSelectionActive";
+
+/**
+ * Holds the URI the user picked via "Select for Compare" until they follow
+ * up with "Compare with Selected".
+ *
+ * In-memory only — selection is ephemeral by design:
+ *
+ * - Matches the VS Code built-in compare UX (re-selecting is the only way to
+ *   refresh the choice, and state never survives a window reload).
+ * - Avoids the stale-URI footgun of persisting a file path that may have
+ *   been moved, renamed, or deleted between sessions.
+ *
+ * The store also toggles a VS Code context key so the menu `when` clause can
+ * hide the second command until there is something to compare against.
+ */
+export class CompareSelectionStore {
+    private selected?: Uri;
+
+    /** Returns the currently selected URI, or `undefined` when nothing is selected. */
+    get(): Uri | undefined {
+        return this.selected;
+    }
+
+    /**
+     * Records `uri` as the left-hand side of the next compare.
+     *
+     * Also flips the VS Code context key so the "Compare with Selected"
+     * explorer-menu entry appears.  Silently overwrites any prior selection
+     * — re-selecting is a valid way to change your mind before following up.
+     */
+    async set(uri: Uri): Promise<void> {
+        this.selected = uri;
+        await commands.executeCommand("setContext", CONTEXT_KEY, true);
+    }
+
+    /**
+     * Drops any pending selection.  Called after a successful compare — the
+     * VS Code built-in compare UX is one-shot, and we match that.
+     */
+    async clear(): Promise<void> {
+        this.selected = undefined;
+        await commands.executeCommand("setContext", CONTEXT_KEY, false);
+    }
+}

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -2,6 +2,7 @@ import { env, ExtensionContext, Uri, window } from "vscode";
 
 import { setContext } from "./infrastructure/extensionContext";
 
+import { CompareSelectionStore } from "./infrastructure/CompareSelectionStore";
 import { EditorStore } from "./infrastructure/EditorStore";
 import { PropertiesPanelStateRepository } from "./infrastructure/PropertiesPanelStateRepository";
 import { VsCodeDocument } from "./infrastructure/VsCodeDocument";
@@ -13,6 +14,7 @@ import { ArtifactService } from "./service/ArtifactService";
 import { BpmnDiffService } from "./service/BpmnDiffService";
 import { BpmnModelerService } from "./service/BpmnModelerService";
 import { DmnModelerService } from "./service/DmnModelerService";
+import { BpmnCompareController } from "./controller/BpmnCompareController";
 import { CommandController } from "./controller/CommandController";
 import { BpmnEditorController } from "./controller/BpmnEditorController";
 import { DmnEditorController } from "./controller/DmnEditorController";
@@ -55,6 +57,7 @@ export function activate(context: ExtensionContext): void {
     const statusBar = new VsCodeStatusBar();
     const vsUI = new VsCodeUI();
     const deploymentState = new VsCodeDeploymentState();
+    const compareSelection = new CompareSelectionStore();
     const secretStore = new VsCodeSecretStore();
     const httpClient = new FetchHttpClient();
     const authResolver = new AuthHeaderResolver(httpClient);
@@ -107,6 +110,7 @@ export function activate(context: ExtensionContext): void {
         statusBar,
     ).register(context);
     new DmnEditorController(editorStore, dmnService, vsUI).register(context);
+    new BpmnCompareController(compareSelection, diffService, vsUI).register(context);
     commandController.register(context);
     new DeploymentController(editorStore, vsDocument, deploymentSvc, startInstanceSvc, vsUI).register(context);
 }

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -17,7 +17,6 @@ import {
     Command,
     CursorChangedCommand,
     DiffCounts,
-    DiffSide,
     LanguageQuery,
     sortIdsByOrder,
     SyncCursorQuery,
@@ -31,48 +30,77 @@ import { bootstrapWebview } from "../infrastructure/bootstrapWebview";
 import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
 import { VsCodeUI } from "../infrastructure/VsCodeUI";
 import { detectExecutionPlatform } from "./bpmnUtils";
+import { DiffPaneEntry, DiffSession } from "./DiffSession";
 
 const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
 
 /**
- * Mutable state for one side of an open diff.  Two entries — one per pane —
- * form a pair via their mutual `partner` back-pointers; the pair fires its
- * highlight computation as soon as both sides have reported ready.
+ * Milliseconds a pre-registered `compare-files` session stays alive with no
+ * panes attached before it is swept.  Covers the "user triggered the command
+ * but the diff tab never opened" edge case.  Longer than any realistic
+ * `vscode.diff` → `resolveCustomTextEditor` latency; short enough that
+ * registering the same pair again after a cancel works without collisions.
  */
-interface DiffPaneEntry {
-    readonly panel: WebviewPanel;
-    readonly document: TextDocument;
-    readonly side: DiffSide;
-    ready: boolean;
-    partner?: DiffPaneEntry;
+const COMPARE_FILES_TTL_MS = 30_000;
+
+/**
+ * A `"scm"` pane that resolved first and is waiting for its partner.
+ *
+ * SCM-initiated diffs don't let us pre-register a session — we learn about
+ * each URI only when its pane resolves.  The first pane goes here; when the
+ * second pane arrives with a matching `document.uri.path`, we promote both
+ * into a full {@link DiffSession} and register it.
+ */
+interface PendingScmPane {
+    readonly entry: DiffPaneEntry;
 }
 
 /**
  * Owns every BPMN diff viewer pane from resolution through disposal.
  *
- * Keying on {@link WebviewPanel} rather than a string id solves the identity
- * problem that the URI-keyed `EditorStore` cannot: VS Code happily creates
- * two panels for the same `file:` URI (the working-tree pane of a diff and
- * a normal editor tab) and both need independent message routing, disposal
- * handling, and document access.  Diff panes never touch `EditorStore`, so
- * there is no collision to work around.
+ * The domain moved from "pair of panes with mutual partner pointers" to
+ * {@link DiffSession}: an explicit object with fixed `before` / `after` URIs
+ * that any diff origin (SCM, `compare-files`) can register into.  The service
+ * is now a registry of sessions plus a per-URI lookup index; pane resolution
+ * is a session lookup instead of a scheme-based heuristic.
  *
  * Responsibilities:
- *   1. Detect whether a URI belongs to an open `.bpmn` diff tab — purely by
- *      tab label, because VS Code exposes `tab.input === undefined` for
- *      custom-editor-backed diff tabs and no typed signal is available.
- *   2. Bootstrap the webview for a newly-resolved diff pane, wire up the
- *      narrow viewer-mode message protocol (`GetBpmnFileCommand`,
- *      `DiffReadyCommand`, `ViewportChangedCommand`, `CursorChangedCommand`),
- *      and link the pane to its partner by shared file path.
- *   3. Once both panes of a pair are ready, run `bpmn-js-differ` on the
+ *   1. Register `compare-files` sessions on demand — pre-known URIs, side
+ *      fixed at construction, TTL-swept if the tab never opens.
+ *   2. Lazily create `scm` sessions when VS Code resolves a diff tab's second
+ *      pane — URIs discovered at resolve time, paired by path equality.
+ *   3. Bootstrap the webview for each resolved pane, wire up the viewer-mode
+ *      message protocol (`GetBpmnFileCommand`, `DiffReadyCommand`,
+ *      `ViewportChangedCommand`, `CursorChangedCommand`), and attach the pane
+ *      to its session.
+ *   4. Once both panes of a session report ready, run `bpmn-js-differ` on the
  *      parsed XMLs and broadcast per-side {@link ApplyDiffHighlightsQuery}.
- *   4. Forward viewport-change and cursor-change messages from one pane to
+ *   5. Forward viewport-change and cursor-change messages from one pane to
  *      its partner so panning, zooming, and stepper navigation stay in sync.
  */
 export class BpmnDiffService {
-    /** Every live diff pane, keyed by its {@link WebviewPanel} reference. */
-    private readonly panes = new Map<WebviewPanel, DiffPaneEntry>();
+    /** Every live session, keyed by `${beforeUri}|${afterUri}`. */
+    private readonly sessions = new Map<string, DiffSession>();
+
+    /**
+     * Lookup index: URI string → session it belongs to.  Populated as soon as
+     * a session is created, whether pre-registered (`compare-files`) or
+     * lazily formed (`scm`).
+     */
+    private readonly sessionByUri = new Map<string, DiffSession>();
+
+    /**
+     * SCM panes awaiting their partner.  Keyed by `document.uri.path` so
+     * `git:foo.bpmn` and `file:foo.bpmn` meet here before being promoted into
+     * a session.
+     */
+    private readonly pendingScm = new Map<string, PendingScmPane>();
+
+    /**
+     * TTL sweepers for pre-registered `compare-files` sessions.  Cleared
+     * once the first pane attaches.
+     */
+    private readonly ttlTimers = new Map<DiffSession, ReturnType<typeof setTimeout>>();
 
     /** Dispose handle for the language-setting change subscription. */
     private languageSubscription?: Disposable;
@@ -92,10 +120,78 @@ export class BpmnDiffService {
         );
     }
 
-    /** Releases the language-setting subscription.  Called when the extension deactivates. */
+    /** Releases the language-setting subscription and any armed TTL timers. */
     dispose(): void {
         this.languageSubscription?.dispose();
         this.languageSubscription = undefined;
+        for (const timer of this.ttlTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.ttlTimers.clear();
+    }
+
+    /**
+     * Pre-registers a `compare-files` session before invoking `vscode.diff`.
+     *
+     * Side assignment is fixed: `leftUri` is `before`, `rightUri` is `after`
+     * — matches the visual order VS Code renders `vscode.diff(a, b)` in.
+     *
+     * A TTL sweeper drops the session if no pane attaches within
+     * {@link COMPARE_FILES_TTL_MS}.  The timer is cleared as soon as the
+     * first pane arrives.
+     *
+     * @returns The created session (useful in tests; production callers can
+     *   ignore the return value).
+     */
+    registerCompareFilesSession(leftUri: Uri, rightUri: Uri): DiffSession {
+        const session = new DiffSession("compare-files", leftUri, rightUri);
+        const id = this.sessionIdOf(session);
+        this.sessions.set(id, session);
+        this.sessionByUri.set(leftUri.toString(), session);
+        this.sessionByUri.set(rightUri.toString(), session);
+        this.ttlTimers.set(
+            session,
+            setTimeout(() => this.sweepOrphan(session), COMPARE_FILES_TTL_MS),
+        );
+        return session;
+    }
+
+    /**
+     * Returns the session this URI belongs to, or `undefined` when none
+     * exists yet.  Covers both pre-registered `compare-files` sessions and
+     * `scm` sessions that have already been promoted from a pending pane.
+     */
+    findSessionFor(uri: Uri): DiffSession | undefined {
+        return this.sessionByUri.get(uri.toString());
+    }
+
+    /**
+     * Returns `true` when this URI should resolve as a (new) diff pane.
+     *
+     * Decision tree:
+     *   1. A pane (full session or pending SCM entry) already exists for
+     *      this URI → false.  The caller is a *second* resolve, e.g. the
+     *      user opened the working-tree file in a normal editor tab after
+     *      the SCM diff was already open — that second tab is an editable
+     *      modeler, not another diff pane.
+     *   2. A pre-registered `compare-files` session exists → true.
+     *   3. The URI is a `git:` scheme → true.  Git-provided documents are
+     *      always readonly and always belong to a diff.
+     *   4. The URI sits in a diff tab per the label heuristic → true.  This
+     *      is the only signal for SCM diffs when both URIs share the `file:`
+     *      scheme (uncommon but possible for some diff-to-working-tree flows).
+     */
+    shouldResolveAsDiff(uri: Uri): boolean {
+        if (this.hasPaneForUri(uri)) {
+            return false;
+        }
+        if (this.findSessionFor(uri)) {
+            return true;
+        }
+        if (uri.scheme === "git") {
+            return true;
+        }
+        return this.isPartOfDiff(uri);
     }
 
     /**
@@ -106,7 +202,9 @@ export class BpmnDiffService {
      * `input === undefined` — there is no `TabInputTextDiff` / `TabInputCustom`
      * variant to branch on.  The only structural signal left is the label,
      * which every diff annotates with a parenthetical (e.g.
-     * `"my-bpmn.bpmn (Working Tree)"`, `"… (HEAD)"`, `"… (HEAD~1 ↔ HEAD)"`).
+     * `"my-bpmn.bpmn (Working Tree)"`, `"… (HEAD)"`, `"… (HEAD~1 ↔ HEAD)"`)
+     * or the `↔` separator used by `vscode.diff(a, b)` when the two basenames
+     * differ.
      */
     isPartOfDiff(uri: Uri): boolean {
         const basename = basenameOfUri(uri);
@@ -115,9 +213,12 @@ export class BpmnDiffService {
         }
         for (const group of window.tabGroups.all) {
             for (const tab of group.tabs) {
+                if (tab.input !== undefined) {
+                    continue;
+                }
                 if (
-                    tab.input === undefined &&
-                    tab.label.startsWith(`${basename} (`)
+                    tab.label.startsWith(`${basename} (`) ||
+                    tab.label.includes(` ↔ `)
                 ) {
                     return true;
                 }
@@ -127,15 +228,17 @@ export class BpmnDiffService {
     }
 
     /**
-     * Returns `true` when a diff pane has already been resolved for the given
-     * URI.  Used by the editor controller to distinguish "this URI is part of
-     * a diff and has not yet resolved a viewer pane" from "this URI already
-     * has a diff viewer and the current resolve is a second, editable tab".
+     * Returns `true` when any pane — attached to a session or still pending
+     * SCM pairing — currently renders `uri`.
      */
     hasPaneForUri(uri: Uri): boolean {
         const needle = uri.toString();
-        for (const entry of this.panes.values()) {
-            if (entry.document.uri.toString() === needle) {
+        const session = this.sessionByUri.get(needle);
+        if (session?.hasPaneFor(uri)) {
+            return true;
+        }
+        for (const pending of this.pendingScm.values()) {
+            if (pending.entry.document.uri.toString() === needle) {
                 return true;
             }
         }
@@ -143,13 +246,17 @@ export class BpmnDiffService {
     }
 
     /**
-     * Bootstraps a freshly-resolved diff pane: installs the webview HTML,
-     * registers the viewer-mode message and dispose listeners, and pairs the
-     * pane with its partner if one already resolved for the same file path.
+     * Bootstraps a freshly-resolved diff pane.
      *
-     * The controller hands the `WebviewPanel` and `TextDocument` directly —
-     * nothing about the diff pane flows through `EditorStore`, which keeps
-     * the two "same URI" panels (viewer + editable modeler) from colliding.
+     * Resolution paths:
+     *   - Pre-registered `compare-files` session: looked up via
+     *     {@link sessionByUri}, pane attaches immediately, TTL cancels.
+     *   - First `scm` pane: stashed in {@link pendingScm}, waits for partner.
+     *   - Second `scm` pane: paired with the pending entry, session created.
+     *
+     * Nothing about a diff pane flows through `EditorStore`, which keeps the
+     * two "same URI" panels (viewer + editable modeler that a user may open
+     * alongside the diff) from colliding.
      */
     resolveDiffPane(panel: WebviewPanel, document: TextDocument): void {
         // Register listeners *before* we hand HTML to the webview: VS Code
@@ -159,16 +266,21 @@ export class BpmnDiffService {
         const entry: DiffPaneEntry = {
             panel,
             document,
-            side: this.sideFor(document.uri),
             ready: false,
         };
-        this.panes.set(panel, entry);
-        this.linkPartner(entry);
 
         panel.webview.onDidReceiveMessage((message: Command) =>
             this.onMessage(entry, message),
         );
         panel.onDidDispose(() => this.disposePane(entry));
+
+        const session = this.findSessionFor(document.uri);
+        if (session) {
+            session.attachPane(entry);
+            this.cancelTtl(session);
+        } else {
+            this.attachOrPendScmPane(entry);
+        }
 
         bootstrapWebview(BPMN_VIEW_TYPE, panel);
     }
@@ -176,56 +288,84 @@ export class BpmnDiffService {
     // ─── Private ─────────────────────────────────────────────────────────────
 
     /**
-     * Assigns a diff side to a freshly-resolved URI.
+     * Either pairs `entry` with a pending SCM pane that shares its path
+     * (promoting both into a full {@link DiffSession}) or stashes `entry`
+     * as the pending pane for later pairing.
      *
-     * `file:` URIs always represent the working tree, i.e. the "after" side.
-     * `git:` URIs are the before side in the common working-tree diff
-     * (`git: ↔ file:`).  For ref-vs-ref diffs both URIs are `git:`: the one
-     * that resolves first gets `"before"` and the second gets `"after"`.
-     * Which ref is "really" before in that case is arbitrary — VS Code's
-     * diff command decides the visual order and we follow it.
+     * Side assignment for SCM:
+     *   - If one URI is `file:` it is the working tree → `after`.
+     *   - Otherwise (ref-vs-ref, both `git:`) the first-registered pane is
+     *     `before`, second is `after` — arbitrary but matches the visual
+     *     order VS Code's SCM diff chose.
      */
-    private sideFor(uri: Uri): DiffSide {
-        if (uri.scheme !== "git") {
-            return "after";
+    private attachOrPendScmPane(entry: DiffPaneEntry): void {
+        const path = entry.document.uri.path;
+        const pending = this.pendingScm.get(path);
+
+        if (!pending) {
+            this.pendingScm.set(path, { entry });
+            return;
         }
-        for (const existing of this.panes.values()) {
-            if (
-                existing.document.uri.path === uri.path &&
-                existing.side === "before"
-            ) {
-                return "after";
-            }
-        }
-        return "before";
+
+        this.pendingScm.delete(path);
+        const { before, after } = resolveScmSides(pending.entry, entry);
+        const session = new DiffSession(
+            "scm",
+            before.document.uri,
+            after.document.uri,
+        );
+        session.attachPane(before);
+        session.attachPane(after);
+
+        const id = this.sessionIdOf(session);
+        this.sessions.set(id, session);
+        this.sessionByUri.set(before.document.uri.toString(), session);
+        this.sessionByUri.set(after.document.uri.toString(), session);
     }
 
-    /**
-     * Links `entry` with any existing unpartnered pane that shares its file
-     * path and sits on the opposite diff side.
-     */
-    private linkPartner(entry: DiffPaneEntry): void {
-        for (const candidate of this.panes.values()) {
-            if (candidate === entry) {
-                continue;
-            }
-            if (
-                candidate.document.uri.path === entry.document.uri.path &&
-                candidate.side !== entry.side &&
-                candidate.partner === undefined
-            ) {
-                entry.partner = candidate;
-                candidate.partner = entry;
-                return;
-            }
+    private sessionIdOf(session: DiffSession): string {
+        return `${session.beforeUri.toString()}|${session.afterUri.toString()}`;
+    }
+
+    private cancelTtl(session: DiffSession): void {
+        const timer = this.ttlTimers.get(session);
+        if (timer) {
+            clearTimeout(timer);
+            this.ttlTimers.delete(session);
         }
+    }
+
+    private sweepOrphan(session: DiffSession): void {
+        this.ttlTimers.delete(session);
+        if (!session.isEmpty()) {
+            return;
+        }
+        this.sessions.delete(this.sessionIdOf(session));
+        this.sessionByUri.delete(session.beforeUri.toString());
+        this.sessionByUri.delete(session.afterUri.toString());
     }
 
     private disposePane(entry: DiffPaneEntry): void {
-        if (entry.partner) {
-            entry.partner.partner = undefined;
+        // Drop from pending (no session ever formed)
+        for (const [key, pending] of this.pendingScm) {
+            if (pending.entry === entry) {
+                this.pendingScm.delete(key);
+                return;
+            }
         }
-        this.panes.delete(entry.panel);
+
+        // Drop from session; retire the session if both panes are gone.
+        const session = this.sessionByUri.get(entry.document.uri.toString());
+        if (!session) {
+            return;
+        }
+        session.detachPane(entry);
+        if (session.isEmpty()) {
+            this.sessions.delete(this.sessionIdOf(session));
+            this.sessionByUri.delete(session.beforeUri.toString());
+            this.sessionByUri.delete(session.afterUri.toString());
+            this.cancelTtl(session);
+        }
     }
 
     private async onMessage(
@@ -280,10 +420,14 @@ export class BpmnDiffService {
     private async markReady(entry: DiffPaneEntry): Promise<void> {
         entry.ready = true;
         await this.sendLanguage(entry);
-        const partner = entry.partner;
-        if (partner?.ready) {
-            const [before, after] =
-                entry.side === "before" ? [entry, partner] : [partner, entry];
+
+        const session = this.sessionByUri.get(entry.document.uri.toString());
+        if (!session || !session.isArmed()) {
+            return;
+        }
+        const before = session.before();
+        const after = session.after();
+        if (before && after) {
             await this.computeAndBroadcast(before, after);
         }
     }
@@ -315,9 +459,11 @@ export class BpmnDiffService {
         if (!event.affectsConfiguration("miragon.bpmnModeler.language")) {
             return;
         }
-        for (const entry of this.panes.values()) {
-            if (entry.ready) {
-                void this.sendLanguage(entry);
+        for (const session of this.sessions.values()) {
+            for (const entry of session.attachedPanes()) {
+                if (entry.ready) {
+                    void this.sendLanguage(entry);
+                }
             }
         }
     }
@@ -330,7 +476,7 @@ export class BpmnDiffService {
         entry: DiffPaneEntry,
         viewport: ViewportChangedCommand["viewport"],
     ): Promise<void> {
-        const partner = entry.partner;
+        const partner = this.partnerOf(entry);
         if (!partner) {
             return;
         }
@@ -354,7 +500,7 @@ export class BpmnDiffService {
         entry: DiffPaneEntry,
         index: number,
     ): Promise<void> {
-        const partner = entry.partner;
+        const partner = this.partnerOf(entry);
         if (!partner) {
             return;
         }
@@ -365,6 +511,11 @@ export class BpmnDiffService {
                 `syncCursor dropped: ${(error as Error).message}`,
             );
         }
+    }
+
+    private partnerOf(entry: DiffPaneEntry): DiffPaneEntry | undefined {
+        const session = this.sessionByUri.get(entry.document.uri.toString());
+        return session?.partnerOf(entry);
     }
 
     /**
@@ -504,4 +655,24 @@ export class BpmnDiffService {
 function basenameOfUri(uri: Uri): string {
     const parts = uri.path.split("/");
     return parts[parts.length - 1] ?? "";
+}
+
+/**
+ * Resolves SCM-diff side assignment for two panes that share a path.
+ *
+ * Invariant: `file:` URIs represent the working tree and must be `after`.
+ * For ref-vs-ref diffs (both `git:`) side follows resolution order, which
+ * mirrors VS Code's own visual ordering choice.
+ */
+function resolveScmSides(
+    first: DiffPaneEntry,
+    second: DiffPaneEntry,
+): { before: DiffPaneEntry; after: DiffPaneEntry } {
+    if (second.document.uri.scheme === "file") {
+        return { before: first, after: second };
+    }
+    if (first.document.uri.scheme === "file") {
+        return { before: second, after: first };
+    }
+    return { before: first, after: second };
 }

--- a/apps/modeler-plugin/src/service/DiffSession.ts
+++ b/apps/modeler-plugin/src/service/DiffSession.ts
@@ -1,0 +1,173 @@
+import { TextDocument, Uri, WebviewPanel } from "vscode";
+
+import { DiffSide } from "@bpmn-modeler/shared";
+
+/**
+ * Where a {@link DiffSession} came from.
+ *
+ * - `"scm"`: VS Code opened the diff (Source Control panel, `git diff`, PR
+ *   review). Session is created lazily when the second pane resolves; URIs
+ *   are paired by path equality.
+ * - `"compare-files"`: the extension itself opened the diff via the
+ *   `bpmn-modeler.compareWithSelected` command. Session is pre-registered
+ *   before `vscode.diff` is invoked, so pane resolution is a simple lookup.
+ */
+export type DiffOrigin = "scm" | "compare-files";
+
+/**
+ * A single webview pane inside a diff session.
+ *
+ * `ready` flips to `true` once the webview has imported its XML and emitted
+ * `DiffReadyCommand`.  The session is armed — and the differ runs — when both
+ * panes report ready.
+ */
+export interface DiffPaneEntry {
+    readonly panel: WebviewPanel;
+    readonly document: TextDocument;
+    ready: boolean;
+}
+
+/**
+ * A paired BPMN diff view — the domain object the rest of the service
+ * revolves around.
+ *
+ * Promotes what used to be implicit pairing (mutual `partner` pointers on two
+ * `DiffPaneEntry` records) into an explicit object that owns both URIs and
+ * both pane slots.  A session can exist with zero, one, or two attached panes
+ * — this matters because:
+ *
+ * - `compare-files` sessions are created up front with both URIs known but
+ *   no panes attached yet; the panes attach as VS Code resolves the two
+ *   sides of the diff tab.
+ * - A fully-attached session becomes half-attached again when the user
+ *   closes one pane (e.g. drags a tab out), and empty when both are gone.
+ *
+ * Side assignment is fixed at construction time — `before` and `after` are
+ * inherent to the session, not inferred from the pane that attaches first.
+ * This is the key change versus the previous scheme-based heuristic, which
+ * could not discriminate two `file:` URIs.
+ */
+export class DiffSession {
+    /** Wall-clock ms at construction — used by the TTL sweeper in the service. */
+    readonly createdAt: number = Date.now();
+
+    private beforePane?: DiffPaneEntry;
+
+    private afterPane?: DiffPaneEntry;
+
+    /**
+     * @param origin How this session came to be — affects nothing in the diff
+     *   logic itself but is useful for logging and future per-origin UX.
+     * @param beforeUri URI rendered in the left pane.
+     * @param afterUri URI rendered in the right pane.
+     */
+    constructor(
+        readonly origin: DiffOrigin,
+        readonly beforeUri: Uri,
+        readonly afterUri: Uri,
+    ) {}
+
+    /**
+     * Returns the canonical side for the given URI, or `undefined` when the
+     * URI belongs to neither slot of this session.
+     */
+    sideFor(uri: Uri): DiffSide | undefined {
+        const needle = uri.toString();
+        if (needle === this.beforeUri.toString()) {
+            return "before";
+        }
+        if (needle === this.afterUri.toString()) {
+            return "after";
+        }
+        return undefined;
+    }
+
+    /** Returns `true` when a pane has already attached for `uri`'s side. */
+    hasPaneFor(uri: Uri): boolean {
+        const side = this.sideFor(uri);
+        if (side === "before") {
+            return this.beforePane !== undefined;
+        }
+        if (side === "after") {
+            return this.afterPane !== undefined;
+        }
+        return false;
+    }
+
+    /**
+     * Attaches `entry` to the slot matching its document URI.
+     *
+     * @returns The assigned side, or `undefined` when the entry's URI does
+     *   not belong to this session.  Callers should treat `undefined` as a
+     *   programming error — only the owning {@link BpmnDiffService} should
+     *   be attaching panes, and it should only do so after a successful
+     *   session lookup.
+     */
+    attachPane(entry: DiffPaneEntry): DiffSide | undefined {
+        const side = this.sideFor(entry.document.uri);
+        if (side === "before") {
+            this.beforePane = entry;
+        } else if (side === "after") {
+            this.afterPane = entry;
+        }
+        return side;
+    }
+
+    /** Drops `entry` from whichever slot held it (no-op if unknown). */
+    detachPane(entry: DiffPaneEntry): void {
+        if (this.beforePane === entry) {
+            this.beforePane = undefined;
+        }
+        if (this.afterPane === entry) {
+            this.afterPane = undefined;
+        }
+    }
+
+    /** Returns the opposite pane, or `undefined` when unpaired. */
+    partnerOf(entry: DiffPaneEntry): DiffPaneEntry | undefined {
+        if (this.beforePane === entry) {
+            return this.afterPane;
+        }
+        if (this.afterPane === entry) {
+            return this.beforePane;
+        }
+        return undefined;
+    }
+
+    /** The before-side pane, or `undefined` when not yet attached. */
+    before(): DiffPaneEntry | undefined {
+        return this.beforePane;
+    }
+
+    /** The after-side pane, or `undefined` when not yet attached. */
+    after(): DiffPaneEntry | undefined {
+        return this.afterPane;
+    }
+
+    /** All currently-attached panes (0 to 2). */
+    attachedPanes(): DiffPaneEntry[] {
+        const panes: DiffPaneEntry[] = [];
+        if (this.beforePane) {
+            panes.push(this.beforePane);
+        }
+        if (this.afterPane) {
+            panes.push(this.afterPane);
+        }
+        return panes;
+    }
+
+    /** Returns `true` when neither slot holds a pane. */
+    isEmpty(): boolean {
+        return this.beforePane === undefined && this.afterPane === undefined;
+    }
+
+    /** Returns `true` when both panes have attached and reported ready. */
+    isArmed(): boolean {
+        return (
+            this.beforePane !== undefined &&
+            this.afterPane !== undefined &&
+            this.beforePane.ready &&
+            this.afterPane.ready
+        );
+    }
+}

--- a/docs/vscode/contributing/architecture/bpmn-diff.md
+++ b/docs/vscode/contributing/architecture/bpmn-diff.md
@@ -5,8 +5,9 @@
 The BPMN diff view renders two side-by-side readonly BPMN canvases in place of
 VS Code's default text diff, with colour-coded element highlights driven by
 [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ). The interesting
-architecture lives in the extension host: detecting when VS Code opens a diff
-pair, coordinating two independent webviews, and keeping their viewports and
+architecture lives in the extension host: routing each resolving
+`CustomTextEditor` into the viewer path when its URI belongs to an open diff,
+coordinating two independent webviews, and keeping their viewports and
 highlight cursors in sync.
 
 See the [user-facing BPMN Diff page](/vscode/features/bpmn-diff) for the UX
@@ -14,49 +15,77 @@ description.
 
 ## System overview
 
-A diff pair is two `CustomTextEditor` webviews backing the same file: a
-`git:`-scheme URI (before) and a `file:`-scheme URI (after). Both are resolved
-by `BpmnEditorController`, which branches into a readonly viewer path when
-either URI belongs to a diff pair.
+A **diff session** is two `CustomTextEditor` webviews that together render one
+diff tab. Sessions come from two origins:
+
+- **`scm`** — VS Code opened the diff via Source Control, `git diff`, a PR
+  review, etc. One URI is typically `git:` (ref), the other `file:` (working
+  tree). The session is created lazily: the first pane to resolve is stashed
+  in a "pending SCM" slot keyed by `uri.path`; when the second pane resolves
+  with the same path, both are promoted into a `DiffSession("scm", …)`.
+- **`compare-files`** — the extension opened the diff via its own Explorer
+  commands (`bpmn-modeler.compareSelected` or the two-step
+  `selectForCompare` / `compareWithSelected`). Both URIs are known up front,
+  so the session is **pre-registered** before `vscode.diff` fires and a
+  30 s TTL sweeper evicts it if no pane ever attaches.
+
+`BpmnEditorController.resolveCustomTextEditor` asks
+`BpmnDiffService.shouldResolveAsDiff(uri)` for each resolving pane. That
+method runs an ordered decision tree: already-has-a-pane → no (the caller is
+a second resolve for a file already open elsewhere); pre-registered session →
+yes; `git:` scheme → yes; label heuristic matches a diff tab → yes;
+otherwise → no.
 
 ```mermaid
 sequenceDiagram
     participant VSCode as VS Code
-    participant Tracker as DiffTabTracker
+    participant Ctrl as BpmnCompareController
     participant Diff as BpmnDiffService
+    participant Editor as BpmnEditorController
     participant BeforePane as Before Webview
     participant AfterPane as After Webview
 
-    VSCode->>Tracker: onDidChangeTabs (diff opened)
-    Tracker->>Diff: onDidOpen(pair)
-    Diff->>Diff: register DiffPair (armed=false)
+    Note over Ctrl,Diff: compare-files origin (pre-registered)
+    Ctrl->>Diff: registerCompareFilesSession(left, right)
+    Ctrl->>VSCode: executeCommand("vscode.diff", left, right)
 
-    VSCode->>BeforePane: resolveCustomTextEditor (git:)
+    Note over VSCode,Editor: scm origin (lazy) skips the two calls above
+    VSCode->>Editor: resolveCustomTextEditor (before URI)
+    Editor->>Diff: shouldResolveAsDiff → resolveDiffPane
+    Diff->>Diff: findSessionFor(uri) — attach or stash pending SCM
+
+    VSCode->>Editor: resolveCustomTextEditor (after URI)
+    Editor->>Diff: shouldResolveAsDiff → resolveDiffPane
+    Diff->>Diff: promote pending → DiffSession / attach
+
     BeforePane->>Diff: DiffReadyCommand
-    Diff->>Diff: pair.markReady(before)
-
-    VSCode->>AfterPane: resolveCustomTextEditor (file:)
     AfterPane->>Diff: DiffReadyCommand
-    Diff->>Diff: pair.markReady(after) → isArmed()
-
-    Diff->>Diff: bpmn-moddle.fromXML(before + after)
-    Diff->>Diff: bpmn-js-differ.diff(defs, defs)
+    Diff->>Diff: session.isArmed() — run bpmn-moddle + bpmn-js-differ
     Diff->>BeforePane: ApplyDiffHighlightsQuery(removed, changed, moved, counts)
     Diff->>AfterPane: ApplyDiffHighlightsQuery(added, changed, moved, counts)
 
     BeforePane->>Diff: ViewportChangedCommand (pan/zoom)
     Diff->>AfterPane: SyncViewportQuery
-
     AfterPane->>Diff: CursorChangedCommand (Next/Prev)
     Diff->>BeforePane: SyncCursorQuery
 ```
 
 ## Entry points
 
-- **`DiffTabTracker`** (extension host) — observes `vscode.window.tabGroups`
-  and emits open/close events for BPMN diff tabs.
-- **`DiffPair`** (extension host) — state machine for a single diff pair
-  (armed flag, side resolution, partner lookup).
+- **`BpmnCompareController`** (extension host) — registers the three Explorer
+  commands (`selectForCompare`, `compareWithSelected`, `compareSelected`),
+  pre-registers a `compare-files` session, and invokes `vscode.diff`.
+- **`CompareSelectionStore`** (extension host) — ephemeral single-URI store
+  that bridges the two-step flow. Toggles the
+  `bpmn-modeler.compareSelectionActive` context key so "Compare with Selected"
+  only appears in the menu when a pick is pending.
+- **`BpmnDiffService`** (extension host) — owns every session, runs the
+  differ, broadcasts highlights, and forwards viewport/cursor sync messages.
+- **`DiffSession`** (extension host) — domain object for one diff: `origin`,
+  fixed `before`/`after` URIs, attached panes, armed flag.
+- **`BpmnEditorController`** (extension host) — branches resolving custom
+  editors between editable modeler and readonly viewer via
+  `BpmnDiffService.shouldResolveAsDiff(uri)`.
 - **`DiffMode`** (webview) — webview entry point for viewer mode, wires the
   viewer + legend + message handlers.
 
@@ -64,10 +93,11 @@ sequenceDiagram
 
 | File | Purpose |
 |---|---|
-| `apps/modeler-plugin/src/infrastructure/DiffTabTracker.ts` | Observes `vscode.window.tabGroups` and emits open/close events for BPMN diff tabs. |
-| `apps/modeler-plugin/src/domain/DiffPair.ts` | State machine for a single diff pair (armed flag, side resolution, partner lookup). |
-| `apps/modeler-plugin/src/service/BpmnDiffService.ts` | Runs `bpmn-js-differ`, broadcasts highlights, forwards viewport-sync messages. |
-| `apps/modeler-plugin/src/controller/BpmnEditorController.ts` | Branches between editable modeler and readonly viewer based on URI scheme / diff. |
+| `apps/modeler-plugin/src/service/BpmnDiffService.ts` | Session registry, differ runner, highlight broadcaster, viewport/cursor forwarder. Hosts `shouldResolveAsDiff` and `registerCompareFilesSession`. |
+| `apps/modeler-plugin/src/service/DiffSession.ts` | Domain object for one diff: origin, fixed before/after URIs, pane slots, armed flag. |
+| `apps/modeler-plugin/src/controller/BpmnEditorController.ts` | Branches between editable modeler and readonly viewer via `BpmnDiffService.shouldResolveAsDiff`. |
+| `apps/modeler-plugin/src/controller/BpmnCompareController.ts` | Explorer commands (`selectForCompare`, `compareWithSelected`, `compareSelected`) and the shared `openBpmnDiff` dispatch. |
+| `apps/modeler-plugin/src/infrastructure/CompareSelectionStore.ts` | In-memory store for the pending "Select for Compare" URI; toggles the `bpmn-modeler.compareSelectionActive` context key. |
 | `apps/modeler-plugin/src/types/bpmn-js-differ.d.ts` | Ambient shim for the untyped `bpmn-js-differ` package. |
 | `apps/modeler-plugin/src/types/bpmn-moddle.d.ts` | Ambient shim for `bpmn-moddle` (factory function, not a class). |
 | `apps/bpmn-webview/src/app/diff/DiffMode.ts` | Webview entry point for viewer mode — wires viewer + legend + message handlers. |
@@ -146,12 +176,21 @@ the differ is upgraded.
 - **Editor id is the full URI string**, not just the path. `git:` and `file:`
   URIs for the same file produce different editor ids, so the `EditorStore`
   can hold both panes side by side without collision.
-- **`DiffTabTracker.isInDiff(uri)` scans the current tab tree** rather than
-  trusting cached state. Custom-editor resolution can race ahead of the
-  `onDidChangeTabs` event, and a fresh scan avoids the race.
-- **The pair is armed only when both panes signal ready.** The differ runs
-  exactly once per pair; subsequent document edits from Git (e.g. checkout of
-  another ref) retire and re-register the pair.
+- **SCM pairing is keyed by `uri.path`, not by the full URI.** That is the
+  only thing `git:foo.bpmn` and `file:foo.bpmn` share. The two paths of a
+  `compare-files` session deliberately differ, which is why that origin must
+  be pre-registered — lazy pairing would never match them.
+- **`shouldResolveAsDiff` short-circuits when a pane already exists for the
+  URI.** Without this, opening a working-tree file in a normal editor tab
+  while the SCM diff is still open would trigger a second resolve, and the
+  label heuristic would route it to the diff path too.
+- **`compare-files` sessions carry a TTL** (`COMPARE_FILES_TTL_MS`, 30 s).
+  If the caller invokes `vscode.diff` and the tab never opens (VS Code swallowed
+  the error, the user cancelled a dialog, etc.) the sweeper evicts the
+  session so the same pair can be registered again cleanly.
+- **Sessions are armed only when both panes signal ready.** The differ runs
+  exactly once per session; subsequent document edits from Git (e.g. checkout
+  of another ref) retire and re-register the session.
 - **`bpmn-moddle` is loaded via dynamic `import()`.** This keeps it in its
   own webpack chunk so the extension host doesn't pay the parse cost until a
   diff actually opens. The package's default export is a factory function

--- a/docs/vscode/features/bpmn-diff.md
+++ b/docs/vscode/features/bpmn-diff.md
@@ -1,14 +1,41 @@
-# BPMN Diff
+# BPMN Diff View
 
 The BPMN Modeler extension replaces VS Code's default text-based diff for `.bpmn` files with two side-by-side readonly BPMN canvases. Element-level changes are highlighted with colour-coded markers driven by [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ) — the same library that powers [demo.bpmn.io/diff](https://demo.bpmn.io/diff) — and panning/zooming in one pane is mirrored to the other.
 
-## Usage
+The diff view opens from two entry points, which share the same UI:
+
+- **Source Control / Git** — any place VS Code opens a text diff for a `.bpmn` file.
+- **Explorer context menu** — pick two `.bpmn` files, either with a multi-selection or one right-click at a time.
+
+## Usage — Source Control
 
 1. Open the **Source Control** panel in VS Code.
 2. Click any modified `.bpmn` file, or open a diff from `git diff`, `git log`, or a pull-request review.
 3. VS Code opens the diff pair in a split editor; both sides render as BPMN canvases instead of XML text.
 
-The left pane shows the **before** version (e.g. `HEAD` or the merge-base) and the right pane shows the **after** version (e.g. the working tree). Each pane is a `NavigatedViewer` — read-only but fully navigable with mouse wheel, drag, and keyboard.
+The left pane shows the **before** version (e.g. `HEAD` or the merge-base) and the right pane shows the **after** version (e.g. the working tree).
+
+## Usage — Compare two files
+
+### Pick both in one click
+
+When the two files are visible side by side in the Explorer:
+
+1. Hold <kbd>Cmd</kbd> / <kbd>Ctrl</kbd> and click the two `.bpmn` files so both are selected.
+2. Right-click either one → **BPMN Modeler: Compare Selected**.
+3. A diff tab opens with two BPMN canvases — the first-selected file on the left (`before`), the second on the right (`after`).
+
+### Pick them one at a time
+
+Useful when the two files live in different Explorer folders, or when you want to pair a file you selected earlier against another one you find later.
+
+1. Right-click the first `.bpmn` file → **BPMN Modeler: Select for Compare**. A status-bar note confirms the pick.
+2. Right-click the second `.bpmn` file → **BPMN Modeler: Compare with Selected**.
+3. The diff tab opens as above.
+
+Selection is in-memory only; reloading the window or running the compare clears it. The menu mirrors VS Code's built-in compare UX: **Select for Compare** and **Compare with Selected** disappear while two files are multi-selected — **Compare Selected** takes their place.
+
+The same viewport/cursor sync and highlight legend that ships for Git diffs applies here — the two origins are indistinguishable in the UI. Each pane is a `NavigatedViewer`: read-only but fully navigable with mouse wheel, drag, and keyboard.
 
 ## Highlights
 
@@ -27,8 +54,9 @@ Colours intentionally match the bpmn.io/diff demo so users familiar with that UI
 
 A floating legend sits at the top-centre of **both panes**:
 
-- Four count slots — Added / Removed / Changed / Moved — each with its colour swatch. Counts are symmetric across the two sides.
-- A **Prev change** / **Next change** navigator that cycles through the shared change list in sequence-flow order. The pane that owns the current element paints a gold glow; the other pane anchors its viewport on the nearest neighbour.
+- Four count slots — Added / Removed / Changed / Moved — each with its colour swatch.  Counts are symmetric across the two sides; both panes show the same numbers.
+- A **Prev change** / **Next change** navigator that cycles through the shared change list in sequence-flow order.
+- Clicking a nav button on either pane advances **both** cursors.  The pane that owns the current id paints a gold glow; the other pane anchors its viewport on the nearest neighbour that does exist locally and clears its own selection marker so the user is not misled.  For elements that exist on both panes, both will glow simultaneously.
 - Buttons are disabled when there are no changes at all.
 
 ## Viewport and Cursor Sync


### PR DESCRIPTION
**Issue**

Closes: #923 

**Description**

Implements a two-step explorer workflow to compare any two .bpmn files:
"Select for Compare" stores the first file, then "Compare with Selected"
opens a diff tab with side-by-side canvases. Refactors diff pairing from
implicit partner pointers to explicit DiffSession objects keyed by before/after
URIs, eliminating scheme-based heuristics and enabling pre-registration before
vscode.diff is invoked. Adds BpmnCompareController, CompareSelectionStore, and
DiffSession; updates BpmnDiffService to manage multiple origins (SCM and
compare-files) with session-based routing and TTL-swept orphan cleanup.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
