### PR TITLE
fix: Ctrl+A in properties panel + Miragon theme on standalone dev builds

### DIFF
--- a/apps/bpmn-webview/jest.config.ts
+++ b/apps/bpmn-webview/jest.config.ts
@@ -1,0 +1,9 @@
+export default {
+    displayName: "bpmn-webview",
+    testEnvironment: "jsdom",
+    transform: {
+        "^.+\\.[tj]s$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }],
+    },
+    moduleFileExtensions: ["ts", "js"],
+    coverageDirectory: "../../coverage/apps/bpmn-webview",
+};

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
@@ -1,0 +1,121 @@
+import { installContentEditableClipboardPolyfill } from "./propertiesPanelClipboard";
+
+const mocks = {
+    requestClipboard: jest.fn().mockResolvedValue(""),
+    writeClipboard: jest.fn<void, [string]>(),
+    onSelectAll: jest.fn(),
+};
+
+beforeAll(() => {
+    jest.useFakeTimers();
+    installContentEditableClipboardPolyfill(
+        () => mocks.requestClipboard(),
+        (text) => mocks.writeClipboard(text),
+        () => mocks.onSelectAll(),
+    );
+});
+
+afterAll(() => {
+    jest.useRealTimers();
+});
+
+beforeEach(() => {
+    jest.runAllTimers();
+    mocks.requestClipboard.mockReset().mockResolvedValue("");
+    mocks.writeClipboard.mockReset();
+    mocks.onSelectAll.mockReset();
+    document.body.innerHTML = "";
+});
+
+afterEach(() => {
+    jest.restoreAllMocks();
+});
+
+function focusedInput(): HTMLInputElement {
+    const el = document.createElement("input");
+    document.body.appendChild(el);
+    el.focus();
+    return el;
+}
+
+function focusedEditor(): HTMLDivElement {
+    const el = document.createElement("div");
+    el.contentEditable = "true";
+    el.tabIndex = -1;
+    document.body.appendChild(el);
+    el.focus();
+    return el;
+}
+
+function focusedDiv(): HTMLDivElement {
+    const el = document.createElement("div");
+    el.tabIndex = 0;
+    document.body.appendChild(el);
+    el.focus();
+    return el;
+}
+
+function ctrl(key: string): KeyboardEvent {
+    return new KeyboardEvent("keydown", { key, ctrlKey: true, bubbles: true });
+}
+
+describe("selecting all text in a properties-panel input (Ctrl+A)", () => {
+    it("selects all text in the field", () => {
+        const input = focusedInput();
+        const selectSpy = jest.spyOn(input, "select");
+        input.dispatchEvent(ctrl("a"));
+        expect(selectSpy).toHaveBeenCalled();
+    });
+
+    it("does not accidentally trigger diagram-element selection", () => {
+        const input = focusedInput();
+        input.dispatchEvent(ctrl("a"));
+        expect(mocks.onSelectAll).not.toHaveBeenCalled();
+    });
+});
+
+describe("selecting all elements in the diagram (Ctrl+A on the canvas)", () => {
+    it("selects all elements in the diagram", () => {
+        const canvas = focusedDiv();
+        canvas.dispatchEvent(ctrl("a"));
+        expect(mocks.onSelectAll).toHaveBeenCalled();
+    });
+});
+
+describe("copy and paste in the FEEL expression editor", () => {
+    it("Ctrl+V pastes from the extension-host clipboard into the editor", () => {
+        const editor = focusedEditor();
+        editor.dispatchEvent(ctrl("v"));
+        expect(mocks.requestClipboard).toHaveBeenCalled();
+    });
+
+    it("Ctrl+C copies the selected expression text to the extension-host clipboard", () => {
+        const editor = focusedEditor();
+        jest.spyOn(window, "getSelection").mockReturnValue({
+            toString: () => "some expression",
+        } as unknown as Selection);
+        editor.dispatchEvent(ctrl("c"));
+        expect(mocks.writeClipboard).toHaveBeenCalledWith("some expression");
+    });
+
+    it("paste does nothing when a plain element (not an editor) is focused", () => {
+        const div = focusedDiv();
+        div.dispatchEvent(ctrl("v"));
+        expect(mocks.requestClipboard).not.toHaveBeenCalled();
+    });
+});
+
+describe("paste triggered via the VS Code command palette", () => {
+    it("writes clipboard text into the focused FEEL editor", () => {
+        focusedEditor();
+        document.execCommand("paste");
+        expect(mocks.requestClipboard).toHaveBeenCalled();
+    });
+
+    it("paste only happens once when both keyboard shortcut and command palette fire", () => {
+        const editor = focusedEditor();
+        editor.dispatchEvent(ctrl("v"));
+        document.execCommand("paste");
+        expect(mocks.requestClipboard).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -1,4 +1,37 @@
 /**
+ * Handles Ctrl/Cmd+A: selects all text in focused inputs; fully intercepts
+ * the event for canvas focus and delegates element selection to onSelectAll.
+ */
+function handleSelectAll(e: KeyboardEvent, el: Element, onSelectAll?: () => void): void {
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+        e.stopPropagation();
+        e.preventDefault();
+        el.select();
+        return;
+    }
+    e.stopPropagation();
+    e.preventDefault();
+    onSelectAll?.();
+}
+
+/**
+ * Writes the current text selection to the extension-host clipboard.
+ */
+function handleCopy(writeClipboard: (text: string) => void): void {
+    const text = window.getSelection()?.toString() ?? "";
+    if (text) writeClipboard(text);
+}
+
+/**
+ * Reads from the extension-host clipboard and pastes into the target element.
+ */
+function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): void {
+    requestClipboard().then((text) => {
+        if (text) dispatchPasteOrInsert(el, text);
+    });
+}
+
+/**
  * Polyfills clipboard operations for all `contenteditable` elements in
  * VS Code webviews.
  *
@@ -13,27 +46,31 @@
  *
  * @param requestClipboard Async callback that reads clipboard text via the extension host.
  * @param writeClipboard Callback that writes text to the extension host clipboard.
+ * @param onSelectAll Called when Ctrl+A fires outside a text input (e.g. on the canvas).
  */
 export function installContentEditableClipboardPolyfill(
     requestClipboard: () => Promise<string>,
     writeClipboard: (text: string) => void,
+    onSelectAll?: () => void,
 ): void {
     let handled = false;
 
-    // ── Primary: capture-phase keydown listener ─────────────────────────
     document.addEventListener(
         "keydown",
         (e: KeyboardEvent) => {
             const el = document.activeElement;
-            if (
-                !(el instanceof HTMLElement) ||
-                el.contentEditable !== "true"
-            ) {
-                return;
-            }
+            if (!(el instanceof Element)) return;
 
             const isMod = e.metaKey || e.ctrlKey;
             if (!isMod) return;
+
+            if (e.key === "a") {
+                handleSelectAll(e, el, onSelectAll);
+                return;
+            }
+
+            if (!(el instanceof HTMLElement)) return;
+            if (el.contentEditable !== "true") return;
 
             if (e.key === "v") {
                 handled = true;
@@ -41,12 +78,7 @@ export function installContentEditableClipboardPolyfill(
                     handled = false;
                 }, 200);
                 e.preventDefault();
-
-                requestClipboard().then((text) => {
-                    if (text) {
-                        dispatchPasteOrInsert(el, text);
-                    }
-                });
+                handlePaste(el, requestClipboard);
             }
 
             if (e.key === "c") {
@@ -54,68 +86,46 @@ export function installContentEditableClipboardPolyfill(
                 setTimeout(() => {
                     handled = false;
                 }, 200);
-                const text = window.getSelection()?.toString() ?? "";
-                if (text) {
-                    writeClipboard(text);
-                }
+                handleCopy(writeClipboard);
             }
         },
-        true, // capture phase — fires before DirectEditing's stopPropagation()
+        true,
     );
 
-    // ── Secondary: execCommand polyfill (fallback) ──────────────────────
-    document.execCommand = function (
-        command: string,
-        showUI?: boolean,
-        value?: string,
-    ): boolean {
-        const el = document.activeElement;
+    const nativeExecCommand = Document.prototype.execCommand;
 
-        if (
-            el instanceof HTMLElement &&
-            el.contentEditable === "true"
-        ) {
-            if (command === "paste") {
-                if (handled) return true;
-                requestClipboard().then((text) => {
-                    if (text) {
-                        dispatchPasteOrInsert(el, text);
-                    }
-                });
-                return true;
-            }
+    Object.defineProperty(document, "execCommand", {
+        value: function (command: string, showUI?: boolean, value?: string): boolean {
+            const el = document.activeElement;
 
-            if (command === "copy") {
-                if (handled) return true;
-                const text = window.getSelection()?.toString() ?? "";
-                if (text) {
-                    writeClipboard(text);
+            if (el instanceof HTMLElement && el.contentEditable === "true") {
+                if (command === "paste") {
+                    if (handled) return true;
+                    handlePaste(el, requestClipboard);
+                    return true;
                 }
-                return true;
-            }
-        }
 
-        return Document.prototype.execCommand.call(
-            document,
-            command,
-            showUI,
-            value,
-        );
-    };
+                if (command === "copy") {
+                    if (handled) return true;
+                    handleCopy(writeClipboard);
+                    return true;
+                }
+            }
+
+            return nativeExecCommand?.call(document, command, showUI, value) ?? false;
+        },
+        writable: true,
+        configurable: true,
+    });
 }
 
 /**
  * Dispatches a synthetic `ClipboardEvent("paste")` on the target element.
- * If no JavaScript handler consumes the event (i.e. `defaultPrevented` remains
- * false), falls back to inserting the text directly via the native
- * `execCommand("insertText")`.
+ * Falls back to `execCommand("insertText")` when no JS handler consumes it.
  *
- * This two-step approach is necessary because:
- * - Editors with JS paste handlers (e.g. CodeMirror 6 / FEEL editor) consume
- *   the ClipboardEvent and handle insertion themselves.
- * - Plain contenteditable elements (e.g. diagram-js TextBox / canvas label
- *   editor) rely on the browser's native paste behavior, which does not fire
- *   for synthetic events — so we must insert the text explicitly.
+ * Editors with JS paste handlers (e.g. CodeMirror 6 / FEEL editor) consume
+ * the ClipboardEvent themselves; plain contenteditable elements (e.g.
+ * diagram-js TextBox) rely on the explicit insertText fallback.
  *
  * @param el The target contenteditable element.
  * @param text The plain text to paste.
@@ -130,10 +140,7 @@ function dispatchPasteOrInsert(el: HTMLElement, text: string): void {
     });
     el.dispatchEvent(event);
 
-    // If no JS handler consumed the paste event, insert text directly.
-    // This covers plain contenteditable elements like the canvas label editor
-    // (diagram-js TextBox) which have no JS paste handler.
     if (!event.defaultPrevented) {
-        Document.prototype.execCommand.call(document, "insertText", false, text);
+        Document.prototype.execCommand?.call(document, "insertText", false, text);
     }
 }

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -164,6 +164,10 @@ window.onload = async function () {
         installContentEditableClipboardPolyfill(
             requestTextClipboard,
             writeTextClipboard,
+            () => {
+                if (!modelerIsInitialized) return;
+                bpmnModeler.getService<any>("editorActions").trigger("selectElements");
+            },
         );
     }
 

--- a/apps/bpmn-webview/tsconfig.spec.json
+++ b/apps/bpmn-webview/tsconfig.spec.json
@@ -2,21 +2,17 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
     "types": [
-      "vitest/globals",
+      "jest",
       "node"
     ]
   },
   "include": [
-    "vite.config.mts",
+    "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
     "src/**/*.d.ts"
   ]
 }

--- a/apps/standalone/tsconfig.json
+++ b/apps/standalone/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2017",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": true,

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
 
 module.exports = [
     {
-        ignores: ["**/dist", "docs/**"],
+        ignores: ["**/dist", "**/lib", "**/src-gen", "**/plugins", "**/gen-webpack*.js", "docs/**"],
     },
     {
         plugins: {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,5 +2,6 @@ export default {
     projects: [
         "<rootDir>/apps/modeler-plugin/jest.config.ts",
         "<rootDir>/libs/bpmn-i18n/jest.config.ts",
+        "<rootDir>/apps/bpmn-webview/jest.config.ts",
     ],
 };

--- a/libs/standalone-extension/src/miragon-theme-contribution.ts
+++ b/libs/standalone-extension/src/miragon-theme-contribution.ts
@@ -19,14 +19,21 @@
  *      profiles where Theia's default won the race during startup.
  *
  * Why both `initialize()` and `onStart()` apply the theme:
- *   `initialize()` runs synchronously before first paint, so the UI never
- *   flickers in a wrong theme. `onStart()` re-asserts after the preference
- *   subsystem has loaded (which can flip the active theme back to whatever
- *   `workbench.colorTheme` was persisted last time). Without both, you
- *   either see a flash or get overridden by stale prefs.
+ *   `initialize()` runs synchronously before first paint so the UI never
+ *   flickers in a wrong theme. `onStart()` is sync (returns immediately)
+ *   and queues two non-blocking `.then()` re-assertions: one when the
+ *   `ThemeService` is initialised, and one when the preference subsystem
+ *   finishes loading — preferences can flip the active theme back to
+ *   whatever `workbench.colorTheme` was persisted last time, so we re-apply
+ *   afterwards. Awaiting either of these would block `startContributions()`
+ *   and the splash would never close. The first-run picker is deferred
+ *   to `stateService.reachedState("ready")` for the same reason — see the
+ *   docstring on `onStart()` below.
  */
 import { inject, injectable } from "@theia/core/shared/inversify";
 import { FrontendApplicationContribution } from "@theia/core/lib/browser";
+import { FrontendApplicationStateService } from "@theia/core/lib/browser/frontend-application-state";
+import { PreferenceService } from "@theia/core/lib/common/preferences";
 import { ThemeService } from "@theia/core/lib/browser/theming";
 import { QuickInputService } from "@theia/core/lib/common/quick-pick-service";
 import { MonacoThemingService } from "@theia/monaco/lib/browser/monaco-theming-service";
@@ -49,8 +56,14 @@ export class MiragonThemeContribution implements FrontendApplicationContribution
     @inject(ThemeService)
     protected readonly themeService!: ThemeService;
 
+    @inject(PreferenceService)
+    protected readonly preferences!: PreferenceService;
+
     @inject(QuickInputService)
     protected readonly quickInputService!: QuickInputService;
+
+    @inject(FrontendApplicationStateService)
+    protected readonly stateService!: FrontendApplicationStateService;
 
     initialize(): void {
         this.monacoThemingService.registerParsedTheme({
@@ -71,14 +84,26 @@ export class MiragonThemeContribution implements FrontendApplicationContribution
         this.ensureMiragonTheme();
     }
 
-    async onStart(): Promise<void> {
-        // After preferences finish loading they may have flipped the theme
-        // back to a stored Theia default. Re-assert if so.
-        await this.themeService.initialized;
-        this.ensureMiragonTheme();
+    /**
+     * Re-asserts the Miragon theme after preferences load. Uses a non-blocking
+     * `.then()` so `ThemeService.validateActiveTheme()` (registered earlier)
+     * runs first and our override wins without deadlocking Theia's startup.
+     *
+     * The first-run picker is deferred until the application reaches the
+     * `'ready'` state. If we awaited it here, `startContributions()` would
+     * block on `quickInputService.showQuickPick(...)`, the main window would
+     * stay hidden behind the splash, and the user would have no way to
+     * dismiss the (invisible) picker — the splash would spin until the
+     * 30 s `maxDuration` fallback closes it.
+     */
+    onStart(): void {
+        this.themeService.initialized.then(() => this.ensureMiragonTheme());
+        this.preferences.ready.then(() => this.ensureMiragonTheme());
 
         if (!window.localStorage.getItem(FIRST_RUN_KEY)) {
-            await this.promptInitialThemeChoice();
+            this.stateService
+                .reachedState("ready")
+                .then(() => this.promptInitialThemeChoice());
         }
     }
 

--- a/libs/standalone-extension/tsconfig.json
+++ b/libs/standalone-extension/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "commonjs",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
     "outDir": "lib",
     "rootDir": "src",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "eslint": "10.2.1",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-prettier": "5.5.5",
+        "jest-environment-jsdom": "30.3.0",
         "npm-run-all": "4.1.5",
         "prettier": "3.8.3",
         "typescript": "6.0.3",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,5 +29,5 @@
             "@miragon/create-append-c7-element-templates": ["./libs/create-append-c7-element-templates/src/index.ts"]
         }
     },
-    "exclude": ["node_modules", "tmp"]
+    "exclude": ["node_modules", "tmp", "dist", "**/lib", "**/src-gen"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,6 +229,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@asamuzakjp/css-color@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@asamuzakjp/css-color@npm:3.2.0"
+  dependencies:
+    "@csstools/css-calc": "npm:^2.1.3"
+    "@csstools/css-color-parser": "npm:^3.0.9"
+    "@csstools/css-parser-algorithms": "npm:^3.0.4"
+    "@csstools/css-tokenizer": "npm:^3.0.3"
+    lru-cache: "npm:^10.4.3"
+  checksum: 10c0/a4bf1c831751b1fae46b437e37e8a38c0b5bd58d23230157ae210bd1e905fe509b89b7c243e63d1522d852668a6292ed730a160e21342772b4e5b7b8ea14c092
+  languageName: node
+  linkType: hard
+
 "@azure/abort-controller@npm:^2.0.0, @azure/abort-controller@npm:^2.1.2":
   version: 2.1.2
   resolution: "@azure/abort-controller@npm:2.1.2"
@@ -2352,6 +2365,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/color-helpers@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@csstools/color-helpers@npm:5.1.0"
+  checksum: 10c0/b7f99d2e455cf1c9b41a67a5327d5d02888cd5c8802a68b1887dffef537d9d4bc66b3c10c1e62b40bbed638b6c1d60b85a232f904ed7b39809c4029cb36567db
+  languageName: node
+  linkType: hard
+
+"@csstools/css-calc@npm:^2.1.3, @csstools/css-calc@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "@csstools/css-calc@npm:2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/42ce5793e55ec4d772083808a11e9fb2dfe36db3ec168713069a276b4c3882205b3507c4680224c28a5d35fe0bc2d308c77f8f2c39c7c09aad8747708eb8ddd8
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^3.0.9":
+  version: 3.1.0
+  resolution: "@csstools/css-color-parser@npm:3.1.0"
+  dependencies:
+    "@csstools/color-helpers": "npm:^5.1.0"
+    "@csstools/css-calc": "npm:^2.1.4"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.5
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/0e0c670ad54ec8ec4d9b07568b80defd83b9482191f5e8ca84ab546b7be6db5d7cc2ba7ac9fae54488b129a4be235d6183d3aab4416fec5e89351f73af4222c5
+  languageName: node
+  linkType: hard
+
+"@csstools/css-parser-algorithms@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.5"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^3.0.4
+  checksum: 10c0/d9a1c888bd43849ae3437ca39251d5c95d2c8fd6b5ccdb7c45491dfd2c1cbdc3075645e80901d120e4d2c1993db9a5b2d83793b779dbbabcfb132adb142eb7f7
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^3.0.3":
+  version: 3.0.4
+  resolution: "@csstools/css-tokenizer@npm:3.0.4"
+  checksum: 10c0/3b589f8e9942075a642213b389bab75a2d50d05d203727fcdac6827648a5572674caff07907eff3f9a2389d86a4ee47308fafe4f8588f4a77b7167c588d2559f
+  languageName: node
+  linkType: hard
+
 "@develar/schema-utils@npm:~2.6.5":
   version: 2.6.5
   resolution: "@develar/schema-utils@npm:2.6.5"
@@ -3072,6 +3131,27 @@ __metadata:
   version: 30.3.0
   resolution: "@jest/diff-sequences@npm:30.3.0"
   checksum: 10c0/8922c16a869b839b6c05f677023b3e5a9aa1610ad78a9c5ec8bd6654e35e8136ea1c7b60ad561910e2ad964bfdb0b09b0254ff8dcfacd4562095766f60c63d76
+  languageName: node
+  linkType: hard
+
+"@jest/environment-jsdom-abstract@npm:30.3.0":
+  version: 30.3.0
+  resolution: "@jest/environment-jsdom-abstract@npm:30.3.0"
+  dependencies:
+    "@jest/environment": "npm:30.3.0"
+    "@jest/fake-timers": "npm:30.3.0"
+    "@jest/types": "npm:30.3.0"
+    "@types/jsdom": "npm:^21.1.7"
+    "@types/node": "npm:*"
+    jest-mock: "npm:30.3.0"
+    jest-util: "npm:30.3.0"
+  peerDependencies:
+    canvas: ^3.0.0
+    jsdom: "*"
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 10c0/95ec44bc3cc4cf91660acd4bf7da547414a1d797a32442dd6c4f6d47c82bb4b6eb2ee6b7a5d177d0827378793433a743462d24f5e445075b69edfbc28ab5ca40
   languageName: node
   linkType: hard
 
@@ -6089,6 +6169,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsdom@npm:^21.1.7":
+  version: 21.1.7
+  resolution: "@types/jsdom@npm:21.1.7"
+  dependencies:
+    "@types/node": "npm:*"
+    "@types/tough-cookie": "npm:*"
+    parse5: "npm:^7.0.0"
+  checksum: 10c0/c0c0025adc2b193e85453eeeea168bb909f0ebad08d6552be7474a407e9c163db8f696dcf1e3cbe8cb9c9d970ba45f4386171794509c1a0fe5d1fed72c91679d
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -6398,6 +6489,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/1ee17888b0532f9907788e3e9d60ef25fd5e376c4a09b40aa6ece407fa67ad3d11d25780914ed6360e50451d3039a4e248696c780dcba410779c2d37842afd19
+  languageName: node
+  linkType: hard
+
+"@types/tough-cookie@npm:*":
+  version: 4.0.5
+  resolution: "@types/tough-cookie@npm:4.0.5"
+  checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
   languageName: node
   linkType: hard
 
@@ -8728,6 +8826,7 @@ __metadata:
     eslint: "npm:10.2.1"
     eslint-config-prettier: "npm:10.1.8"
     eslint-plugin-prettier: "npm:5.5.5"
+    jest-environment-jsdom: "npm:30.3.0"
     npm-run-all: "npm:4.1.5"
     prettier: "npm:3.8.3"
     typescript: "npm:6.0.3"
@@ -10126,6 +10225,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssstyle@npm:^4.2.1":
+  version: 4.6.0
+  resolution: "cssstyle@npm:4.6.0"
+  dependencies:
+    "@asamuzakjp/css-color": "npm:^3.2.0"
+    rrweb-cssom: "npm:^0.8.0"
+  checksum: 10c0/71add1b0ffafa1bedbef6855db6189b9523d3320e015a0bf3fbd504760efb9a81e1f1a225228d5fa892ee58e56d06994ca372e7f4e461cda7c4c9985fe075f65
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.2.2, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
@@ -10539,6 +10648,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-urls@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "data-urls@npm:5.0.0"
+  dependencies:
+    whatwg-mimetype: "npm:^4.0.0"
+    whatwg-url: "npm:^14.0.0"
+  checksum: 10c0/1b894d7d41c861f3a4ed2ae9b1c3f0909d4575ada02e36d3d3bc584bdd84278e20709070c79c3b3bff7ac98598cb191eb3e86a89a79ea4ee1ef360e1694f92ad
+  languageName: node
+  linkType: hard
+
 "data-view-buffer@npm:^1.0.1":
   version: 1.0.1
   resolution: "data-view-buffer@npm:1.0.1"
@@ -10632,6 +10751,13 @@ __metadata:
   version: 4.0.0
   resolution: "decamelize@npm:4.0.0"
   checksum: 10c0/e06da03fc05333e8cd2778c1487da67ffbea5b84e03ca80449519b8fa61f888714bbc6f459ea963d5641b4aa98832130eb5cd193d90ae9f0a27eee14be8e278d
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.5.0":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 10c0/07d69fbcc54167a340d2d97de95f546f9ff1f69d2b45a02fd7a5292412df3cd9eb7e23065e532a318f5474a2e1bccf8392fdf0443ef467f97f3bf8cb0477e5aa
   languageName: node
   linkType: hard
 
@@ -13538,6 +13664,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-encoding-sniffer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "html-encoding-sniffer@npm:4.0.0"
+  dependencies:
+    whatwg-encoding: "npm:^3.1.1"
+  checksum: 10c0/523398055dc61ac9b34718a719cb4aa691e4166f29187e211e1607de63dc25ac7af52ca7c9aead0c4b3c0415ffecb17326396e1202e2e86ff4bca4c0ee4c6140
+  languageName: node
+  linkType: hard
+
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -13613,7 +13748,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.1":
+"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.1, http-proxy-agent@npm:^7.0.2":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -14211,6 +14346,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-potential-custom-element-name@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-potential-custom-element-name@npm:1.0.1"
+  checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
+  languageName: node
+  linkType: hard
+
 "is-promise@npm:^4.0.0":
   version: 4.0.0
   resolution: "is-promise@npm:4.0.0"
@@ -14627,6 +14769,22 @@ __metadata:
     jest-util: "npm:30.3.0"
     pretty-format: "npm:30.3.0"
   checksum: 10c0/d23d2b43b3ea42beaf99648e2cf1c74b8a13c3e45c7c882979171471c225f7d666cb4a0d5f1ff9031b4504866fa3badc7266ffd885d3d8035420c559a31501e1
+  languageName: node
+  linkType: hard
+
+"jest-environment-jsdom@npm:30.3.0":
+  version: 30.3.0
+  resolution: "jest-environment-jsdom@npm:30.3.0"
+  dependencies:
+    "@jest/environment": "npm:30.3.0"
+    "@jest/environment-jsdom-abstract": "npm:30.3.0"
+    jsdom: "npm:^26.1.0"
+  peerDependencies:
+    canvas: ^3.0.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 10c0/1d9a288c847dc7d3fe0ac4bd494fa5f78581d5f7f1f28fd1f58073634f139b6e4d13d1ea1bbed8e68693f45b74279fb7ea002dd453faa98ab6ab657c443cc0ce
   languageName: node
   linkType: hard
 
@@ -15049,6 +15207,39 @@ __metadata:
   version: 2.3.0
   resolution: "jschardet@npm:2.3.0"
   checksum: 10c0/990b54b2a28d587cc3182eb2f4f93190ec803223cb22e346e016f489cfa6befbeed5ba609e263f38d1a5da168cddc4b73407c09a816847f2fdc1c1a3fd063ef1
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:^26.1.0":
+  version: 26.1.0
+  resolution: "jsdom@npm:26.1.0"
+  dependencies:
+    cssstyle: "npm:^4.2.1"
+    data-urls: "npm:^5.0.0"
+    decimal.js: "npm:^10.5.0"
+    html-encoding-sniffer: "npm:^4.0.0"
+    http-proxy-agent: "npm:^7.0.2"
+    https-proxy-agent: "npm:^7.0.6"
+    is-potential-custom-element-name: "npm:^1.0.1"
+    nwsapi: "npm:^2.2.16"
+    parse5: "npm:^7.2.1"
+    rrweb-cssom: "npm:^0.8.0"
+    saxes: "npm:^6.0.0"
+    symbol-tree: "npm:^3.2.4"
+    tough-cookie: "npm:^5.1.1"
+    w3c-xmlserializer: "npm:^5.0.0"
+    webidl-conversions: "npm:^7.0.0"
+    whatwg-encoding: "npm:^3.1.1"
+    whatwg-mimetype: "npm:^4.0.0"
+    whatwg-url: "npm:^14.1.1"
+    ws: "npm:^8.18.0"
+    xml-name-validator: "npm:^5.0.0"
+  peerDependencies:
+    canvas: ^3.0.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 10c0/5b14a5bc32ce077a06fb42d1ab95b1191afa5cbbce8859e3b96831c5143becbbcbf0511d4d4934e922d2901443ced2cdc3b734c1cf30b5f73b3e067ce457d0f4
   languageName: node
   linkType: hard
 
@@ -15787,7 +15978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
+"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0, lru-cache@npm:^10.4.3":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
   checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
@@ -17011,6 +17202,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nwsapi@npm:^2.2.16":
+  version: 2.2.23
+  resolution: "nwsapi@npm:2.2.23"
+  checksum: 10c0/e44bfc9246baf659581206ed716d291a1905185247795fb8a302cb09315c943a31023b4ac4d026a5eaf32b2def51d77b3d0f9ebf4f3d35f70e105fcb6447c76e
+  languageName: node
+  linkType: hard
+
 "object-assign@npm:^4, object-assign@npm:^4.0.1, object-assign@npm:^4.1.1":
   version: 4.1.1
   resolution: "object-assign@npm:4.1.1"
@@ -17374,7 +17572,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^7.0.0, parse5@npm:^7.3.0":
+"parse5@npm:^7.0.0, parse5@npm:^7.2.1, parse5@npm:^7.3.0":
   version: 7.3.0
   resolution: "parse5@npm:7.3.0"
   dependencies:
@@ -18113,7 +18311,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
@@ -18960,6 +19158,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rrweb-cssom@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rrweb-cssom@npm:0.8.0"
+  checksum: 10c0/56f2bfd56733adb92c0b56e274c43f864b8dd48784d6fe946ef5ff8d438234015e59ad837fc2ad54714b6421384141c1add4eb569e72054e350d1f8a50b8ac7b
+  languageName: node
+  linkType: hard
+
 "run-applescript@npm:^7.0.0":
   version: 7.1.0
   resolution: "run-applescript@npm:7.1.0"
@@ -19047,6 +19252,15 @@ __metadata:
   version: 11.0.2
   resolution: "saxen@npm:11.0.2"
   checksum: 10c0/9ca99fb956e57aef2fcf5fe3376343e4ff8bb991475c7320fe741a3b41b24ce077e6a0923be7bae0953ac70ba918f7f87c5d8877dd363506ca8a828a2ca3a0c1
+  languageName: node
+  linkType: hard
+
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
+  dependencies:
+    xmlchars: "npm:^2.2.0"
+  checksum: 10c0/3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
   languageName: node
   linkType: hard
 
@@ -20160,6 +20374,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"symbol-tree@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "symbol-tree@npm:3.2.4"
+  checksum: 10c0/dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
+  languageName: node
+  linkType: hard
+
 "synckit@npm:^0.11.12, synckit@npm:^0.11.8":
   version: 0.11.12
   resolution: "synckit@npm:0.11.12"
@@ -20494,6 +20715,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tldts-core@npm:^6.1.86":
+  version: 6.1.86
+  resolution: "tldts-core@npm:6.1.86"
+  checksum: 10c0/8133c29375f3f99f88fce5f4d62f6ecb9532b106f31e5423b27c1eb1b6e711bd41875184a456819ceaed5c8b94f43911b1ad57e25c6eb86e1fc201228ff7e2af
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^6.1.32":
+  version: 6.1.86
+  resolution: "tldts@npm:6.1.86"
+  dependencies:
+    tldts-core: "npm:^6.1.86"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/27ae7526d9d78cb97b2de3f4d102e0b4321d1ccff0648a7bb0e039ed54acbce86bacdcd9cd3c14310e519b457854e7bafbef1f529f58a1e217a737ced63f0940
+  languageName: node
+  linkType: hard
+
 "tmp-promise@npm:^3.0.2":
   version: 3.0.3
   resolution: "tmp-promise@npm:3.0.3"
@@ -20548,6 +20787,24 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^5.1.1":
+  version: 5.1.2
+  resolution: "tough-cookie@npm:5.1.2"
+  dependencies:
+    tldts: "npm:^6.1.32"
+  checksum: 10c0/5f95023a47de0f30a902bba951664b359725597d8adeabc66a0b93a931c3af801e1e697dae4b8c21a012056c0ea88bd2bf4dfe66b2adcf8e2f42cd9796fe0626
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^5.1.0":
+  version: 5.1.1
+  resolution: "tr46@npm:5.1.1"
+  dependencies:
+    punycode: "npm:^2.3.1"
+  checksum: 10c0/ae270e194d52ec67ebd695c1a42876e0f19b96e4aca2ab464ab1d9d17dc3acd3e18764f5034c93897db73421563be27c70c98359c4501136a497e46deda5d5ec
   languageName: node
   linkType: hard
 
@@ -21936,6 +22193,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"w3c-xmlserializer@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "w3c-xmlserializer@npm:5.0.0"
+  dependencies:
+    xml-name-validator: "npm:^5.0.0"
+  checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
+  languageName: node
+  linkType: hard
+
 "walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
@@ -21952,6 +22218,13 @@ __metadata:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
   checksum: 10c0/dffbb483d1f61be90dc570630a1eb308581e2227d507d783b1d94a57ac7b705ecd9a1a4b73d73c15eab596d39874e5276a3d9cb88bbb698bafc3f8d08c34cf17
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "webidl-conversions@npm:7.0.0"
+  checksum: 10c0/228d8cb6d270c23b0720cb2d95c579202db3aaf8f633b4e9dd94ec2000a04e7e6e43b76a94509cdb30479bd00ae253ab2371a2da9f81446cc313f89a4213a2c4
   languageName: node
   linkType: hard
 
@@ -22065,6 +22338,16 @@ __metadata:
   version: 4.0.0
   resolution: "whatwg-mimetype@npm:4.0.0"
   checksum: 10c0/a773cdc8126b514d790bdae7052e8bf242970cebd84af62fb2f35a33411e78e981f6c0ab9ed1fe6ec5071b09d5340ac9178e05b52d35a9c4bcf558ba1b1551df
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^14.0.0, whatwg-url@npm:^14.1.1":
+  version: 14.2.0
+  resolution: "whatwg-url@npm:14.2.0"
+  dependencies:
+    tr46: "npm:^5.1.0"
+    webidl-conversions: "npm:^7.0.0"
+  checksum: 10c0/f746fc2f4c906607d09537de1227b13f9494c171141e5427ed7d2c0dd0b6a48b43d8e71abaae57d368d0c06b673fd8ec63550b32ad5ed64990c7b0266c2b4272
   languageName: node
   linkType: hard
 
@@ -22356,6 +22639,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-name-validator@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "xml-name-validator@npm:5.0.0"
+  checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
+  languageName: node
+  linkType: hard
+
 "xml2js@npm:^0.5.0":
   version: 0.5.0
   resolution: "xml2js@npm:0.5.0"
@@ -22377,6 +22667,13 @@ __metadata:
   version: 11.0.1
   resolution: "xmlbuilder@npm:11.0.1"
   checksum: 10c0/74b979f89a0a129926bc786b913459bdbcefa809afaa551c5ab83f89b1915bdaea14c11c759284bb9b931e3b53004dbc2181e21d3ca9553eeb0b2a7b4e40c35b
+  languageName: node
+  linkType: hard
+
+"xmlchars@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "xmlchars@npm:2.2.0"
+  checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **fix(webview):** Ctrl+A in the element ID input field no longer selects all canvas elements. A capture-phase keydown guard intercepts `Ctrl/Cmd+A` when an `<input>` or `<textarea>` is focused, stopping propagation before bpmn-js's keyboard handler fires. Closes #972.
- **fix(standalone):** Miragon theme now applies correctly in `yarn workspace @miragon/bpmn-modeler-standalone dev` builds. In dev mode, Theia generates async `import()` chunks (vs synchronous `require()` in prod), making the preference system resolve late — after `onStart()` had already set the Miragon theme, `ThemeService.validateActiveTheme()` would overwrite it. A second `ensureMiragonTheme()` call scheduled via `preferences.ready.then()` (non-blocking, runs after `validateActiveTheme()`) fixes the race.
- **fix(lint):** `yarn lint` was OOMing (~4 GB) in the pre-push hook because `@typescript-eslint/parser` loaded `tsconfig.base.json` without excluding compiled output. Added `**/lib`, `**/src-gen`, `**/plugins`, and `**/gen-webpack*.js` to the ESLint global ignores, and added `dist`, `**/lib`, `**/src-gen` to `tsconfig.base.json`'s `exclude` so the TypeScript parser doesn't pull generated files into its type program.

## Test plan

- [ ] Open a BPMN diagram, click an element, focus the **ID** field, press `Ctrl+A` → only the text in the field should be selected; no canvas elements should be selected
- [ ] Verify `Ctrl+C` / `Ctrl+V` still work in the ID field
- [ ] Verify `Ctrl+A` on the canvas (no input focused) still selects all elements
- [ ] Run `corepack yarn workspace @miragon/bpmn-modeler-standalone dev` → Miragon Light or Dark theme should be active on launch (no generic Theia grey)
- [ ] Relaunch the standalone dev build → chosen theme persists
- [ ] `corepack yarn lint` completes without OOM
- [ ] `corepack yarn test` passes