### PR TITLE
ci: enforce pinned npm dependencies across all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v6
 
+      - name: Check pinned dependencies
+        uses: Miragon/pin-npm-dependencies@v1
+
       - name: Enable corepack
         run: corepack enable
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Miragon/pin-npm-dependencies@v1
       - run: corepack enable
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-create-append-c7.yml
+++ b/.github/workflows/release-create-append-c7.yml
@@ -37,6 +37,9 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.RELEASE_PAT }}
 
+      - name: Check pinned dependencies
+        uses: Miragon/pin-npm-dependencies@v1
+
       - name: Corepack enable
         run: corepack enable
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
           persist-credentials: false
           token: ${{ secrets.RELEASE_PAT }}
 
+      - name: Check pinned dependencies
+        uses: Miragon/pin-npm-dependencies@v1
+
       - name: Corepack enable
         run: corepack enable
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,6 @@
     "devDependencies": {
         "mermaid": "10.9.3",
         "vitepress": "1.6.4",
-        "vitepress-plugin-mermaid": "^2.0.17"
+        "vitepress-plugin-mermaid": "2.0.17"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6502,7 +6502,7 @@ __metadata:
   dependencies:
     mermaid: "npm:10.9.3"
     vitepress: "npm:1.6.4"
-    vitepress-plugin-mermaid: "npm:^2.0.17"
+    vitepress-plugin-mermaid: "npm:2.0.17"
   languageName: unknown
   linkType: soft
 
@@ -12693,7 +12693,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vitepress-plugin-mermaid@npm:^2.0.17":
+"vitepress-plugin-mermaid@npm:2.0.17":
   version: 2.0.17
   resolution: "vitepress-plugin-mermaid@npm:2.0.17"
   dependencies:


### PR DESCRIPTION
## Summary

- Adds `Miragon/pin-npm-dependencies@v1` step to all CI workflows that install dependencies (`build.yml`, `release.yml`, `release-create-append-c7.yml`, `deploy-docs.yml`) — fails the build if any `package.json` introduces a version range (`^`/`~`)
- Pins `vitepress-plugin-mermaid` in `docs/package.json` from `^2.0.17` → `2.0.17` to satisfy the new check

## Test plan

- [ ] CI build passes on this PR
- [ ] Verify the "Check pinned dependencies" step appears in the build job log