### PR TITLE
ci(standalone): create Casks/ before writing Cask in homebrew tap

### DIFF
--- a/.github/workflows/publish-standalone-homebrew.yml
+++ b/.github/workflows/publish-standalone-homebrew.yml
@@ -82,6 +82,7 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Miragon/homebrew-tap.git" tap
+          mkdir -p tap/Casks
           cp miragon-bpmn-modeler.rb tap/Casks/miragon-bpmn-modeler.rb
           cd tap
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

The Homebrew tap workflow assumed `tap/Casks/` already existed. When the tap is empty — e.g. right after wiping a stale Cask, which we did during the 0.9.2 → 0.0.1 reset — Git has no empty directory to clone, so the `cp miragon-bpmn-modeler.rb tap/Casks/miragon-bpmn-modeler.rb` step failed with `No such file or directory`.

Adding `mkdir -p tap/Casks` makes the step idempotent and self-healing regardless of tap state.

## Changes

- `.github/workflows/publish-standalone-homebrew.yml` — one-line `mkdir -p tap/Casks` before the `cp`.

## Test plan

- [ ] Merge.
- [ ] Manually dispatch **Publish Standalone (Homebrew)** with `tag: standalone-v0.0.1`.
- [ ] `Miragon/homebrew-tap` ends up with `Casks/miragon-bpmn-modeler.rb` at version `0.0.1` and a fresh sha256.