### PR TITLE
ci: manual-only publish across all release pipes + raise standalone heap

### DIFF
--- a/.github/workflows/publish-create-append-c7.yml
+++ b/.github/workflows/publish-create-append-c7.yml
@@ -1,13 +1,10 @@
 name: Publish create-append-c7-element-templates
 
-# Builds and publishes @miragon/create-append-c7-element-templates
-# to npm when a GitHub Release with a create-append-c7-element-templates/v*
-# tag is published. Also supports a manual workflow_dispatch with a
-# dry-run option (npm publish --dry-run).
+# Builds and publishes @miragon/create-append-c7-element-templates to npm.
+# Manual workflow_dispatch only; uses the version in
+# libs/create-append-c7-element-templates/package.json.
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       dry-run:
@@ -27,7 +24,6 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'create-append-c7-element-templates/'))
 
     steps:
       - name: Checkout
@@ -52,28 +48,18 @@ jobs:
       - name: Install dependencies (focused)
         run: yarn workspaces focus bpmn-modeler @miragon/create-append-c7-element-templates
 
-      - name: Verify package.json version matches tag
-        if: github.event_name == 'release'
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          TAG_VERSION="${TAG#create-append-c7-element-templates/v}"
-          PKG_VERSION=$(node -e "console.log(require('./libs/create-append-c7-element-templates/package.json').version)")
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "package.json version ($PKG_VERSION) does not match release tag ($TAG_VERSION)." && exit 1
-          fi
-
       - name: Build library
         run: yarn workspace @miragon/create-append-c7-element-templates build
 
       - name: Dry-run publish
-        if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
+        if: inputs.dry-run == true
         working-directory: libs/create-append-c7-element-templates
         run: npm publish --access public --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
+        if: inputs.dry-run == false
         working-directory: libs/create-append-c7-element-templates
         run: npm publish --access public
         env:

--- a/.github/workflows/publish-standalone-homebrew.yml
+++ b/.github/workflows/publish-standalone-homebrew.yml
@@ -3,20 +3,16 @@ name: Publish Standalone (Homebrew)
 # Updates the Cask formula in Miragon/homebrew-tap after a standalone release.
 #
 # Triggers:
-#   - Automatically after release-standalone.yml completes successfully
 #   - Manually via workflow_dispatch (supports dry_run for testing without pushing)
 #
 # Required GitHub repo secret:
 #   HOMEBREW_TAP_TOKEN   PAT with repo scope on Miragon/homebrew-tap
 
 on:
-  workflow_run:
-    workflows: ["Publish Standalone (macOS)"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. standalone-v0.9.2)"
+        description: "Release tag (e.g. standalone-v0.0.1)"
         required: true
         type: string
       dry_run:
@@ -30,26 +26,15 @@ jobs:
   update-tap:
     name: Update Cask formula
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
     steps:
       - name: Resolve tag and version
         id: meta
         env:
-          EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
         run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            TAG="$INPUT_TAG"
-          else
-            # publish-standalone.yml is triggered by release:published, so
-            # head_branch is unreliable — fetch the latest standalone-v* release directly
-            TAG=$(gh api "repos/$GH_REPO/releases" \
-              --jq '[.[] | select(.tag_name | startswith("standalone-v"))][0].tag_name')
-          fi
+          TAG="$INPUT_TAG"
           VERSION="${TAG#standalone-v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -91,7 +76,7 @@ jobs:
           cat miragon-bpmn-modeler.rb
 
       - name: Push to homebrew-tap
-        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
+        if: ${{ !inputs.dry_run }}
         env:
           VERSION: ${{ steps.meta.outputs.version }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -1,8 +1,6 @@
 name: Publish Standalone (macOS)
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       dry-run:
@@ -22,7 +20,6 @@ jobs:
   publish-macos:
     name: Build, sign, notarize, publish (macOS)
     runs-on: macos-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'standalone-v'))
 
     steps:
       - name: Checkout sources
@@ -41,16 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Verify package.json version matches tag
-        if: github.event_name == 'release'
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          TAG_VERSION="${TAG#standalone-v}"
-          PKG_VERSION=$(node -e "console.log(require('./apps/standalone/package.json').version)")
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "apps/standalone/package.json version ($PKG_VERSION) does not match release tag ($TAG_VERSION)." && exit 1
-          fi
-
       - name: Build extension
         run: yarn build
 
@@ -62,7 +49,7 @@ jobs:
         run: yarn workspace @miragon/bpmn-modeler-standalone bundle
 
       - name: Build, sign, notarize DMG (dry-run)
-        if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
+        if: inputs.dry-run == true
         run: yarn workspace @miragon/bpmn-modeler-standalone run package:signed
         env:
           NODE_OPTIONS: --max-old-space-size=8192
@@ -73,7 +60,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload DMG artifact (dry-run)
-        if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
+        if: inputs.dry-run == true
         uses: actions/upload-artifact@v7
         with:
           name: standalone-dmg-dry-run
@@ -81,7 +68,7 @@ jobs:
           retention-days: 7
 
       - name: Build, sign, notarize, publish DMG
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
+        if: inputs.dry-run == false
         run: yarn workspace @miragon/bpmn-modeler-standalone run package:release
         env:
           NODE_OPTIONS: --max-old-space-size=8192

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -65,6 +65,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
         run: yarn workspace @miragon/bpmn-modeler-standalone run package:signed
         env:
+          NODE_OPTIONS: --max-old-space-size=8192
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -83,6 +84,7 @@ jobs:
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
         run: yarn workspace @miragon/bpmn-modeler-standalone run package:release
         env:
+          NODE_OPTIONS: --max-old-space-size=8192
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/.github/workflows/publish-vscode-modeler.yml
+++ b/.github/workflows/publish-vscode-modeler.yml
@@ -1,12 +1,10 @@
 name: Publish VS Code Modeler
 
-# Builds and publishes the VS Code extension when a GitHub Release with a
-# v* tag is published. Also supports a manual workflow_dispatch with a
-# dry-run option that produces a vsix artifact without publishing.
+# Builds and publishes the VS Code extension. Manual workflow_dispatch only;
+# dry-run uploads a vsix artifact, non-dry-run publishes to the VS Code
+# Marketplace using the version in apps/modeler-plugin/package.json.
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       dry-run:
@@ -26,7 +24,6 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v'))
 
     steps:
       - name: Checkout
@@ -53,21 +50,8 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
-          else
-            VERSION=$(node -e "console.log(require('./apps/modeler-plugin/package.json').version)")
-          fi
+          VERSION=$(node -e "console.log(require('./apps/modeler-plugin/package.json').version)")
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Verify package.json version matches tag
-        if: github.event_name == 'release'
-        run: |
-          PKG_VERSION=$(node -e "console.log(require('./apps/modeler-plugin/package.json').version)")
-          if [ "$PKG_VERSION" != "${{ steps.version.outputs.version }}" ]; then
-            echo "package.json version ($PKG_VERSION) does not match release tag (${{ steps.version.outputs.version }})." && exit 1
-          fi
 
       - name: Build
         run: yarn build
@@ -80,22 +64,15 @@ jobs:
         run: vsce package --out bpmn-modeler-plugin.vsix --yarn --no-dependencies
 
       - name: Upload vsix artifact (dry-run)
-        if: github.event_name == 'workflow_dispatch' && inputs.dry-run == true
+        if: inputs.dry-run == true
         uses: actions/upload-artifact@v7
         with:
           name: bpmn-modeler-plugin-v${{ steps.version.outputs.version }}
           path: dist/apps/modeler-plugin/bpmn-modeler-plugin.vsix
           retention-days: 7
 
-      - name: Attach vsix to release
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.event.release.tag_name }}
-          files: dist/apps/modeler-plugin/bpmn-modeler-plugin.vsix
-
       - name: Publish to VS Code Marketplace
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.dry-run == false)
+        if: inputs.dry-run == false
         working-directory: dist/apps/modeler-plugin
         run: vsce publish --yarn --no-dependencies
         env:


### PR DESCRIPTION
## Summary

Two CI fixes bundled together; both target the publish path:

1. **Manual-only publish across all release pipelines.** Every `publish-*` workflow previously fired automatically on `release:published` (and the homebrew one on `workflow_run`). Tag-prefix `if:` filters were the only thing keeping them from cross-firing — fragile if a release name ever drifts. They now require `workflow_dispatch` with explicit inputs. The three `prepare-release-*` workflows were already manual-only.

2. **Heap fix for the standalone publish build.** The Theia production webpack run OOM'd on `macos-latest` at the default ~4 GB V8 heap (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`). `NODE_OPTIONS=--max-old-space-size=8192` on both build steps gives webpack the headroom it needs.

## Changes

- `.github/workflows/publish-standalone.yml` — drop `release:published`; bump heap; simplify gating + drop the now-unreachable tag-version verify step.
- `.github/workflows/publish-standalone-homebrew.yml` — drop the `workflow_run` trigger; require `tag` input.
- `.github/workflows/publish-vscode-modeler.yml` — drop `release:published`; read version from `apps/modeler-plugin/package.json`; drop the tag-version verify step and the "attach vsix to release" step.
- `.github/workflows/publish-create-append-c7.yml` — drop `release:published`; drop the tag-version verify step.

`prepare-release-*.yml` are unchanged — they were already `workflow_dispatch`-only and still create the GitHub Release as a side effect (now harmless because no publisher auto-listens).

## New release flow (manual, per package)

| Step | Workflow | Inputs |
|---|---|---|
| 1 | `Prepare Release …`               | `release-type` |
| 2 | `Publish …` (or `Publish Standalone (macOS)` for the desktop app) | `dry-run: false` |
| 3 (standalone only) | `Publish Standalone (Homebrew)` | `tag: standalone-v…` |

## Test plan

- [ ] Merge.
- [ ] Manually dispatch **Publish Standalone (macOS)** from `main` with `dry-run: false` → completes without OOM, DMG + `latest-mac.yml` land on `standalone-v0.0.1`.
- [ ] Manually dispatch **Publish Standalone (Homebrew)** with `tag: standalone-v0.0.1` → tap Cask regenerated at `0.0.1` with fresh sha256.
- [ ] Smoke-test that creating an unrelated GitHub release (e.g. via the Prepare Release VS Code Modeler workflow's draft) does **not** auto-trigger any `publish-*` workflow.