### PR TITLE
chore: rename repository to bpmn-modeler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,5 +54,5 @@ jobs:
           directory: "./coverage"
           fail_ci_if_error: false
           flags: unittests
-          name: bpmn-vscode-modeler
+          name: bpmn-modeler
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
   contents: write
 
 concurrency:
-  group: bpmn-vscode-modeler-release
+  group: bpmn-modeler-release
   cancel-in-progress: false
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ uphold this code.
 
 Before opening a bug report, please:
 
-1. Search [existing issues](https://github.com/Miragon/bpmn-vscode-modeler/issues)
+1. Search [existing issues](https://github.com/Miragon/bpmn-modeler/issues)
    to avoid duplicates.
 2. Verify you are running the latest version of the extension from the
    Marketplace.
@@ -70,8 +70,8 @@ Discussing scope in an issue *before* writing code saves everyone time.
 ### Clone and install
 
 ```bash
-git clone https://github.com/Miragon/bpmn-vscode-modeler.git
-cd bpmn-vscode-modeler
+git clone https://github.com/Miragon/bpmn-modeler.git
+cd bpmn-modeler
 corepack yarn install
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 <br />
 <div align="center">
     <a href="#">
-        <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
+        <img src="https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
     </a>
     <h3>BPMN, where your work already happens.</h3>
     <p>A growing family of BPMN/DMN tools built around a shared modeler core — in VS Code, on the desktop, and (soon) talking to your AI assistant.</p>
     <p>
-        <a href="https://miragon.github.io/bpmn-vscode-modeler/">Documentation</a>
+        <a href="https://miragon.github.io/bpmn-modeler/">Documentation</a>
         ·
         <a href="https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler">Install on Marketplace</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Issues</a>
+        <a href="https://github.com/Miragon/bpmn-modeler/issues">Issues</a>
     </p>
 </div>
 
@@ -34,7 +34,7 @@ re-open in your IDE, commit, repeat.
 We wanted to skip the round trip. **Open a `.bpmn` file. Model. Commit.
 Done.** Same editor, same git workflow, same diff in code review.
 
-![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/modeler-preview.png)
 
 That first idea — *bring BPMN modeling to where engineers already are* —
 turned into the VS Code modeler you see above. From there, the same core
@@ -87,7 +87,7 @@ surfaces; each one has its own README with its own pitch.
 |---|---|---|
 | [`apps/modeler-plugin`](apps/modeler-plugin/README.md) | The VS Code extension — the public BPMN/DMN modeler. | Published on the [Marketplace][marketplace-url] |
 | [`apps/standalone`](apps/standalone/README.md) | Theia/Electron desktop shell wrapping the same modeler — same features, no VS Code required. | Build-from-source, unreleased |
-| `apps/bpmn-iq-plugin` | Separate VS Code extension that pushes your BPMN landscape to an LLM over MCP — see [bpmn-iq](https://github.com/Miragon/bpmn-iq). | Landing in [PR #943](https://github.com/Miragon/bpmn-vscode-modeler/pull/943) |
+| `apps/bpmn-iq-plugin` | Separate VS Code extension that pushes your BPMN landscape to an LLM over MCP — see [bpmn-iq](https://github.com/Miragon/bpmn-iq). | Landing in [PR #943](https://github.com/Miragon/bpmn-modeler/pull/943) |
 | [`apps/bpmn-webview`](apps/bpmn-webview/README.md) | BPMN canvas webview embedded in the extension host. | Internal |
 | [`apps/dmn-webview`](apps/dmn-webview/README.md) | DMN canvas webview embedded in the extension host. | Internal |
 | [`apps/deployment-webview`](apps/deployment-webview/README.md) | Deployment sidebar webview. | Internal |
@@ -110,13 +110,13 @@ corepack yarn watch      # F5 in VS Code → "Run modeler-plugin"
 For the full setup, PR flow, and commit conventions see
 **[`CONTRIBUTING.md`](CONTRIBUTING.md)**. For architecture, build system,
 and contributor walkthroughs see **[`docs/`](docs/)** (also published at
-<https://miragon.github.io/bpmn-vscode-modeler/>).
+<https://miragon.github.io/bpmn-modeler/>).
 
 ## Support
 
 Questions, ideas, or commercial support? Reach out at
 [info@miragon.io](mailto:info@miragon.io) — or open an
-[issue](https://github.com/Miragon/bpmn-vscode-modeler/issues).
+[issue](https://github.com/Miragon/bpmn-modeler/issues).
 
 ## License
 
@@ -124,14 +124,14 @@ Distributed under the [Apache License 2.0](LICENSE).
 
 <!-- MARKDOWN LINKS & IMAGES -->
 
-[contributors-shield]: https://img.shields.io/github/contributors/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-[contributors-url]: https://github.com/Miragon/bpmn-vscode-modeler/graphs/contributors
-[forks-shield]: https://img.shields.io/github/forks/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-[forks-url]: https://github.com/Miragon/bpmn-vscode-modeler/network/members
-[stars-shield]: https://img.shields.io/github/stars/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-[stars-url]: https://github.com/Miragon/bpmn-vscode-modeler/stargazers
-[issues-shield]: https://img.shields.io/github/issues/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-[issues-url]: https://github.com/Miragon/bpmn-vscode-modeler/issues
-[license-shield]: https://img.shields.io/github/license/Miragon/bpmn-vscode-modeler.svg?style=for-the-badge
-[license-url]: https://github.com/Miragon/bpmn-vscode-modeler/blob/main/LICENSE
+[contributors-shield]: https://img.shields.io/github/contributors/Miragon/bpmn-modeler.svg?style=for-the-badge
+[contributors-url]: https://github.com/Miragon/bpmn-modeler/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/Miragon/bpmn-modeler.svg?style=for-the-badge
+[forks-url]: https://github.com/Miragon/bpmn-modeler/network/members
+[stars-shield]: https://img.shields.io/github/stars/Miragon/bpmn-modeler.svg?style=for-the-badge
+[stars-url]: https://github.com/Miragon/bpmn-modeler/stargazers
+[issues-shield]: https://img.shields.io/github/issues/Miragon/bpmn-modeler.svg?style=for-the-badge
+[issues-url]: https://github.com/Miragon/bpmn-modeler/issues
+[license-shield]: https://img.shields.io/github/license/Miragon/bpmn-modeler.svg?style=for-the-badge
+[license-url]: https://github.com/Miragon/bpmn-modeler/blob/main/LICENSE
 [marketplace-url]: https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler

--- a/apps/bpmn-webview/README.md
+++ b/apps/bpmn-webview/README.md
@@ -35,7 +35,7 @@ isolated UI work without launching VS Code.
 ## Further reading
 
 - Architecture and message protocol:
-  [`/architecture`](https://miragon.github.io/bpmn-vscode-modeler/) skill /
+  [`/architecture`](https://miragon.github.io/bpmn-modeler/) skill /
   docs site.
 - bpmn-js internals (EventBus, services, copy-paste): the project's
   `/bpmn-js` skill.

--- a/apps/dmn-webview/README.md
+++ b/apps/dmn-webview/README.md
@@ -26,5 +26,5 @@ corepack yarn workspace dmn-webview serve  # standalone Vite dev server in a bro
 ## Further reading
 
 - Architecture and message protocol: project `/architecture` skill, docs
-  site at <https://miragon.github.io/bpmn-vscode-modeler/>.
+  site at <https://miragon.github.io/bpmn-modeler/>.
 - Webview lifecycle and CSP: project `/vscode-webviews` skill.

--- a/apps/modeler-plugin/README.md
+++ b/apps/modeler-plugin/README.md
@@ -1,13 +1,13 @@
 <div align="center">
-    <img src="https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/miragon-logo.png" alt="Miragon" height="140">
+    <img src="https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/miragon-logo.png" alt="Miragon" height="140">
     <h3>Camunda Modeler by Miragon</h3>
     <p>BPMN 2.0 and DMN modeling for Camunda 7 and Camunda 8 — directly in VS Code.</p>
     <p>
-        <a href="https://miragon.github.io/bpmn-vscode-modeler/">Documentation</a>
+        <a href="https://miragon.github.io/bpmn-modeler/">Documentation</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/issues">Report Bug</a>
+        <a href="https://github.com/Miragon/bpmn-modeler/issues">Report Bug</a>
         ·
-        <a href="https://github.com/Miragon/bpmn-vscode-modeler/pulls">Request Feature</a>
+        <a href="https://github.com/Miragon/bpmn-modeler/pulls">Request Feature</a>
     </p>
 </div>
 
@@ -42,7 +42,7 @@ project.
   available in English, Deutsch, Español, Français, Nederlands,
   Português (Brasil), Русский, 简体中文, and 繁體中文.
 
-![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+![BPMN VS Code Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/modeler-preview.png)
 
 ## Getting started
 
@@ -81,10 +81,10 @@ Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`
 
 ## Support and feedback
 
-- Documentation: <https://miragon.github.io/bpmn-vscode-modeler/>
-- Bugs / feature requests: <https://github.com/Miragon/bpmn-vscode-modeler/issues>
+- Documentation: <https://miragon.github.io/bpmn-modeler/>
+- Bugs / feature requests: <https://github.com/Miragon/bpmn-modeler/issues>
 - Contact: [info@miragon.io](mailto:info@miragon.io)
 
 ## License
 
-Distributed under the [Apache License 2.0](https://github.com/Miragon/bpmn-vscode-modeler/blob/main/LICENSE).
+Distributed under the [Apache License 2.0](https://github.com/Miragon/bpmn-modeler/blob/main/LICENSE).

--- a/apps/modeler-plugin/package.json
+++ b/apps/modeler-plugin/package.json
@@ -28,10 +28,10 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/Miragon/bpmn-vscode-modeler.git"
+        "url": "https://github.com/Miragon/bpmn-modeler.git"
     },
     "bugs": {
-        "url": "https://github.com/Miragon/bpmn-vscode-modeler/issues"
+        "url": "https://github.com/Miragon/bpmn-modeler/issues"
     },
     "engines": {
         "vscode": "^1.76.0"

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -115,7 +115,7 @@ export function activate(context: ExtensionContext): void {
     new DeploymentController(editorStore, vsDocument, deploymentSvc, startInstanceSvc, vsUI).register(context);
 }
 
-const RELEASES_BASE = "https://github.com/Miragon/bpmn-vscode-modeler/releases/tag";
+const RELEASES_BASE = "https://github.com/Miragon/bpmn-modeler/releases/tag";
 const LAST_NOTIFIED_KEY = "lastNotifiedVersion";
 
 /**

--- a/apps/standalone/README.md
+++ b/apps/standalone/README.md
@@ -5,7 +5,7 @@ deployment features as the VS Code extension, no VS Code required. Built on
 [Eclipse Theia](https://theia-ide.org/) and packaged with Electron, loading
 the same `.vsix` that ships to the VS Code Marketplace.
 
-![BPMN Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-vscode-modeler/main/images/modeler-preview.png)
+![BPMN Modeler Preview](https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/modeler-preview.png)
 
 > Same modeling surface as the VS Code extension — the screenshot above is
 > the modeler running in VS Code; the standalone app shows the exact same
@@ -146,4 +146,4 @@ apps/standalone/
 
 ## Related
 
-- Issue: [#917](https://github.com/Miragon/bpmn-vscode-modeler/issues/917)
+- Issue: [#917](https://github.com/Miragon/bpmn-modeler/issues/917)

--- a/apps/standalone/electron-builder.yml
+++ b/apps/standalone/electron-builder.yml
@@ -8,7 +8,7 @@ directories:
 publish:
   provider: github
   owner: Miragon
-  repo: bpmn-vscode-modeler
+  repo: bpmn-modeler
 files:
   - lib/**/*
   - src-gen/**/*

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,7 +4,7 @@ import { withMermaid } from "vitepress-plugin-mermaid";
 export default withMermaid(defineConfig({
     title: "Miragon BPMN Modeler",
     description: "Professional BPMN/DMN process modeling — as a VS Code extension or a standalone desktop app",
-    base: "/bpmn-vscode-modeler/",
+    base: "/bpmn-modeler/",
     appearance: false,
     head: [
         [
@@ -12,7 +12,7 @@ export default withMermaid(defineConfig({
             {
                 rel: "icon",
                 type: "image/png",
-                href: "/bpmn-vscode-modeler/miragon-favicon.png",
+                href: "/bpmn-modeler/miragon-favicon.png",
             },
         ],
     ],
@@ -105,7 +105,7 @@ export default withMermaid(defineConfig({
         socialLinks: [
             {
                 icon: "github",
-                link: "https://github.com/Miragon/bpmn-vscode-modeler",
+                link: "https://github.com/Miragon/bpmn-modeler",
             },
         ],
         search: { provider: "local" },

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -8,7 +8,7 @@ const { frontmatter } = useData();
 const version = ref("unknown");
 onMounted(async () => {
     try {
-        const res = await fetch("https://api.github.com/repos/Miragon/bpmn-vscode-modeler/releases/latest");
+        const res = await fetch("https://api.github.com/repos/Miragon/bpmn-modeler/releases/latest");
         if (!res.ok) return;
         const { tag_name } = await res.json();
         version.value = (tag_name ?? "").replace(/^v/, "") || "unknown";
@@ -19,7 +19,7 @@ onMounted(async () => {
 
 const MARKETPLACE_URL =
     "https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler";
-const GITHUB_URL = "https://github.com/Miragon/bpmn-vscode-modeler";
+const GITHUB_URL = "https://github.com/Miragon/bpmn-modeler";
 </script>
 
 <template>

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
     "name": "docs",
     "private": true,
     "scripts": {
-        "dev": "portless run sh -c '(open $PORTLESS_URL/bpmn-vscode-modeler/) & vitepress dev . --port $PORT --host 127.0.0.1'",
+        "dev": "portless run sh -c '(open $PORTLESS_URL/bpmn-modeler/) & vitepress dev . --port $PORT --host 127.0.0.1'",
         "build": "vitepress build .",
         "preview": "vitepress preview ."
     },

--- a/docs/standalone/getting-started.md
+++ b/docs/standalone/getting-started.md
@@ -11,14 +11,14 @@ Windows and Linux builds may follow.
 ## Download & install
 
 Signed, notarized `.dmg` artefacts are published to
-[GitHub Releases](https://github.com/Miragon/bpmn-vscode-modeler/releases).
+[GitHub Releases](https://github.com/Miragon/bpmn-modeler/releases).
 Look for tags matching `standalone-v*` and download the `.dmg`. Drag it
 to `/Applications` and double-click — no Gatekeeper workaround needed.
 
 The app then auto-updates from GitHub Releases on each launch.
 
 If you'd rather build from source, see
-[`apps/standalone/README.md`](https://github.com/Miragon/bpmn-vscode-modeler/blob/main/apps/standalone/README.md).
+[`apps/standalone/README.md`](https://github.com/Miragon/bpmn-modeler/blob/main/apps/standalone/README.md).
 
 ## Open a diagram
 

--- a/docs/vscode/contributing/development.md
+++ b/docs/vscode/contributing/development.md
@@ -123,7 +123,7 @@ yarn lint
 ```
 
 Coverage reports are uploaded
-to [Codecov](https://app.codecov.io/gh/Miragon/bpmn-vscode-modeler)
+to [Codecov](https://app.codecov.io/gh/Miragon/bpmn-modeler)
 on CI.
 
 ## Code Style

--- a/docs/vscode/contributing/release-process.md
+++ b/docs/vscode/contributing/release-process.md
@@ -2,7 +2,7 @@
 
 This page documents the release workflow for maintainers. The user-facing
 version history lives on
-[GitHub Releases](https://github.com/Miragon/bpmn-vscode-modeler/releases).
+[GitHub Releases](https://github.com/Miragon/bpmn-modeler/releases).
 
 ```mermaid
 flowchart LR
@@ -42,7 +42,7 @@ flowchart LR
 ## Create a new release
 
 Releases are triggered manually
-via [GitHub Actions](https://github.com/Miragon/bpmn-vscode-modeler/actions/workflows/release.yml).
+via [GitHub Actions](https://github.com/Miragon/bpmn-modeler/actions/workflows/release.yml).
 
 ### Steps
 

--- a/libs/create-append-c7-element-templates/package.json
+++ b/libs/create-append-c7-element-templates/package.json
@@ -20,11 +20,11 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/Miragon/bpmn-vscode-modeler",
+        "url": "https://github.com/Miragon/bpmn-modeler",
         "directory": "libs/create-append-c7-element-templates"
     },
     "bugs": {
-        "url": "https://github.com/Miragon/bpmn-vscode-modeler/issues"
+        "url": "https://github.com/Miragon/bpmn-modeler/issues"
     },
     "peerDependencies": {
         "bpmn-js": "18.14.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "bpmn-vscode-modeler",
+    "name": "bpmn-modeler",
     "version": "0.6.2",
     "license": "Apache-2.0",
     "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8582,9 +8582,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bpmn-vscode-modeler@workspace:.":
+"bpmn-modeler@workspace:.":
   version: 0.0.0-use.local
-  resolution: "bpmn-vscode-modeler@workspace:."
+  resolution: "bpmn-modeler@workspace:."
   dependencies:
     "@bpmn-io/form-js": "npm:1.21.2"
     "@bpmn-io/properties-panel": "npm:3.40.6"


### PR DESCRIPTION
## Summary

- Renames the GitHub repository from `bpmn-vscode-modeler` to `bpmn-modeler`
- Updates all in-repo references: `package.json` files, READMEs, CI workflows, VitePress docs config, and contributing docs

## Test plan

- [ ] Verify CI passes
- [ ] Verify docs site base path resolves correctly at `/bpmn-modeler/`