### PR TITLE
docs: rebrand extension to "BPMN Modeler" (#909)

### DIFF
--- a/.agent/skills/vscode-ux-guidelines/SKILL.md
+++ b/.agent/skills/vscode-ux-guidelines/SKILL.md
@@ -37,7 +37,7 @@ When you need **action buttons**, use the raw VS Code API directly (as `apps/mod
 ```typescript
 window
     .showInformationMessage(
-        `Camunda Modeler updated to v${current}. See what's new!`,
+        `BPMN Modeler updated to v${current}. See what's new!`,
         "View Release Notes",
     )
     .then((selection) => {

--- a/apps/modeler-plugin/package.json
+++ b/apps/modeler-plugin/package.json
@@ -4,8 +4,8 @@
         "build": "webpack --mode production",
         "dev": "webpack --mode development --watch"
     },
-    "displayName": "Camunda Modeler by Miragon",
-    "description": "Create and edit BPMN 2.0 and DMN Diagrams for Camunda 7 and Camunda 8 with VS Code.",
+    "displayName": "BPMN Modeler",
+    "description": "Create and edit BPMN 2.0 and DMN diagrams in VS Code. Supports Camunda 7 and Camunda 8.",
     "license": "SEE LICENSE IN LICENSE",
     "version": "0.9.2",
     "publisher": "miragon-gmbh",

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -139,7 +139,7 @@ function notifyIfNewRelease(context: ExtensionContext): void {
 
     window
         .showInformationMessage(
-            `Camunda Modeler updated to v${current}. See what's new!`,
+            `BPMN Modeler updated to v${current}. See what's new!`,
             "View Release Notes",
         )
         .then((selection) => {


### PR DESCRIPTION
**Issue**

Closes #909

**Description**

Rebrands the VS Code extension from *"Camunda Modeler by Miragon"* to **"BPMN Modeler"** so the product name no longer positions it as Camunda‑specific. Updates `displayName` and `description` in `apps/modeler-plugin/package.json`, and the in‑extension release notification in `apps/modeler-plugin/src/main.ts` (plus the matching example in the `vscode-ux-guidelines` skill). Camunda remains discoverable: the `keywords` array still contains `Camunda` and `Camunda Modeler`, and Camunda 7/8 are now framed as supported engines rather than part of the product identity. READMEs and VitePress docs already used `Miragon BPMN Modeler` / `BPMN VS Code Modeler` and required no further changes.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created