### PR TITLE
chore: add conductor.json for Conductor workspace setup

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "setup": "corepack yarn install",
+    "run": "corepack yarn dev",
+    "archive": "rm -rf dist node_modules"
+  },
+  "runScriptMode": "nonconcurrent"
+}


### PR DESCRIPTION
## Summary

- Adds `conductor.json` to share a standard Conductor workspace config with the team
- **setup**: `corepack yarn install` — installs all Yarn 4 workspace dependencies
- **run**: `corepack yarn dev` — starts the full dev stack (libs → webview servers + webpack watch)
- **archive**: `rm -rf dist node_modules` — reclaims disk on archive (skips Yarn cache since it's global)
- **runScriptMode: nonconcurrent** — terminates the old dev stack before starting a new one

## Test plan

- [ ] Open project in Conductor → "Set up workspace" runs `corepack yarn install` without errors
- [ ] Click "Run" → full dev watch stack starts (shared lib, webviews, plugin)
- [ ] Re-trigger run → previous process is terminated before new one starts