### PR TITLE
docs: remove the standalone release-tag chip from the nav header

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,31 +1,19 @@
 <script setup lang="ts">
 import DefaultTheme from "vitepress/theme";
-import { ref, computed, onMounted } from "vue";
+import { computed } from "vue";
 import { useData, withBase } from "vitepress";
 import SiteFooter from "./components/SiteFooter.vue";
-import { fetchLatestStandaloneRelease } from "./utils/release";
 const { Layout } = DefaultTheme;
 const { frontmatter, page } = useData();
 const showSiteFooter = computed(() =>
     frontmatter.value.layout === "home" || page.value.relativePath === "download.md",
 );
-
-// Display the literal release tag (e.g. "standalone-v0.9.2") in the top-nav
-// version chip — no prefix munging.
-const releaseTag = ref<string | null>(null);
-onMounted(async () => {
-    const release = await fetchLatestStandaloneRelease();
-    releaseTag.value = release?.tagName ?? null;
-});
 </script>
 
 <template>
     <Layout>
         <template #nav-bar-content-after>
             <div class="nav-extras">
-                <span v-if="releaseTag" class="version-chip">
-                    <span class="v-dot"></span>{{ releaseTag }}
-                </span>
                 <a class="install-btn" :href="withBase('/download')">
                     <span class="ico">↓</span> Install
                 </a>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -78,36 +78,12 @@
 .VPNavBar:not(.has-sidebar) .DocSearch-Button:hover { background: rgba(255,255,255,0.75) !important; }
 .dark .VPNavBar:not(.has-sidebar) .DocSearch-Button:hover { background: rgba(255,255,255,0.1) !important; }
 
-/* Nav extras: version chip + Install button */
+/* Nav extras: Install button */
 .nav-extras {
   display: inline-flex;
   align-items: center;
   gap: 12px;
   margin-left: 16px;
-}
-.version-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 10px;
-  background: rgba(255,255,255,0.5);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border: 1px solid var(--miragon-border);
-  border-radius: 6px;
-  font-family: ui-monospace, Menlo, monospace;
-  font-size: 12px;
-  color: var(--miragon-fg-muted);
-  font-weight: 600;
-}
-.dark .version-chip {
-  background: rgba(255,255,255,0.04);
-}
-.version-chip .v-dot {
-  width: 6px; height: 6px;
-  border-radius: 50%;
-  background: var(--miragon-green);
-  box-shadow: 0 0 8px var(--miragon-green);
 }
 .install-btn {
   display: inline-flex;


### PR DESCRIPTION
## Summary

The nav-bar version chip rendered the latest standalone GitHub release tag (e.g. \`standalone-v0.0.1\`) in the header. With the site now covering two separately versioned products — the VS Code extension and the Standalone Theia app — a single chip showing only one of their versions is misleading; it implies they're aligned when they aren't.

## Changes

- \`docs/.vitepress/theme/Layout.vue\` — drop the chip element from the \`#nav-bar-content-after\` slot and its supporting \`onMounted\` fetch + \`releaseTag\` ref. The 'Install' button stays in \`nav-extras\`.
- \`docs/.vitepress/theme/custom.css\` — remove the orphan \`.version-chip\`, \`.dark .version-chip\`, and \`.version-chip .v-dot\` rules. \`.nav-extras\` and \`.install-btn\` rules stay.

\`fetchLatestStandaloneRelease\` is still used by \`DownloadPage.vue\` to populate per-platform install buttons on the download page, so the utility module stays.

## Test plan

- [ ] Merge.
- [ ] Visit the deployed site and confirm the chip is gone from the header on every page (home + docs pages + download page).
- [ ] The Install button still renders and links to /download.
- [ ] The download page's per-platform install buttons still resolve to the latest standalone release.