### PR TITLE
chore(standalone): reset version to 0.0.1

### DIFF
--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -3,7 +3,7 @@
   "name": "@miragon/bpmn-modeler-standalone",
   "description": "Miragon BPMN Modeler — standalone Theia-based Electron desktop app",
   "productName": "Miragon BPMN Modeler",
-  "version": "0.9.2",
+  "version": "0.0.1",
   "main": "scripts/theia-electron-main.js",
   "license": "Apache-2.0",
   "author": "Miragon",

--- a/libs/standalone-extension/package.json
+++ b/libs/standalone-extension/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@miragon/bpmn-modeler-standalone-extension",
-  "version": "0.9.2",
+  "version": "0.0.1",
   "description": "Theia frontend extension contributing Miragon themes and view overrides for @miragon/bpmn-modeler-standalone.",
   "license": "Apache-2.0",
   "main": "lib/frontend-module.js",


### PR DESCRIPTION
## Summary

Wipe the previously published `standalone-v0.9.2` (a test release, no users) and restart the standalone app's version line at `0.0.1`. This PR is just the in-repo version reset; the matching cleanup steps run outside the repo.

- `apps/standalone/package.json`: `0.9.2` → `0.0.1`
- `libs/standalone-extension/package.json`: `0.9.2` → `0.0.1`

## Follow-up steps (manual, after merge)

1. Delete the GitHub release + tag: `gh release delete standalone-v0.9.2 --cleanup-tag --yes`
2. Delete the Cask formula in `Miragon/homebrew-tap`: `git rm Casks/miragon-bpmn-modeler.rb`
3. Tag and create release `standalone-v0.0.1` from main — the existing publish + homebrew workflows handle the DMG, electron-updater metadata, and Cask regeneration automatically.

## Test plan

- [ ] CI passes
- [ ] After merge: `git show origin/main:apps/standalone/package.json | grep version` → `0.0.1`
- [ ] After follow-up step 3: `gh release view standalone-v0.0.1` shows DMG + `latest-mac.yml` artifacts
- [ ] After follow-up step 3: `Miragon/homebrew-tap` `Casks/miragon-bpmn-modeler.rb` shows `version "0.0.1"` with a fresh sha256