### PR TITLE
feat: register standalone modeler as default handler for .bpmn and .dmn files

### DIFF
--- a/apps/standalone/electron-builder.yml
+++ b/apps/standalone/electron-builder.yml
@@ -9,6 +9,17 @@ publish:
   provider: github
   owner: Miragon
   repo: bpmn-modeler
+fileAssociations:
+  - ext: bpmn
+    name: BPMN Process Model
+    description: BPMN 2.0 Process Diagram
+    mimeType: application/bpmn+xml
+    role: Editor
+  - ext: dmn
+    name: DMN Decision Model
+    description: DMN 1.3 Decision Table
+    mimeType: application/dmn+xml
+    role: Editor
 
 files:
   - lib/**/*


### PR DESCRIPTION
## Summary

- Adds `fileAssociations` block to `apps/standalone/electron-builder.yml` for `.bpmn` and `.dmn` file types
- electron-builder now generates `CFBundleDocumentTypes` (macOS), NSIS registry entries (Windows), and `.desktop` MimeType entries (Linux)
- Closes #965

## Test plan

- [ ] Build the standalone app
- [ ] On macOS: `cat "Miragon BPMN Modeler.app/Contents/Info.plist" | grep -A 20 CFBundleDocumentTypes` — verify `bpmn` and `dmn` entries appear
- [ ] Right-click a `.bpmn` file in Finder → "Open With" → Miragon BPMN Modeler should appear and be settable as default