### PR TITLE
fix(docs): colorize trailing dot in 'made for you' heading

### DIFF
--- a/docs/.vitepress/theme/components/DownloadPage.vue
+++ b/docs/.vitepress/theme/components/DownloadPage.vue
@@ -50,7 +50,7 @@ async function copyHomebrew() {
             <div class="dl-hero">
                 <h1 class="dl-h1">
                     BPMN Modeler,<br />
-                    <span class="grad">made for you</span>.
+                    <span class="grad">made for you.</span>
                 </h1>
                 <p class="dl-sub">
                     Edit BPMN and DMN files in VS Code or as a standalone


### PR DESCRIPTION
## Summary

- The period after "made for you." on the download page was black because it sat outside the `<span class="grad">` element
- Moved the dot inside the span so it receives the same blue-to-green gradient as the rest of the text

## Change

`docs/.vitepress/theme/components/DownloadPage.vue` — one character moved inside the span.