### PR TITLE
docs: restructure READMEs for multi-target repo (#945)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ development guide (project structure, build system, architecture, testing), see
 - [Development Setup](#development-setup)
 - [Pull Request Process](#pull-request-process)
 - [Commit Messages](#commit-messages)
+- [Updating a Marketplace Listing](#updating-a-marketplace-listing)
 - [License](#license)
 
 ## Code of Conduct
@@ -121,6 +122,36 @@ docs: clarify element template discovery
 ```
 
 Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`, `ci`.
+
+## Updating a Marketplace Listing
+
+A VS Code Marketplace listing is composed from two sources inside the
+extension's workspace (e.g. `apps/modeler-plugin/`):
+
+1. **`README.md`** — rendered as the listing's main content. The
+   workspace-local README is bundled into the VSIX by
+   `webpack.config.js` via `CopyWebpackPlugin`. **Never** point this copy
+   at the root `README.md` — the root file is a repo-level overview and
+   does not belong on a product page.
+2. **`package.json` fields** — listing metadata: `displayName`,
+   `description`, `categories`, `keywords`, `icon`, `badges`, `repository`,
+   `homepage`, `galleryBanner`.
+
+To preview a listing locally before publishing:
+
+```bash
+corepack yarn build
+cd dist/apps/modeler-plugin
+npx @vscode/vsce package --no-dependencies --out preview.vsix
+```
+
+Open the `.vsix` (it is a zip): the `extension/README.md` inside is exactly
+what the Marketplace will render. You can also run
+`npx @vscode/vsce ls` from the same directory to list everything bundled.
+
+When introducing a new publishable extension, follow the same pattern:
+ship a workspace-local `README.md` and copy it (not the root one) into the
+VSIX from that workspace's `webpack.config.js`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,161 +1,102 @@
 <div id="top"></div>
 
-<!-- PROJECT SHIELDS -->
 [![Contributors][contributors-shield]][contributors-url]
 [![Forks][forks-shield]][forks-url]
 [![Stargazers][stars-shield]][stars-url]
 [![Issues][issues-shield]][issues-url]
 [![MIT License][license-shield]][license-url]
-<!-- END OF PROJECT SHIELDS -->
 
-<!-- PROJECT LOGO -->
 <br />
 <div align="center">
     <a href="#">
-        <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Logo" height="180">
+        <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
     </a>
-    <h3>BPMN VS Code Modeler</h3>
+    <h3>BPMN VS Code Modeler — monorepo</h3>
+    <p>A family of BPMN/DMN modeling tools built around a shared modeler core.</p>
     <p>
         <a href="https://miragon.github.io/bpmn-vscode-modeler/">Documentation</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Report Bug</a>
+        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Issues</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/pulls">Request Feature</a>
+        <a href="https://github.com/Miragon/bpmn-vscode-modeler/pulls">Pull requests</a>
     </p>
 </div>
 
-## About The Project
+## What this repo ships
 
-The BPMN VS Code Modeler is a VS Code extension for BPMN and DMN process modeling, built
-on top of [bpmn-js](https://bpmn.io/toolkit/bpmn-js/). It targets teams working
-with **Camunda 7 and Camunda 8** and integrates directly into your existing VS Code
-workflow.
+This repository hosts more than one product. They share a common BPMN/DMN
+modeling core (built on [bpmn-js](https://bpmn.io/) and
+[dmn-js](https://github.com/bpmn-io/dmn-js)) and target different surfaces:
 
-> **Powered by [bpmn.io](https://bpmn.io/)** — Built on [bpmn-js](https://github.com/bpmn-io/bpmn-js)
-> and [dmn-js](https://github.com/bpmn-io/dmn-js). Thanks to the bpmn.io team for their work.
+- **BPMN/DMN modeling for Camunda 7 and Camunda 8** — full BPMN 2.0 and DMN
+  editing with engine-aware properties.
+- **Deployment workflows** — deploy diagrams and start instances against C7
+  or C8 from inside the editor.
+- **BPMN diff** — element-level visual diff across two `.bpmn` files.
+- **Multi-language UI** — modeler localised into 9 languages.
+- **Multiple delivery surfaces** — VS Code extension today, standalone
+  desktop app target in progress, more extensions planned.
 
-## Features
+Each product has its own README with its own pitch, feature list, and (where
+applicable) marketplace listing. Start there.
 
-- **BPMN Modeling**: Create and edit BPMN 2.0 diagrams with full Camunda 7 and Camunda 8
-  support.
-- **DMN Modeling**: Create and edit DMN decision tables.
-- **Element Templates**: Convention-based element template discovery — place templates
-  under `<configFolder>/element-templates/` anywhere between your BPMN file and the
-  workspace root. No extra project config file needed.
-- **Deployment**: Deploy BPMN/DMN diagrams and start process instances directly from a
-  sidebar panel. Supports Camunda 7 and Camunda 8 with no auth, Basic Auth, and OAuth2
-  Client Credentials. Payload files are discovered by convention from
-  `<configFolder>/payloads/`.
-- **BPMN Diff View**: Side-by-side readonly BPMN canvases for `.bpmn` files. 
-  Element-level changes are colour-coded (added, removed, changed, moved) via 
-  [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ), with synchronized 
-  pan/zoom and a prev/next change navigator.
-- **Multi-Language UI**: The modeler UI (palette, context pad, properties panel) is
-  available in English, Deutsch, Français, Nederlands, Português (Brasil), Русский,
-  简体中文, and 繁體中文. Change the language via settings or the command palette.
+## Modules
 
-![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+| Module | What it is | Status |
+|---|---|---|
+| [`apps/modeler-plugin`](apps/modeler-plugin/README.md) | VS Code extension — the public BPMN/DMN modeler. | Published on the [VS Code Marketplace][marketplace-url] |
+| [`apps/standalone`](apps/standalone/README.md) | Theia/Electron desktop shell wrapping the same modeler. | Build-from-source, unreleased |
+| [`apps/bpmn-webview`](apps/bpmn-webview/README.md) | BPMN canvas webview embedded in the extension host. | Internal |
+| [`apps/dmn-webview`](apps/dmn-webview/README.md) | DMN canvas webview embedded in the extension host. | Internal |
+| [`apps/deployment-webview`](apps/deployment-webview/README.md) | Deployment sidebar webview. | Internal |
+| [`libs/shared`](libs/shared/README.md) | Shared message types and webview utilities. | Internal |
 
-## Getting Started (Users)
+> Internal modules are not published separately — they are bundled into the
+> distributables above.
 
-Install the extension from the VS Code Marketplace and open any `.bpmn` or `.dmn` file.
-The modeler opens automatically as a custom editor.
+## For users
 
-### Configuration
+You probably want **[`apps/modeler-plugin`](apps/modeler-plugin/README.md)** —
+install *Camunda Modeler by Miragon* from the VS Code Marketplace and open
+any `.bpmn` or `.dmn` file.
 
-Search for "BPMN Modeler" in Settings (`Ctrl+,` / `Cmd+,`) to view all available options.
+## For contributors
 
-| Setting                                         | Default                     | Description                                                             |
-|-------------------------------------------------|-----------------------------|-------------------------------------------------------------------------|
-| `miragon.bpmnModeler.configFolder`              | `.camunda`                  | Folder name used for element template and payload file discovery        |
-| `miragon.bpmnModeler.language`                  | `en`                        | UI language for the modeler (e.g. `de`, `fr`, `zh-Hans`)                |
-| `miragon.bpmnModeler.colorTheme`                | `automatic`                 | Color theme for the BPMN canvas (`automatic` or `light`)                |
-| `miragon.bpmnModeler.favouriteBpmnElements`     | `["bpmn:ServiceTask", ...]` | BPMN element types to pin at the top of the append menu palette (max 6) |
-| `miragon.bpmnModeler.showTransactionBoundaries` | `true`                      | Show transaction boundaries in the BPMN canvas (C7 only)                |
-| `miragon.bpmnModeler.c8ApiVersion`              | `v2`                        | REST API version prefix for Camunda 8 deployment endpoints              |
+- Development setup, PR flow, and commit conventions:
+  [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Architecture, build system, testing, and contributor walkthroughs:
+  [`docs/`](docs/) (also published at
+  <https://miragon.github.io/bpmn-vscode-modeler/>)
 
-### Command Palette
+Quick orientation:
 
-Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) to view
-all available commands.
+```bash
+corepack enable
+corepack yarn install
+corepack yarn build      # build everything
+corepack yarn watch      # F5 in VS Code → "Run modeler-plugin"
+```
 
-| Command                                   | Keybinding     | Description                                                      |
-|-------------------------------------------|----------------|------------------------------------------------------------------|
-| BPMN Modeler: Change Modeler Language     |                | Change the UI language of the modeler                            |
-| BPMN Modeler: Deploy Diagram              |                | Open the Deployment sidebar for the current BPMN/DMN diagram     |
-| BPMN Modeler: Copy Diagram as SVG         |                | Copy the current diagram to the clipboard as SVG                 |
-| BPMN Modeler: Save Diagram as SVG         |                | Create a SVG file of the current diagram next to the bpmn file   |
-| BPMN Modeler: Change Engine Version       |                | Switch between engine versions (not between platforms C7 -> C8)  |
-| BPMN Modeler: Migrate All BPMN Diagrams   |                | Switch the engine versions of all BPMN diagrams in the workspace |
-| BPMN Modeler: Toggle Standard Text Editor | `Ctrl+Shift+E` | Open the XML text editor next to the bpmn modeler                |
-| BPMN Modeler: Display Logging Information |                | Open a console showing modeler log output                        |
-
-
-## Contributing
-
-Contributions are what make the open source community such an amazing place to learn,
-inspire, and create. Any contributions are **greatly appreciated**.
-
-For a full contributor guide including setup, project structure, development workflow,
-code style, branching model, and CI/CD details, see
-**[docs/README.md](docs/README.md)**.
-
-### Quick Start
-
-1. **Prerequisites**: Node.js v20+, `corepack enable`, VS Code
-2. **Clone and install**:
-   ```bash
-   git clone https://github.com/Miragon/bpmn-vscode-modeler.git
-   cd bpmn-vscode-modeler
-   corepack yarn install
-   ```
-3. **Start watch mode**: `yarn dev`
-4. **Launch the extension**: Open the **Run and Debug** panel in VS Code, select
-   **"Run modeler-plugin"**, and press **F5**.
-
-### Opening a Pull Request
-
-1. Open an issue with the tag `enhancement` or `bug`
-2. Fork the repository
-3. Create a feature branch (`git checkout -b feat/my-feature`)
-4. Use semantic commit messages scoped to the affected workspace:
-   ```
-   feat(bpmn): add token simulation toolbar
-   fix(dmn): correct decision table rendering
-   ```
-5. Push and open a Pull Request
-
-Please use semantic commit messages as described
-in [here](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716).
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full setup.
 
 ## Support
 
-If you have questions or need support, reach out via
-email ([info@miragon.io](mailto:info@miragon.io)).
+Questions or commercial support: [info@miragon.io](mailto:info@miragon.io).
 
 ## License
 
-Distributed under the [Apache License Version 2.0](LICENSE).
+Distributed under the [Apache License 2.0](LICENSE).
 
 <!-- MARKDOWN LINKS & IMAGES -->
-<!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 
 [contributors-shield]: https://img.shields.io/github/contributors/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-
 [contributors-url]: https://github.com/Miragon/bpmn-vscode-modeler/graphs/contributors
-
 [forks-shield]: https://img.shields.io/github/forks/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-
 [forks-url]: https://github.com/Miragon/bpmn-vscode-modeler/network/members
-
 [stars-shield]: https://img.shields.io/github/stars/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-
 [stars-url]: https://github.com/Miragon/bpmn-vscode-modeler/stargazers
-
 [issues-shield]: https://img.shields.io/github/issues/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-
 [issues-url]: https://github.com/Miragon/bpmn-vscode-modeler/issues
-
 [license-shield]: https://img.shields.io/github/license/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-
 [license-url]: https://github.com/Miragon/bpmn-vscode-modeler/blob/main/LICENSE
+[marketplace-url]: https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler

--- a/README.md
+++ b/README.md
@@ -43,12 +43,8 @@ quietly grew into more places where process work actually happens:
 - **In VS Code**, as the public extension — the original product.
 - **On the desktop**, as a standalone Theia/Electron app for users and
   organisations not on VS Code, with the exact same modeling surface.
-- **In your AI assistant**, via a separate plugin that pushes your BPMN
-  landscape to an LLM over MCP — so Claude can lint your models, diff what
-  you just edited against what's deployed, and answer questions about a
-  whole process landscape without anyone pasting XML into chat. *(Landing
-  soon — see [PR #943](https://github.com/Miragon/bpmn-vscode-modeler/pull/943)
-  and the [bpmn-iq](https://github.com/Miragon/bpmn-iq) project.)*
+- **And next: AI-assisted BPMN tooling** — bringing the same modeling
+  context into your AI assistant. *Stay tuned.* ✨
 
 Different surfaces, one modeling engine, one repo.
 

--- a/README.md
+++ b/README.md
@@ -11,41 +11,73 @@
     <a href="#">
         <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
     </a>
-    <h3>BPMN VS Code Modeler — monorepo</h3>
-    <p>A family of BPMN/DMN modeling tools built around a shared modeler core.</p>
+    <h3>Model BPMN where your code already lives.</h3>
+    <p>A family of BPMN/DMN tools built around a shared modeler core — VS Code today, more surfaces tomorrow.</p>
     <p>
         <a href="https://miragon.github.io/bpmn-vscode-modeler/">Documentation</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Issues</a>
+        <a href="https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler">Install on Marketplace</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/pulls">Pull requests</a>
+        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Issues</a>
     </p>
 </div>
 
-## What this repo ships
+---
 
-This repository hosts more than one product. They share a common BPMN/DMN
-modeling core (built on [bpmn-js](https://bpmn.io/) and
-[dmn-js](https://github.com/bpmn-io/dmn-js)) and target different surfaces:
+## Why we built this
 
-- **BPMN/DMN modeling for Camunda 7 and Camunda 8** — full BPMN 2.0 and DMN
-  editing with engine-aware properties.
-- **Deployment workflows** — deploy diagrams and start instances against C7
-  or C8 from inside the editor.
-- **BPMN diff** — element-level visual diff across two `.bpmn` files.
-- **Multi-language UI** — modeler localised into 9 languages.
-- **Multiple delivery surfaces** — VS Code extension today, standalone
-  desktop app target in progress, more extensions planned.
+Process diagrams are code. They live in your repo, get reviewed in pull
+requests, and ship with the rest of your software. But for years the only
+way to edit them was a separate desktop modeler — context switch, save,
+re-open in your IDE, commit, repeat.
 
-Each product has its own README with its own pitch, feature list, and (where
-applicable) marketplace listing. Start there.
+We wanted to skip the round trip. **Open a `.bpmn` file. Model. Commit.
+Done.** Same editor, same git workflow, same diff in code review.
 
-## Modules
+That core idea — *bring BPMN modeling to where the engineers already are* —
+turned into the modeler you see below, and then into a small family of
+related tools sharing the same engine. This repo hosts all of them.
+
+![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+
+## What you get
+
+- **Full BPMN 2.0 + DMN modeling** for **Camunda 7** and **Camunda 8** —
+  engine-aware properties, no profile switching ceremony.
+- **Element templates by convention** — drop them in `.camunda/element-templates/`
+  next to your BPMN file, the modeler picks them up. No project config required.
+- **Deploy from the editor** — a sidebar that pushes your diagram to C7 or
+  C8 (no auth, Basic, or OAuth2 Client Credentials) and starts a process
+  instance with payload files discovered from `.camunda/payloads/`.
+- **Visual BPMN diff** — open two `.bpmn` files side by side, see what
+  changed at the element level (added · removed · changed · moved) with
+  synchronized pan/zoom. Great in code review.
+- **Speaks your language** — UI translated into 9 locales: English,
+  Deutsch, Español, Français, Nederlands, Português (Brasil), Русский,
+  简体中文, 繁體中文.
+- **Built on [bpmn.io](https://bpmn.io/)** — the toolkit the official
+  Camunda Modeler is based on. You get the same modeling foundation, just
+  embedded where you already work.
+
+### Try it in 30 seconds
+
+> Install **[Camunda Modeler by Miragon][marketplace-url]** from the VS Code
+> Marketplace, open any `.bpmn` or `.dmn` file — the modeler opens
+> automatically as a custom editor. That's it.
+
+For settings, commands, and the full feature tour see
+**[`apps/modeler-plugin/README.md`](apps/modeler-plugin/README.md)** — the
+same page that's published as the Marketplace listing.
+
+## Modules in this repo
+
+This is a monorepo. Around the modeler core we ship multiple delivery
+surfaces; each one has its own README with its own pitch.
 
 | Module | What it is | Status |
 |---|---|---|
-| [`apps/modeler-plugin`](apps/modeler-plugin/README.md) | VS Code extension — the public BPMN/DMN modeler. | Published on the [VS Code Marketplace][marketplace-url] |
-| [`apps/standalone`](apps/standalone/README.md) | Theia/Electron desktop shell wrapping the same modeler. | Build-from-source, unreleased |
+| [`apps/modeler-plugin`](apps/modeler-plugin/README.md) | The VS Code extension — the public BPMN/DMN modeler. | Published on the [Marketplace][marketplace-url] |
+| [`apps/standalone`](apps/standalone/README.md) | Theia/Electron desktop shell wrapping the same modeler — same features, no VS Code required. | Build-from-source, unreleased |
 | [`apps/bpmn-webview`](apps/bpmn-webview/README.md) | BPMN canvas webview embedded in the extension host. | Internal |
 | [`apps/dmn-webview`](apps/dmn-webview/README.md) | DMN canvas webview embedded in the extension host. | Internal |
 | [`apps/deployment-webview`](apps/deployment-webview/README.md) | Deployment sidebar webview. | Internal |
@@ -54,21 +86,9 @@ applicable) marketplace listing. Start there.
 > Internal modules are not published separately — they are bundled into the
 > distributables above.
 
-## For users
+## Contributing
 
-You probably want **[`apps/modeler-plugin`](apps/modeler-plugin/README.md)** —
-install *Camunda Modeler by Miragon* from the VS Code Marketplace and open
-any `.bpmn` or `.dmn` file.
-
-## For contributors
-
-- Development setup, PR flow, and commit conventions:
-  [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- Architecture, build system, testing, and contributor walkthroughs:
-  [`docs/`](docs/) (also published at
-  <https://miragon.github.io/bpmn-vscode-modeler/>)
-
-Quick orientation:
+We love PRs. Whether you fix a typo or land a feature, the path is the same:
 
 ```bash
 corepack enable
@@ -77,11 +97,16 @@ corepack yarn build      # build everything
 corepack yarn watch      # F5 in VS Code → "Run modeler-plugin"
 ```
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full setup.
+For the full setup, PR flow, and commit conventions see
+**[`CONTRIBUTING.md`](CONTRIBUTING.md)**. For architecture, build system,
+and contributor walkthroughs see **[`docs/`](docs/)** (also published at
+<https://miragon.github.io/bpmn-vscode-modeler/>).
 
 ## Support
 
-Questions or commercial support: [info@miragon.io](mailto:info@miragon.io).
+Questions, ideas, or commercial support? Reach out at
+[info@miragon.io](mailto:info@miragon.io) — or open an
+[issue](https://github.com/Miragon/bpmn-vscode-modeler/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
     <a href="#">
         <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
     </a>
-    <h3>Model BPMN where your code already lives.</h3>
-    <p>A family of BPMN/DMN tools built around a shared modeler core — VS Code today, more surfaces tomorrow.</p>
+    <h3>BPMN, where your work already happens.</h3>
+    <p>A growing family of BPMN/DMN tools built around a shared modeler core — in VS Code, on the desktop, and (soon) talking to your AI assistant.</p>
     <p>
         <a href="https://miragon.github.io/bpmn-vscode-modeler/">Documentation</a>
         ·
@@ -34,11 +34,23 @@ re-open in your IDE, commit, repeat.
 We wanted to skip the round trip. **Open a `.bpmn` file. Model. Commit.
 Done.** Same editor, same git workflow, same diff in code review.
 
-That core idea — *bring BPMN modeling to where the engineers already are* —
-turned into the modeler you see below, and then into a small family of
-related tools sharing the same engine. This repo hosts all of them.
-
 ![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+
+That first idea — *bring BPMN modeling to where engineers already are* —
+turned into the VS Code modeler you see above. From there, the same core
+quietly grew into more places where process work actually happens:
+
+- **In VS Code**, as the public extension — the original product.
+- **On the desktop**, as a standalone Theia/Electron app for users and
+  organisations not on VS Code, with the exact same modeling surface.
+- **In your AI assistant**, via a separate plugin that pushes your BPMN
+  landscape to an LLM over MCP — so Claude can lint your models, diff what
+  you just edited against what's deployed, and answer questions about a
+  whole process landscape without anyone pasting XML into chat. *(Landing
+  soon — see [PR #943](https://github.com/Miragon/bpmn-vscode-modeler/pull/943)
+  and the [bpmn-iq](https://github.com/Miragon/bpmn-iq) project.)*
+
+Different surfaces, one modeling engine, one repo.
 
 ## What you get
 
@@ -78,6 +90,7 @@ surfaces; each one has its own README with its own pitch.
 |---|---|---|
 | [`apps/modeler-plugin`](apps/modeler-plugin/README.md) | The VS Code extension — the public BPMN/DMN modeler. | Published on the [Marketplace][marketplace-url] |
 | [`apps/standalone`](apps/standalone/README.md) | Theia/Electron desktop shell wrapping the same modeler — same features, no VS Code required. | Build-from-source, unreleased |
+| `apps/bpmn-iq-plugin` | Separate VS Code extension that pushes your BPMN landscape to an LLM over MCP — see [bpmn-iq](https://github.com/Miragon/bpmn-iq). | Landing in [PR #943](https://github.com/Miragon/bpmn-vscode-modeler/pull/943) |
 | [`apps/bpmn-webview`](apps/bpmn-webview/README.md) | BPMN canvas webview embedded in the extension host. | Internal |
 | [`apps/dmn-webview`](apps/dmn-webview/README.md) | DMN canvas webview embedded in the extension host. | Internal |
 | [`apps/deployment-webview`](apps/deployment-webview/README.md) | Deployment sidebar webview. | Internal |

--- a/apps/bpmn-webview/README.md
+++ b/apps/bpmn-webview/README.md
@@ -1,0 +1,42 @@
+# `apps/bpmn-webview/` — BPMN canvas webview
+
+Internal module. **Not published separately.**
+
+The BPMN modeling surface that runs inside the VS Code webview hosted by
+[`apps/modeler-plugin`](../modeler-plugin/README.md). Built with Vite and
+[bpmn-js](https://github.com/bpmn-io/bpmn-js); communicates with the
+extension host via a typed Query/Command message protocol from
+[`libs/shared`](../../libs/shared/README.md).
+
+## Why this lives in its own workspace
+
+Webview frontends are browser code with their own bundler, dependency tree,
+and dev workflow — separate from the Node.js extension host. Keeping them in
+their own workspace lets each one iterate independently and run in a normal
+browser during development.
+
+## Local development
+
+From the repo root:
+
+```bash
+corepack yarn watch                       # rebuild bundle to disk; F5 launches the extension host
+corepack yarn workspace bpmn-webview serve  # standalone Vite dev server in a browser
+```
+
+`watch` is what you want when developing the full extension. `serve` is for
+isolated UI work without launching VS Code.
+
+## Build output
+
+`vite build` writes to `dist/webview-staging/bpmn-webview/`. The
+`modeler-plugin` webpack config copies that folder into the VSIX.
+
+## Further reading
+
+- Architecture and message protocol:
+  [`/architecture`](https://miragon.github.io/bpmn-vscode-modeler/) skill /
+  docs site.
+- bpmn-js internals (EventBus, services, copy-paste): the project's
+  `/bpmn-js` skill.
+- Webview lifecycle and CSP: the project's `/vscode-webviews` skill.

--- a/apps/deployment-webview/README.md
+++ b/apps/deployment-webview/README.md
@@ -1,0 +1,38 @@
+# `apps/deployment-webview/` — Deployment sidebar webview
+
+Internal module. **Not published separately.**
+
+Renders the **Deploy Diagram** sidebar of the modeler extension: a small
+form that collects engine type, endpoint, auth credentials, and an optional
+payload, then asks the extension host to deploy and (optionally) start a
+process instance against Camunda 7 or Camunda 8.
+
+Hosted by [`apps/modeler-plugin`](../modeler-plugin/README.md). Talks to the
+extension host via the typed Query/Command protocol from
+[`libs/shared`](../../libs/shared/README.md).
+
+## Dual-HTML pattern
+
+The deployment sidebar has **two copies** of its HTML that must stay in
+sync:
+
+- `apps/deployment-webview/index.html` — Vite development.
+- `apps/modeler-plugin/src/infrastructure/DeploymentWebviewHtml.ts` —
+  runtime in VS Code (CSP nonce, theme variables).
+
+When modifying deployment form markup, update **both**.
+
+## Local development
+
+From the repo root:
+
+```bash
+corepack yarn watch                              # rebuild bundle to disk; F5 launches the extension host
+corepack yarn workspace deployment-webview serve  # standalone Vite dev server in a browser
+```
+
+## Further reading
+
+- Project `/architecture` skill — deployment subsystem, hexagonal ports for
+  C7/C8 engines.
+- Project `/vscode-webviews` skill — webview lifecycle, CSP, theming.

--- a/apps/dmn-webview/README.md
+++ b/apps/dmn-webview/README.md
@@ -1,0 +1,30 @@
+# `apps/dmn-webview/` — DMN canvas webview
+
+Internal module. **Not published separately.**
+
+The DMN modeling surface (decision tables, decision requirements diagrams,
+literal expressions) that runs inside the VS Code webview hosted by
+[`apps/modeler-plugin`](../modeler-plugin/README.md). Built with Vite and
+[dmn-js](https://github.com/bpmn-io/dmn-js); communicates with the extension
+host via the typed Query/Command protocol from
+[`libs/shared`](../../libs/shared/README.md).
+
+## Local development
+
+From the repo root:
+
+```bash
+corepack yarn watch                       # rebuild bundle to disk; F5 launches the extension host
+corepack yarn workspace dmn-webview serve  # standalone Vite dev server in a browser
+```
+
+## Build output
+
+`vite build` writes to `dist/webview-staging/dmn-webview/`. The
+`modeler-plugin` webpack config copies that folder into the VSIX.
+
+## Further reading
+
+- Architecture and message protocol: project `/architecture` skill, docs
+  site at <https://miragon.github.io/bpmn-vscode-modeler/>.
+- Webview lifecycle and CSP: project `/vscode-webviews` skill.

--- a/apps/modeler-plugin/README.md
+++ b/apps/modeler-plugin/README.md
@@ -1,0 +1,89 @@
+<div align="center">
+    <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Miragon" height="140">
+    <h3>Camunda Modeler by Miragon</h3>
+    <p>BPMN 2.0 and DMN modeling for Camunda 7 and Camunda 8 — directly in VS Code.</p>
+    <p>
+        <a href="https://miragon.github.io/bpmn-vscode-modeler/">Documentation</a>
+        ·
+        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Report Bug</a>
+        ·
+        <a href="https://github.com/Miragon/bpmn-vscode-modeler/pulls">Request Feature</a>
+    </p>
+</div>
+
+## Why this extension
+
+Model and maintain BPMN/DMN files where your code already lives. No context
+switch into a separate desktop modeler, no detached tooling — diagrams are
+versioned, reviewed, and edited in the same workflow as the rest of your
+project.
+
+> **Powered by [bpmn.io](https://bpmn.io/)** — built on
+> [bpmn-js](https://github.com/bpmn-io/bpmn-js) and
+> [dmn-js](https://github.com/bpmn-io/dmn-js).
+
+## Features
+
+- **BPMN modeling** — full BPMN 2.0 with Camunda 7 and Camunda 8 properties.
+- **DMN modeling** — decision tables, decision requirements diagrams, literal
+  expressions.
+- **Element templates** — convention-based discovery: drop templates under
+  `<configFolder>/element-templates/` anywhere between your BPMN file and the
+  workspace root. No extra project config needed.
+- **Deployment sidebar** — deploy diagrams and start process instances against
+  Camunda 7 or 8. Supports no auth, Basic Auth, and OAuth2 Client Credentials.
+  Payload files are discovered by convention from `<configFolder>/payloads/`.
+- **BPMN diff view** — side-by-side readonly canvases for two `.bpmn` files
+  with element-level colour coding (added / removed / changed / moved) via
+  [`bpmn-js-differ`](https://github.com/bpmn-io/bpmn-js-differ), synchronized
+  pan/zoom, and a prev/next change navigator.
+- **Multi-language UI** — palette, context pad, and properties panel
+  available in English, Deutsch, Español, Français, Nederlands,
+  Português (Brasil), Русский, 简体中文, and 繁體中文.
+
+![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+
+## Getting started
+
+Install **Camunda Modeler by Miragon** from the VS Code Marketplace, then open
+any `.bpmn` or `.dmn` file — the modeler opens automatically as a custom
+editor.
+
+### Settings
+
+Search for "BPMN Modeler" in Settings (`Ctrl+,` / `Cmd+,`).
+
+| Setting                                         | Default                     | Description                                                             |
+|-------------------------------------------------|-----------------------------|-------------------------------------------------------------------------|
+| `miragon.bpmnModeler.configFolder`              | `.camunda`                  | Folder name used for element template and payload file discovery        |
+| `miragon.bpmnModeler.language`                  | `en`                        | UI language for the modeler (e.g. `de`, `fr`, `zh-Hans`)                |
+| `miragon.bpmnModeler.colorTheme`                | `automatic`                 | Color theme for the BPMN canvas (`automatic` or `light`)                |
+| `miragon.bpmnModeler.favouriteBpmnElements`     | `["bpmn:ServiceTask", ...]` | BPMN element types pinned at the top of the append menu palette (max 6) |
+| `miragon.bpmnModeler.showTransactionBoundaries` | `true`                      | Show transaction boundaries in the BPMN canvas (C7 only)                |
+| `miragon.bpmnModeler.c8ApiVersion`              | `v2`                        | REST API version prefix for Camunda 8 deployment endpoints              |
+| `miragon.bpmnModeler.alignToOrigin`             | `false`                     | Align the diagram to the origin when opening a new diagram              |
+
+### Commands
+
+Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
+
+| Command                                   | Keybinding     | Description                                                      |
+|-------------------------------------------|----------------|------------------------------------------------------------------|
+| BPMN Modeler: Change Modeler Language     |                | Change the UI language of the modeler                            |
+| BPMN Modeler: Deploy Diagram              |                | Open the Deployment sidebar for the current BPMN/DMN diagram     |
+| BPMN Modeler: Copy Diagram as SVG         |                | Copy the current diagram to the clipboard as SVG                 |
+| BPMN Modeler: Save Diagram as SVG         |                | Save a SVG file of the current diagram next to the bpmn file     |
+| BPMN Modeler: Change Engine Version       |                | Switch between engine versions (within a platform)               |
+| BPMN Modeler: Migrate All BPMN Diagrams   |                | Switch the engine versions of all BPMN diagrams in the workspace |
+| BPMN Modeler: Toggle Standard Text Editor | `Ctrl+Shift+E` | Open the XML text editor next to the BPMN modeler                |
+| BPMN Modeler: Display Logging Information |                | Open a console showing modeler log output                        |
+
+## Support and feedback
+
+- Documentation: <https://miragon.github.io/bpmn-vscode-modeler/>
+- Bugs / feature requests: <https://github.com/Miragon/bpmn-vscode-modeler/issues>
+- Contact: [info@miragon.io](mailto:info@miragon.io)
+
+## License
+
+Distributed under the [Apache License 2.0](https://github.com/Miragon/bpmn-vscode-modeler/blob/main/LICENSE).

--- a/apps/modeler-plugin/webpack.config.js
+++ b/apps/modeler-plugin/webpack.config.js
@@ -82,7 +82,10 @@ module.exports = (env, argv) => {
                         noErrorOnMissing: true,
                     },
                     {
-                        from: path.resolve(__dirname, "../../README.md"),
+                        // The Marketplace listing is rendered from the README
+                        // bundled into the VSIX. Always use the workspace-local
+                        // README so each extension's listing is self-contained.
+                        from: path.resolve(__dirname, "README.md"),
                         to: ".",
                         noErrorOnMissing: true,
                     },

--- a/apps/standalone/README.md
+++ b/apps/standalone/README.md
@@ -5,6 +5,12 @@ deployment features as the VS Code extension, no VS Code required. Built on
 [Eclipse Theia](https://theia-ide.org/) and packaged with Electron, loading
 the same `.vsix` that ships to the VS Code Marketplace.
 
+![BPMN Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+
+> Same modeling surface as the VS Code extension — the screenshot above is
+> the modeler running in VS Code; the standalone app shows the exact same
+> editor inside a Theia/Electron window.
+
 > **Status:** build-from-source, not yet released. Distribution channels and
 > a product name will be announced once the desktop target is ready for
 > general availability.

--- a/apps/standalone/README.md
+++ b/apps/standalone/README.md
@@ -1,8 +1,13 @@
 # `apps/standalone/` — Theia Electron shell
 
-Packages the BPMN/DMN modeler as a **standalone desktop app** built on
-[Eclipse Theia](https://theia-ide.org/), loading the same `.vsix` that ships
-to the VS Code marketplace.
+Standalone desktop app version of the BPMN/DMN modeler — same modeling and
+deployment features as the VS Code extension, no VS Code required. Built on
+[Eclipse Theia](https://theia-ide.org/) and packaged with Electron, loading
+the same `.vsix` that ships to the VS Code Marketplace.
+
+> **Status:** build-from-source, not yet released. Distribution channels and
+> a product name will be announced once the desktop target is ready for
+> general availability.
 
 This workspace is **opt-in**. It is intentionally *not* included in the root
 `build` / `test` / `lint` scripts. Run its scripts explicitly.

--- a/libs/shared/README.md
+++ b/libs/shared/README.md
@@ -1,8 +1,15 @@
-# BPMN Modeler Library
+# `libs/shared/` — webview shared library
 
-This library provides modules that can be used within your webviews.
+Internal module. **Not published separately.**
 
-If you use this lib you have to add following to your `vite.config.mts`:
+Provides the typed Query/Command message protocol and shared utilities used
+by every webview in this repo (BPMN, DMN, deployment) to talk to the
+extension host. Consumed via the `@bpmn-modeler/shared` path alias defined
+in `tsconfig.base.json`.
+
+## Usage from a webview workspace
+
+Add the alias to your `vite.config.mts`:
 
 ```ts
 export default defineConfig( {


### PR DESCRIPTION
## Summary

Restructures READMEs so the multi-target nature of the repo is visible up front and each module owns its own user-facing pitch. Closes #945.

- **Root `README.md`** — repo-level overview with a "BPMN, where your work already happens" story arc spanning the three surfaces (VS Code · standalone desktop · AI integration via [bpmn-iq](https://github.com/Miragon/bpmn-iq), landing in #943). Keeps the modeler hero screenshot. Long-form feature tables removed from root.
- **`apps/modeler-plugin/README.md`** — new, becomes the Marketplace listing. Contains the badges, features, settings/commands tables previously living in the root README.
- **`apps/modeler-plugin/webpack.config.js`** — VSIX now bundles the workspace-local README instead of the root one. Marketplace listing is therefore self-contained per workspace.
- **New READMEs** for `apps/bpmn-webview`, `apps/dmn-webview`, `apps/deployment-webview` (internal modules — purpose, dev workflow, build output, skill cross-links).
- **`apps/standalone/README.md`** — added user-facing intro + the same modeler preview image.
- **`libs/shared/README.md`** — labelled internal.
- **`CONTRIBUTING.md`** — new "Updating a Marketplace Listing" section documenting the file flow (`webpack.config.js` → `dist/` → `vsce package`/`publish`) and how to preview locally.

## Test plan

- [x] `corepack yarn build` passes; modeler-plugin VSIX builds clean.
- [x] Verified `dist/apps/modeler-plugin/README.md` is byte-identical to `apps/modeler-plugin/README.md` (the file the Marketplace will render).
- [ ] Visual scan: root README scannable in <30s; each `apps/*` README focused, no duplicated feature lists across workspaces.
- [ ] Verify all existing marketplace links and badges still resolve.