### PR TITLE
docs: note Operaton & CIB7 compatibility via C7 metamodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 
 The BPMN VS Code Modeler is a VS Code extension for BPMN and DMN process modeling, built
 on top of [bpmn-js](https://bpmn.io/toolkit/bpmn-js/). It targets teams working
-with **Camunda 7 and Camunda 8** and integrates directly into your existing VS Code
-workflow.
+with **Camunda 7, Camunda 8**, and compatible forks such as **Operaton** and **CIB7**,
+and integrates directly into your existing VS Code workflow.
 
 > **Powered by [bpmn.io](https://bpmn.io/)** — Built on [bpmn-js](https://github.com/bpmn-io/bpmn-js)
 > and [dmn-js](https://github.com/bpmn-io/dmn-js). Thanks to the bpmn.io team for their work.
@@ -37,7 +37,7 @@ workflow.
 ## Features
 
 - **BPMN Modeling**: Create and edit BPMN 2.0 diagrams with full Camunda 7 and Camunda 8
-  support.
+  support, including compatible forks (Operaton, CIB7).
 - **DMN Modeling**: Create and edit DMN decision tables.
 - **Element Templates**: Convention-based element template discovery — place templates
   under `<configFolder>/element-templates/` anywhere between your BPMN file and the

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ hero:
 features:
   - icon: ◎
     title: Professional modeling
-    details: Full Camunda 7 & 8. Element templates, append menu, multi-language display, copy-paste across diagrams.
+    details: Full Camunda 7, 8 & compatible forks (Operaton, CIB7). Element templates, append menu, multi-language display, copy-paste across diagrams.
     link: /vscode/features/append-menu
     linkText: Explore modeling
   - icon: ⇌
@@ -34,5 +34,6 @@ Professional BPMN and DMN modeling that fits how you work — embedded in VS Cod
 | One-click deploy to Camunda 7 & 8 | <span class="ok">✓</span> | <span class="ok">✓</span> | <span class="no">✕</span> |
 | Element template discovery | <span class="ok">✓</span> Auto by convention | <span class="ok">✓</span> Manual config | <span class="no">✕</span> |
 | Camunda 7 support | <span class="ok">✓</span> | <span class="ok">✓</span> | <span class="no">✕</span> |
+| Operaton / CIB7 support | <span class="ok">✓</span> via C7 compatibility | <span class="ok">✓</span> | <span class="ok">✓</span> |
 | Camunda 8 / Zeebe support | <span class="ok">✓</span> | <span class="ok">✓</span> | <span class="ok">✓</span> |
 | Open source | <span class="ok">✓</span> Apache 2.0 | <span class="ok">✓</span> | <span class="ok">✓</span> |

--- a/docs/vscode/features/index.md
+++ b/docs/vscode/features/index.md
@@ -25,6 +25,14 @@ Here's what you get, roughly in the order you reach for it.
   start process instances directly from VS Code. Camunda 7 and 8 support,
   three auth modes, payload file discovery by convention.
 
+## Operaton & CIB7 Compatibility
+
+Operaton and CIB7 are community forks of Camunda 7 that retain a backward-compatible
+BPMN metamodel. Because this modeler's Camunda 7 support targets the standard C7
+metamodel, diagrams and element templates designed for Camunda 7 work unchanged with
+Operaton and CIB7. No separate engine profile is needed — select Camunda 7 as your
+engine target.
+
 ## Configure
 
 - **[Language Support](/vscode/features/language-support)** — switch the

--- a/docs/vscode/features/index.md
+++ b/docs/vscode/features/index.md
@@ -24,15 +24,6 @@ Here's what you get, roughly in the order you reach for it.
 - **[Deployment](/vscode/features/deployment)** — push BPMN/DMN diagrams and
   start process instances directly from VS Code. Camunda 7 and 8 support,
   three auth modes, payload file discovery by convention.
-
-## Operaton & CIB7 Compatibility
-
-Operaton and CIB7 are community forks of Camunda 7 that retain a backward-compatible
-BPMN metamodel. Because this modeler's Camunda 7 support targets the standard C7
-metamodel, diagrams and element templates designed for Camunda 7 work unchanged with
-Operaton and CIB7. No separate engine profile is needed — select Camunda 7 as your
-engine target.
-
 ## Configure
 
 - **[Language Support](/vscode/features/language-support)** — switch the

--- a/docs/vscode/getting-started.md
+++ b/docs/vscode/getting-started.md
@@ -1,7 +1,8 @@
 # Getting Started
 
 The Miragon BPMN Modeler is a VS Code extension for editing BPMN 2.0 and DMN
-diagrams with full Camunda 7 and Camunda 8 support.
+diagrams with full Camunda 7 and Camunda 8 support. Camunda 7-compatible engines such as
+**Operaton** and **CIB7** are also supported — they share the same BPMN metamodel.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Mentions Operaton and CIB7 as supported engines in README, docs landing page, getting-started, and features index
- No new engine profile needed — they share the Camunda 7 BPMN metamodel
- Closes #901

## Changes

- `README.md`: extended engine mention to include Operaton & CIB7
- `docs/index.md`: updated hero feature text + added comparison table row
- `docs/vscode/getting-started.md`: one-sentence note on C7-compatible forks
- `docs/vscode/features/index.md`: compact "Operaton & CIB7 Compatibility" section