### PR TITLE
ci: add --immutable flag to yarn install in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '20'
 
       - name: Install dependencies
-        run: yarn
+        run: yarn install --immutable
 
       - name: Audit dependencies
         run: yarn npm audit --all --severity high


### PR DESCRIPTION
## Summary
- `build.yml` ran `yarn install` without `--immutable`, allowing out-of-sync lockfiles to silently pass CI
- Added `--immutable` to match the pattern already used in `release.yml` and `release-create-append-c7.yml`

## Test plan
- [ ] CI build passes on this branch (clean lockfile)
- [ ] Verify that a branch with a manually tampered `yarn.lock` now fails the "Install dependencies" step