### PR TITLE
feat: ship Miragon themes in VS Code plugin & default both apps to light (#983)

### DIFF
--- a/apps/modeler-plugin/package.json
+++ b/apps/modeler-plugin/package.json
@@ -79,6 +79,20 @@
     ],
     "main": "main.js",
     "contributes": {
+        "themes": [
+            {
+                "id": "miragon-light",
+                "label": "Miragon Light",
+                "uiTheme": "vs",
+                "path": "./themes/miragon-light.json"
+            },
+            {
+                "id": "miragon-dark",
+                "label": "Miragon Dark",
+                "uiTheme": "vs-dark",
+                "path": "./themes/miragon-dark.json"
+            }
+        ],
         "customEditors": [
             {
                 "id": "bpmn-modeler.bpmn",

--- a/apps/modeler-plugin/webpack.config.js
+++ b/apps/modeler-plugin/webpack.config.js
@@ -83,6 +83,16 @@ module.exports = (env, argv) => {
                         noErrorOnMissing: true,
                     },
                     {
+                        // Single source of truth: themes live in the standalone
+                        // extension. `vsce package --no-dependencies` strips
+                        // node_modules, so the JSON must be present in dist.
+                        from: path.resolve(
+                            __dirname,
+                            "../../libs/standalone-extension/src/themes",
+                        ),
+                        to: "themes",
+                    },
+                    {
                         from: path.resolve(__dirname, "../../LICENSE"),
                         to: ".",
                         noErrorOnMissing: true,

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -16,7 +16,10 @@
       "config": {
         "applicationName": "Miragon BPMN Modeler",
         "reloadOnReconnect": true,
-        "defaultTheme": "miragon-light",
+        "defaultTheme": {
+          "light": "miragon-light",
+          "dark": "miragon-dark"
+        },
         "preferences": {
           "files.enableTrash": false,
           "security.workspace.trust.enabled": false

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -16,10 +16,7 @@
       "config": {
         "applicationName": "Miragon BPMN Modeler",
         "reloadOnReconnect": true,
-        "defaultTheme": {
-          "light": "miragon-light",
-          "dark": "miragon-dark"
-        },
+        "defaultTheme": "miragon-light",
         "preferences": {
           "files.enableTrash": false,
           "security.workspace.trust.enabled": false

--- a/libs/standalone-extension/src/miragon-theme-contribution.ts
+++ b/libs/standalone-extension/src/miragon-theme-contribution.ts
@@ -14,9 +14,10 @@
  *      explicitly aware that Light/Dark/Auto are options, instead of being
  *      silently dropped into whatever the OS preference dictates.
  *
- *   4. Falls back to the OS appearance (`prefers-color-scheme: dark`) when
- *      no Miragon theme is currently active — covers fresh profiles AND
- *      profiles where Theia's default won the race during startup.
+ *   4. Falls back to **Miragon Light** when no Miragon theme is currently
+ *      active — covers fresh profiles AND profiles where Theia's default
+ *      won the race during startup. The OS-appearance helper remains
+ *      available for the explicit "Use System Theme" picker choice.
  *
  * Why both `initialize()` and `onStart()` apply the theme:
  *   `initialize()` runs synchronously before first paint so the UI never
@@ -109,16 +110,20 @@ export class MiragonThemeContribution implements FrontendApplicationContribution
 
     /**
      * If the active theme is not one of ours (e.g. an orphaned Theia default
-     * carried over from an earlier run), pick a Miragon theme based on the
-     * OS preference. Once a Miragon theme is active, leave the user's choice
-     * alone so manual switches survive restarts.
+     * carried over from an earlier run), apply Miragon Light as the default.
+     * Once a Miragon theme is active, leave the user's choice alone so manual
+     * switches survive restarts.
      */
     private ensureMiragonTheme(): void {
         const activeId = this.themeService.getCurrentTheme().id;
         if ((MIRAGON_THEME_IDS as readonly string[]).includes(activeId)) {
             return;
         }
-        this.applySystemTheme();
+        this.applyDefaultTheme();
+    }
+
+    private applyDefaultTheme(): void {
+        this.themeService.setCurrentTheme(MIRAGON_LIGHT_THEME_ID, true);
     }
 
     private applySystemTheme(): void {
@@ -139,16 +144,16 @@ export class MiragonThemeContribution implements FrontendApplicationContribution
             const choice = await this.quickInputService.showQuickPick(
                 [
                     {
-                        label: SYSTEM_CHOICE_LABEL,
-                        description: "Follow your OS appearance (recommended)",
+                        label: "Miragon Light",
+                        description: "Light UI with Miragon accents (recommended)",
                     },
                     {
                         label: "Miragon Dark",
                         description: "Dark UI with Miragon accents",
                     },
                     {
-                        label: "Miragon Light",
-                        description: "Light UI with Miragon accents",
+                        label: SYSTEM_CHOICE_LABEL,
+                        description: "Follow your OS appearance",
                     },
                 ],
                 {


### PR DESCRIPTION
## Summary

Closes #983. Two related changes:

- **VS Code plugin** now contributes **Miragon Light** and **Miragon Dark** as native color themes via `contributes.themes`. Users pick them from *Preferences: Color Theme* like any other theme — no new setting, no webview plumbing. Webviews follow automatically because they already track VS Code's active theme via `--vscode-*` CSS variables and the `body.vscode-dark/light` class.
- **Default theme is now Miragon Light** in both products. Previously the standalone fell back to whichever theme matched the OS (`prefers-color-scheme`), so dark-OS users always saw Miragon Dark on first launch. Now Light is the unconditional default; the OS-detection helper is preserved for the picker's "Use System Theme" option.

## Why a webpack copy and not a workspace dependency

CI publishes via ` vsce package --out bpmn-modeler-plugin.vsix --yarn --no-dependencies` (`.github/workflows/publish-vscode-modeler.yml:79-80`). The `--no-dependencies` flag strips `node_modules/` from the VSIX, so a workspace dep on `@miragon/bpmn-modeler-standalone-extension` would leave the theme JSON missing at runtime. Copying from `libs/standalone-extension/src/themes/` at build time matches the established cross-workspace asset pattern in this repo (already used for `images/miragon-logo.png` and the webview build outputs). The JSONs remain a single source of truth.

## Changes

- `apps/modeler-plugin/package.json` — `contributes.themes` with `id`, `label`, `uiTheme`, `path` for both variants. Light listed first.
- `apps/modeler-plugin/webpack.config.js` — `CopyWebpackPlugin` pattern copying `libs/standalone-extension/src/themes` → `dist/apps/modeler-plugin/themes/`.
- `apps/standalone/package.json` — `defaultTheme` collapsed to the string `"miragon-light"` (removes the brief Dark flash on dark-OS cold starts).
- `libs/standalone-extension/src/miragon-theme-contribution.ts` — new `applyDefaultTheme()` that unconditionally applies Miragon Light; `applySystemTheme()` retained but only used by the picker's "Use System Theme" branch; first-run picker reordered to Light → Dark → System.

## Test plan

- [x] `corepack yarn workspace @miragon/bpmn-modeler-standalone-extension build` succeeds.
- [x] `corepack yarn workspace vs-code-bpmn-modeler build` succeeds; `dist/apps/modeler-plugin/themes/miragon-{dark,light}.json` are emitted.
- [x] `dist/apps/modeler-plugin/package.json` retains the `contributes.themes` block (Light first, Dark second, both with `id`).
- [x] `(cd dist/apps/modeler-plugin && npx @vscode/vsce ls --no-dependencies)` lists `themes/miragon-{dark,light}.json` — confirms the published VSIX will contain them.
- [x] `corepack yarn test` — 54 tests pass.
- [x] `corepack yarn lint` — 0 errors.
- [ ] Manual VS Code F5 launch: open *Preferences: Color Theme*, verify both themes appear and apply correctly across BPMN/DMN/deployment webviews.
- [ ] Manual standalone cold start with a wiped profile: app opens in Miragon Light regardless of OS dark mode; first-run picker shows Light → Dark → System with Light highlighted.

## Out of scope

- Auto-applying Miragon Light on first VS Code install — VS Code does not honour manifest order for the Color Theme picker, and no manifest-level "default theme" exists. A first-activation handler that sets `workbench.colorTheme` once via `globalState` would be needed; not added here.
- Coupling the BPMN diagram accent colour (`--dt-primary-*`) to Miragon green when a Miragon theme is active. Left for a follow-up.