### PR TITLE
ci(standalone): upload built DMG artifacts to GitHub release

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -67,14 +67,30 @@ jobs:
           path: apps/standalone/dist/*.dmg
           retention-days: 7
 
-      - name: Build, sign, notarize, publish DMG
+      - name: Build, sign, notarize DMG
         if: inputs.dry-run == false
         run: yarn workspace @miragon/bpmn-modeler-standalone run package:release
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Upload artifacts to release
+        if: inputs.dry-run == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -e "console.log(require('./apps/standalone/package.json').version)")
+          TAG="standalone-v${VERSION}"
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG does not exist. Create it first (tag + 'gh release create $TAG')." && exit 1
+          fi
+          shopt -s nullglob
+          FILES=(apps/standalone/dist/*.dmg apps/standalone/dist/*.dmg.blockmap apps/standalone/dist/latest-mac.yml)
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "No artifacts found in apps/standalone/dist/." && exit 1
+          fi
+          gh release upload "$TAG" "${FILES[@]}" --clobber


### PR DESCRIPTION
## Summary

The `standalone-v0.0.1` release ended up empty after a successful publish run because `apps/standalone/package.json`'s `package:release` script invokes `electron-builder --publish never` and the workflow had no follow-up upload step. Built DMG, blockmap, and `latest-mac.yml` were produced under `apps/standalone/dist/` and then discarded when the runner ended.

This PR keeps the prepare/publish split intact (so retries don't re-bump versions and the pattern stays consistent with the other publish pipelines) and adds an explicit upload step in `publish-standalone.yml`.

## Changes

- `.github/workflows/publish-standalone.yml`
  - Rename `Build, sign, notarize, publish DMG` → `Build, sign, notarize DMG` (upload now happens separately).
  - Add `Upload artifacts to release` step gated on `inputs.dry-run == false`. It resolves the version from `apps/standalone/package.json`, asserts the matching `standalone-vX.Y.Z` release already exists, and runs `gh release upload --clobber` on `*.dmg`, `*.dmg.blockmap`, and `latest-mac.yml`.

`package:release` stays at `--publish never` — the workflow owns the upload.

## Why this approach

- **Explicit over implicit**: doesn't rely on electron-builder's GH publisher resolving `v${version}` vs `standalone-v${version}` tags, which historically caused confusion.
- **Filenames match Homebrew expectations**: GitHub normalizes asset names with spaces (`Miragon BPMN Modeler-0.0.1-arm64.dmg`) to dotted form (`Miragon.BPMN.Modeler-0.0.1-arm64.dmg`), which is exactly what `publish-standalone-homebrew.yml` constructs.
- **Idempotent retries**: `--clobber` replaces same-named assets, so re-running publish after a fix doesn't duplicate.
- **Local devs unaffected**: running `package:release` locally still doesn't try to publish.

## Test plan

- [ ] Merge.
- [ ] Manually dispatch **Publish Standalone (macOS)** from `main` with `dry-run: false`.
- [ ] `gh release view standalone-v0.0.1 --json assets` shows: `Miragon.BPMN.Modeler-0.0.1-arm64.dmg`, `*.blockmap`, `latest-mac.yml`.
- [ ] Manually dispatch **Publish Standalone (Homebrew)** with `tag: standalone-v0.0.1`.
- [ ] `Miragon/homebrew-tap` `Casks/miragon-bpmn-modeler.rb` regenerated at `version "0.0.1"` with a fresh sha256.
- [ ] Optional: `brew install --cask miragon/tap/miragon-bpmn-modeler` on a clean Mac launches successfully.