### PR TITLE
chore(dev): add yarn dev:install for one-command local VSIX testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ vitest.config.*.timestamp*
 docs/.vitepress/dist
 docs/.vitepress/cache
 .gstack/
+.agent/logs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,19 +74,66 @@ cd bpmn-vscode-modeler
 corepack yarn install
 ```
 
-### Run the Extension Development Host
+### Testing the extension locally
 
-1. Start watch mode:
-   ```bash
-   corepack yarn watch
-   ```
-2. Open the **Run and Debug** panel in VS Code.
-3. Select **"Run modeler-plugin"** and press **F5**.
+VS Code extensions can't be tested by simply running a script in a terminal —
+VS Code itself needs to load the extension. There are two ways to do this,
+each suited to a different stage of your work.
 
-Reload the host after a change with `Cmd+R` (macOS) or `Ctrl+R` (Windows/Linux).
+---
 
-For comprehensive guidance (standalone browser preview, testing, architecture),
-see [`docs/development.md`](docs/development.md).
+#### Option A: Extension Development Host *(use while actively coding)*
+
+This is the standard VS Code development loop. It opens a **second VS Code
+window** with your local build loaded inside it. You can make code changes
+and reload that window in seconds — your real VS Code is never touched.
+
+**Step 1 — Open this repository in VS Code** (the folder containing this
+`CONTRIBUTING.md`). If you are working in another tool like Conductor, you
+still need to do this separately.
+
+**Step 2 — Start the build watcher** in a terminal inside VS Code:
+
+```bash
+corepack yarn watch
+```
+
+Wait until you see the first successful build in the terminal output before
+continuing.
+
+**Step 3 — Press F5** (or open the **Run and Debug** panel in the left
+sidebar, select **"Run modeler-plugin"** from the dropdown, and click the
+green play button).
+
+A second VS Code window opens — this is the **Extension Development Host**.
+Open any `.bpmn` or `.dmn` file inside it to use the modeler.
+
+**After each code change:** the watcher rebuilds automatically. Press
+**Cmd+R** (macOS) or **Ctrl+R** (Windows/Linux) inside the Extension
+Development Host window to reload and pick up the new build.
+
+---
+
+#### Option B: Open in your real VS Code *(use before opening a PR)*
+
+This opens a new VS Code window with the dev build of the modeler loaded
+alongside your real settings, themes, and other extensions — without touching
+your installed Marketplace version at all. When you close the window,
+everything is back to normal.
+
+```bash
+corepack yarn dev:open
+```
+
+This builds the full project and then opens VS Code pointing at the sample
+diagrams in `resources/example-process/`. Your existing installation of the
+extension is untouched; the dev version is active only in that window.
+
+---
+
+For deeper guidance — standalone browser preview of the webview UI, build
+system internals, and architecture — see
+[`docs/vscode/contributing/development.md`](docs/vscode/contributing/development.md).
 
 ## Pull Request Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,12 +141,12 @@ Marketplace version. To restore the clean Marketplace version:
 
 ```bash
 code --uninstall-extension miragon-gmbh.vs-code-bpmn-modeler
+code --install-extension miragon-gmbh.vs-code-bpmn-modeler
 ```
 
-Then reinstall from the Extensions panel in VS Code. Unlike the old `dev:install`,
-`yarn dev:open` never modifies your installed extension — so this situation cannot
-be caused by it. If you already have a dev build installed, the uninstall above is
-still needed to clear it.
+Unlike the old `dev:install`, `yarn dev:open` never modifies your installed
+extension — so this situation cannot be caused by it. If you already have a dev
+build installed, the two commands above are still needed to clear it.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,8 +143,10 @@ Marketplace version. To restore the clean Marketplace version:
 code --uninstall-extension miragon-gmbh.vs-code-bpmn-modeler
 ```
 
-Then reinstall from the Extensions panel in VS Code. The current `yarn dev:open`
-workflow avoids this problem entirely — it never modifies your installed extension.
+Then reinstall from the Extensions panel in VS Code. Unlike the old `dev:install`,
+`yarn dev:open` never modifies your installed extension — so this situation cannot
+be caused by it. If you already have a dev build installed, the uninstall above is
+still needed to clear it.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,23 @@ extension is untouched; the dev version is active only in that window.
 
 ---
 
+### Troubleshooting
+
+**Unexpected features showing in the extension (e.g. unreleased UI from another branch)**
+
+If you previously ran an older `dev:install` command from a feature branch, that
+dev build may have been force-installed into your real VS Code and replaced your
+Marketplace version. To restore the clean Marketplace version:
+
+```bash
+code --uninstall-extension miragon-gmbh.vs-code-bpmn-modeler
+```
+
+Then reinstall from the Extensions panel in VS Code. The current `yarn dev:open`
+workflow avoids this problem entirely — it never modifies your installed extension.
+
+---
+
 For deeper guidance — standalone browser preview of the webview UI, build
 system internals, and architecture — see
 [`docs/vscode/contributing/development.md`](docs/vscode/contributing/development.md).

--- a/docs/vscode/contributing/development.md
+++ b/docs/vscode/contributing/development.md
@@ -68,13 +68,30 @@ Opens the VitePress docs site in your browser.
 
 ### Run the extension in VS Code
 
-1. Open the repository root in VS Code.
-2. Run `yarn watch` to start watch mode.
-3. Open the **Run and Debug** panel and select **"Run modeler-plugin"**.
-4. Press **F5** to launch the Extension Development Host.
+Two workflows are available — choose based on where you are in your work:
 
-To reload the extension host after a change, press **Cmd+R** (macOS) or **Ctrl+R** (
-Windows/Linux).
+**Extension Development Host (daily development)**
+
+1. Open the repository root in VS Code.
+2. Run `yarn watch` and wait for the first build to complete.
+3. Press **F5** (or open **Run and Debug** → select **"Run modeler-plugin"** → click play).
+
+A second VS Code window opens with your extension loaded. Open a `.bpmn` or
+`.dmn` file inside it to use the modeler.
+
+To pick up a code change: wait for the watcher to rebuild, then press
+**Cmd+R** (macOS) or **Ctrl+R** (Windows/Linux) inside the Extension
+Development Host window.
+
+**Open in real VS Code (pre-PR validation)**
+
+```bash
+yarn dev:open
+```
+
+Builds the project and opens a new VS Code window with the dev build loaded
+alongside your real settings and extensions — your Marketplace install is
+untouched. See [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md) for full details.
 
 ### Target a single workspace
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
         "docs:build": "corepack yarn workspace docs build",
         "docs:preview": "corepack yarn workspace docs preview",
         "test": "jest --coverage",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "dev:open": "npm-run-all -s build dev:open:launch",
+        "dev:open:launch": "code --extensionDevelopmentPath=dist/apps/modeler-plugin resources/example-process"
     },
     "devDependencies": {
         "@eslint/eslintrc": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "docs:preview": "corepack yarn workspace docs preview",
         "test": "jest --coverage",
         "lint": "eslint .",
-        "dev:open": "npm-run-all -s build dev:open:launch",
+        "dev:open": "npm-run-all -s dev:open:clean build dev:open:launch",
+        "dev:open:clean": "node -e \"require('fs').rmSync('dist/apps/modeler-plugin', { recursive: true, force: true })\"",
         "dev:open:launch": "code --extensionDevelopmentPath=dist/apps/modeler-plugin resources/example-process"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

- Adds `yarn dev:open` as a one-command workflow to test the extension locally without touching the contributor's Marketplace install
- Uses `--extensionDevelopmentPath` to load the dev build from `dist/` for that window session only — no VSIX packaging, no forced install, no cleanup step needed
- Rewrites the local testing section in `CONTRIBUTING.md` and `docs/vscode/contributing/development.md` in plain, step-by-step language for contributors unfamiliar with VS Code extension development
- Adds `.agent/logs/` to `.gitignore`

## Two testing workflows

| | `yarn watch` + F5 | `yarn dev:open` |
|---|---|---|
| **When** | Active development loop | Final validation before PR |
| **Environment** | Isolated Extension Development Host | Real VS Code (settings, themes, extensions) |
| **Debugger** | ✅ | ❌ |
| **Affects installed extension?** | ❌ | ❌ |
| **Reload** | Cmd+R after each rebuild | Re-run the command |

## Test plan

- [ ] `yarn dev:open` builds, then opens a new VS Code window with the dev modeler active
- [ ] Marketplace version remains installed in other VS Code windows
- [ ] `yarn watch` + F5 still opens Extension Development Host as before
- [ ] CONTRIBUTING.md reads clearly without prior VS Code extension development knowledge