### PR TITLE
ci(standalone): bump standalone-extension in lockstep with the app

### DIFF
--- a/.github/workflows/prepare-release-standalone.yml
+++ b/.github/workflows/prepare-release-standalone.yml
@@ -1,8 +1,9 @@
 name: Prepare Release Standalone
 
-# Bumps the standalone app version, commits and tags the bump, then
-# creates a GitHub Release. Building, signing, notarizing and publishing
-# the DMG is handled by publish-standalone.yml on release: published.
+# Bumps the standalone app and standalone-extension versions in lockstep,
+# commits and tags the bump, then creates a GitHub Release. Building,
+# signing, notarizing and publishing the DMG is handled by
+# publish-standalone.yml.
 
 on:
   workflow_dispatch:
@@ -64,6 +65,7 @@ jobs:
         run: |
           yarn workspace @miragon/bpmn-modeler-standalone version "${{ inputs.release-type }}"
           NEW_VERSION=$(node -e "console.log(require('./apps/standalone/package.json').version)")
+          yarn workspace @miragon/bpmn-modeler-standalone-extension version "$NEW_VERSION"
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build standalone
@@ -81,7 +83,7 @@ jobs:
         run: |
           NEW_VERSION="${{ steps.version.outputs.version }}"
           TAG="standalone-v${NEW_VERSION}"
-          git add apps/standalone/package.json
+          git add apps/standalone/package.json libs/standalone-extension/package.json
           git commit -m "chore(release): standalone v${NEW_VERSION}"
           git push origin HEAD
           git tag -a "$TAG" -m "release $TAG"


### PR DESCRIPTION
## Summary

The standalone Theia frontend extension (`libs/standalone-extension`) ships inside the standalone app's DMG as a single bundled artifact, so their `version` fields should stay locked together. The prepare workflow only bumped `apps/standalone/package.json`, leaving the extension's version field stale and drifting after each release.

This PR makes the prepare workflow set the extension's version to whatever the app was just bumped to — using an explicit `yarn workspace ... version <semver>` rather than a second relative bump. That way the lib always tracks the app, regardless of any prior drift.

## Changes

- `.github/workflows/prepare-release-standalone.yml`
  - **Bump version** step: after bumping the app, read the new version and set `@miragon/bpmn-modeler-standalone-extension` to the same value explicitly.
  - **Commit and tag** step: stage `libs/standalone-extension/package.json` alongside the app's `package.json`.
  - Header comment updated to reflect the dual-bump.

## Test plan

- [ ] Merge.
- [ ] Manually dispatch **Prepare Release Standalone** with `release-type: patch`, `dry-run: true` first to confirm the workflow runs cleanly.
- [ ] Then a real `dry-run: false` run when you're ready for `0.0.2`. Verify both `apps/standalone/package.json` and `libs/standalone-extension/package.json` end up at the same version on `main`, and the release commit contains both files.