### PR TITLE
refactor(bpmn-webview): split clipboard guard into separate listeners

### DIFF
--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
@@ -14,16 +14,22 @@ import { installContentEditableClipboardPolyfill } from "./propertiesPanelClipbo
 const mocks = {
     requestClipboard: vi.fn().mockResolvedValue(""),
     writeClipboard: vi.fn<(text: string) => void>(),
-    onSelectAll: vi.fn(),
 };
+
+/**
+ * Bubble-phase spy that stands in for bpmn-js's `Keyboard` service: if the
+ * guard correctly stops propagation, this never fires; if propagation leaks
+ * through, this records the keystroke as bpmn-js would have seen it.
+ */
+const bpmnJsKeyboardSpy = vi.fn<(e: KeyboardEvent) => void>();
 
 beforeAll(() => {
     vi.useFakeTimers();
     installContentEditableClipboardPolyfill(
         () => mocks.requestClipboard(),
         (text) => mocks.writeClipboard(text),
-        () => mocks.onSelectAll(),
     );
+    document.addEventListener("keydown", (e) => bpmnJsKeyboardSpy(e));
 });
 
 afterAll(() => {
@@ -34,7 +40,7 @@ beforeEach(() => {
     vi.runAllTimers();
     mocks.requestClipboard.mockReset().mockResolvedValue("");
     mocks.writeClipboard.mockReset();
-    mocks.onSelectAll.mockReset();
+    bpmnJsKeyboardSpy.mockReset();
     document.body.innerHTML = "";
 });
 
@@ -44,6 +50,13 @@ afterEach(() => {
 
 function focusedInput(): HTMLInputElement {
     const el = document.createElement("input");
+    document.body.appendChild(el);
+    el.focus();
+    return el;
+}
+
+function focusedTextarea(): HTMLTextAreaElement {
+    const el = document.createElement("textarea");
     document.body.appendChild(el);
     el.focus();
     return el;
@@ -70,33 +83,31 @@ function ctrl(key: string): KeyboardEvent {
     return new KeyboardEvent("keydown", { key, ctrlKey: true, bubbles: true });
 }
 
-describe("selecting all text in a properties-panel input (Ctrl+A)", () => {
-    it("selects all text in the field", () => {
-        const input = focusedInput();
-        const selectSpy = vi.spyOn(input, "select");
-        input.dispatchEvent(ctrl("a"));
-        expect(selectSpy).toHaveBeenCalled();
+describe("Ctrl+A guard: text-editing surfaces own their selection", () => {
+    it("does not let Ctrl+A in a properties-panel <input> reach bpmn-js", () => {
+        focusedInput().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
     });
 
-    it("does not accidentally trigger diagram-element selection", () => {
-        const input = focusedInput();
-        input.dispatchEvent(ctrl("a"));
-        expect(mocks.onSelectAll).not.toHaveBeenCalled();
+    it("does not let Ctrl+A in a <textarea> reach bpmn-js", () => {
+        focusedTextarea().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
     });
-});
 
-describe("selecting all elements in the diagram (Ctrl+A on the canvas)", () => {
-    it("selects all elements in the diagram", () => {
-        const canvas = focusedDiv();
-        canvas.dispatchEvent(ctrl("a"));
-        expect(mocks.onSelectAll).toHaveBeenCalled();
+    it("does not let Ctrl+A in a contenteditable (label / FEEL editor) reach bpmn-js", () => {
+        focusedEditor().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).not.toHaveBeenCalled();
+    });
+
+    it("lets Ctrl+A on a non-text element propagate so bpmn-js can select the canvas", () => {
+        focusedDiv().dispatchEvent(ctrl("a"));
+        expect(bpmnJsKeyboardSpy).toHaveBeenCalledTimes(1);
     });
 });
 
 describe("copy and paste in the FEEL expression editor", () => {
     it("Ctrl+V pastes from the extension-host clipboard into the editor", () => {
-        const editor = focusedEditor();
-        editor.dispatchEvent(ctrl("v"));
+        focusedEditor().dispatchEvent(ctrl("v"));
         expect(mocks.requestClipboard).toHaveBeenCalled();
     });
 
@@ -110,8 +121,7 @@ describe("copy and paste in the FEEL expression editor", () => {
     });
 
     it("paste does nothing when a plain element (not an editor) is focused", () => {
-        const div = focusedDiv();
-        div.dispatchEvent(ctrl("v"));
+        focusedDiv().dispatchEvent(ctrl("v"));
         expect(mocks.requestClipboard).not.toHaveBeenCalled();
     });
 });

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
@@ -23,6 +23,17 @@ const mocks = {
  */
 const bpmnJsKeyboardSpy = vi.fn<(e: KeyboardEvent) => void>();
 
+/**
+ * Bubble-phase spy on `window` that stands in for Theia's webview
+ * pre-bootstrap forwarder. The real forwarder lives on the inner iframe's
+ * window in bubble phase and posts the keystroke to the outer Theia shell
+ * unconditionally (no `defaultPrevented` gate); if it fires, the outer
+ * shell runs SELECT_ALL = `document.execCommand("selectAll")` against the
+ * whole Theia chrome. The Ctrl+A guard must stop the bubble at `document`
+ * so this never sees the event — for *every* surface, canvas included.
+ */
+const theiaForwarderSpy = vi.fn<(e: KeyboardEvent) => void>();
+
 beforeAll(() => {
     vi.useFakeTimers();
     installContentEditableClipboardPolyfill(
@@ -30,6 +41,7 @@ beforeAll(() => {
         (text) => mocks.writeClipboard(text),
     );
     document.addEventListener("keydown", (e) => bpmnJsKeyboardSpy(e));
+    window.addEventListener("keydown", (e) => theiaForwarderSpy(e));
 });
 
 afterAll(() => {
@@ -41,6 +53,7 @@ beforeEach(() => {
     mocks.requestClipboard.mockReset().mockResolvedValue("");
     mocks.writeClipboard.mockReset();
     bpmnJsKeyboardSpy.mockReset();
+    theiaForwarderSpy.mockReset();
     document.body.innerHTML = "";
 });
 
@@ -102,6 +115,23 @@ describe("Ctrl+A guard: text-editing surfaces own their selection", () => {
     it("lets Ctrl+A on a non-text element propagate so bpmn-js can select the canvas", () => {
         focusedDiv().dispatchEvent(ctrl("a"));
         expect(bpmnJsKeyboardSpy).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("Ctrl+A guard: block the Theia outer-shell SELECT_ALL forward", () => {
+    it("stops Ctrl+A on the canvas before it reaches `window`", () => {
+        focusedDiv().dispatchEvent(ctrl("a"));
+        expect(theiaForwarderSpy).not.toHaveBeenCalled();
+    });
+
+    it("stops Ctrl+A in an <input> before it reaches `window`", () => {
+        focusedInput().dispatchEvent(ctrl("a"));
+        expect(theiaForwarderSpy).not.toHaveBeenCalled();
+    });
+
+    it("stops Ctrl+A in a contenteditable before it reaches `window`", () => {
+        focusedEditor().dispatchEvent(ctrl("a"));
+        expect(theiaForwarderSpy).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -1,17 +1,17 @@
 /**
- * Handles Ctrl/Cmd+A: selects all text in focused inputs; fully intercepts
- * the event for canvas focus and delegates element selection to onSelectAll.
+ * Returns true if `el` is a surface where the user is editing text
+ * (`<input>`, `<textarea>`, or any `contenteditable` element).
+ *
+ * The webview-level keyboard guard uses this predicate to decide whether
+ * bpmn-js should be allowed to receive a Ctrl/Cmd+A keystroke: text surfaces
+ * own their own selection, so the event must not reach bpmn-js's Keyboard
+ * service.
  */
-function handleSelectAll(e: KeyboardEvent, el: Element, onSelectAll?: () => void): void {
-    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-        e.stopPropagation();
-        e.preventDefault();
-        el.select();
-        return;
-    }
-    e.stopPropagation();
-    e.preventDefault();
-    onSelectAll?.();
+function isTextEditingSurface(el: Element | null): boolean {
+    if (el instanceof HTMLInputElement) return true;
+    if (el instanceof HTMLTextAreaElement) return true;
+    if (el instanceof HTMLElement && el.contentEditable === "true") return true;
+    return false;
 }
 
 /**
@@ -32,26 +32,36 @@ function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): 
 }
 
 /**
- * Polyfills clipboard operations for all `contenteditable` elements in
- * VS Code webviews.
+ * Installs the webview-level keyboard / clipboard guard.
  *
- * Uses two complementary mechanisms:
- * 1. A `keydown` capture-phase listener that intercepts Cmd/Ctrl+C/V before
- *    any element handler can call `stopPropagation()` (fixes the canvas label
- *    editor whose DirectEditing module stops propagation on every keydown).
- * 2. A `document.execCommand` polyfill as fallback for non-keyboard clipboard
- *    triggers (e.g. VS Code command palette).
+ * Two responsibilities, both registered as a single document-level capture-phase
+ * `keydown` listener:
  *
- * A dedup flag prevents double-handling when both layers fire.
+ * 1. **Ctrl/Cmd+A guard.** When focus is on a text-editing surface
+ *    (`<input>`, `<textarea>`, or any contenteditable element), stop the event
+ *    from propagating so bpmn-js's `Keyboard` service does not turn it into a
+ *    canvas `selectElements` action. The surface's own owner then handles the
+ *    keystroke:
+ *      - browser native for `<input>` / `<textarea>`,
+ *      - `LabelClipboardModule` for the BPMN label overlay,
+ *      - CodeMirror 6 for the Camunda 8 FEEL expression editor.
+ *    When focus is elsewhere, the handler does nothing — bpmn-js's built-in
+ *    Ctrl+A binding selects the canvas.
+ *
+ * 2. **Ctrl/Cmd+C/V bridge for contenteditable.** VS Code webview iframes lack
+ *    clipboard permissions, and bpmn-js's `DirectEditing._handleKey` calls
+ *    `stopPropagation()` on every keydown from the label overlay. The
+ *    capture-phase listener intercepts the keys early and bridges them through
+ *    the extension host. A `document.execCommand` polyfill covers non-keyboard
+ *    triggers (e.g. VS Code command palette); a dedup flag prevents double
+ *    handling when both layers fire.
  *
  * @param requestClipboard Async callback that reads clipboard text via the extension host.
  * @param writeClipboard Callback that writes text to the extension host clipboard.
- * @param onSelectAll Called when Ctrl+A fires outside a text input (e.g. on the canvas).
  */
 export function installContentEditableClipboardPolyfill(
     requestClipboard: () => Promise<string>,
     writeClipboard: (text: string) => void,
-    onSelectAll?: () => void,
 ): void {
     let handled = false;
 
@@ -65,7 +75,9 @@ export function installContentEditableClipboardPolyfill(
             if (!isMod) return;
 
             if (e.key === "a") {
-                handleSelectAll(e, el, onSelectAll);
+                if (isTextEditingSurface(el)) {
+                    e.stopPropagation();
+                }
                 return;
             }
 

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -34,27 +34,28 @@ function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): 
 /**
  * Installs the webview-level keyboard / clipboard guard.
  *
- * Two responsibilities, both registered as a single document-level capture-phase
- * `keydown` listener:
+ * Registers two `keydown` listeners on `document`, each with a deliberately
+ * chosen phase:
  *
- * 1. **Ctrl/Cmd+A guard.** When focus is on a text-editing surface
- *    (`<input>`, `<textarea>`, or any contenteditable element), stop the event
- *    from propagating so bpmn-js's `Keyboard` service does not turn it into a
- *    canvas `selectElements` action. The surface's own owner then handles the
- *    keystroke:
- *      - browser native for `<input>` / `<textarea>`,
- *      - `LabelClipboardModule` for the BPMN label overlay,
- *      - CodeMirror 6 for the Camunda 8 FEEL expression editor.
- *    When focus is elsewhere, the handler does nothing — bpmn-js's built-in
- *    Ctrl+A binding selects the canvas.
- *
- * 2. **Ctrl/Cmd+C/V bridge for contenteditable.** VS Code webview iframes lack
- *    clipboard permissions, and bpmn-js's `DirectEditing._handleKey` calls
- *    `stopPropagation()` on every keydown from the label overlay. The
- *    capture-phase listener intercepts the keys early and bridges them through
- *    the extension host. A `document.execCommand` polyfill covers non-keyboard
- *    triggers (e.g. VS Code command palette); a dedup flag prevents double
+ * 1. **Capture phase — Ctrl/Cmd+C/V bridge for contenteditable.** VS Code
+ *    webview iframes lack clipboard permissions, and bpmn-js's
+ *    `DirectEditing._handleKey` calls `stopPropagation()` on every keydown
+ *    from the label overlay. Capture-phase fires before that stopPropagation,
+ *    so the bridge can intercept the keys and route them through the
+ *    extension host. A `document.execCommand` polyfill covers non-keyboard
+ *    triggers (VS Code command palette); a dedup flag prevents double
  *    handling when both layers fire.
+ *
+ * 2. **Bubble phase — Ctrl/Cmd+A guard.** Each text surface owns its own
+ *    Ctrl+A: browser native for `<input>`/`<textarea>`, `LabelClipboardModule`
+ *    for the BPMN label overlay, CodeMirror 6 for the Camunda 8 FEEL editor.
+ *    Bubble-phase lets those owners run first (capture + target phases).
+ *    Then, at `document` during bubble, we call `stopImmediatePropagation()`
+ *    if focus is on a text surface — that blocks bpmn-js's `Keyboard`
+ *    listener, which is also on `document` in bubble phase and registered
+ *    after us (modeler boots after this polyfill). When focus is elsewhere
+ *    the listener returns without stopping, so bpmn-js's built-in
+ *    `selectElements` binding handles the canvas case.
  *
  * @param requestClipboard Async callback that reads clipboard text via the extension host.
  * @param writeClipboard Callback that writes text to the extension host clipboard.
@@ -69,19 +70,10 @@ export function installContentEditableClipboardPolyfill(
         "keydown",
         (e: KeyboardEvent) => {
             const el = document.activeElement;
-            if (!(el instanceof Element)) return;
+            if (!(el instanceof HTMLElement)) return;
 
             const isMod = e.metaKey || e.ctrlKey;
             if (!isMod) return;
-
-            if (e.key === "a") {
-                if (isTextEditingSurface(el)) {
-                    e.stopPropagation();
-                }
-                return;
-            }
-
-            if (!(el instanceof HTMLElement)) return;
             if (el.contentEditable !== "true") return;
 
             if (e.key === "v") {
@@ -102,6 +94,31 @@ export function installContentEditableClipboardPolyfill(
             }
         },
         true,
+    );
+
+    document.addEventListener(
+        "keydown",
+        (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== "a") return;
+            const el = document.activeElement;
+            if (!isTextEditingSurface(el)) return;
+
+            // Block bpmn-js's Keyboard listener (same node, same phase,
+            // registered after us). stopPropagation alone would leave it
+            // running because it doesn't affect same-node listeners.
+            e.stopImmediatePropagation();
+
+            // Contenteditable surfaces (BPMN label, FEEL editor) own their
+            // own selection via scoped handlers run in earlier phases.
+            // For `<input>`/`<textarea>`, the native default action is
+            // unreliable inside the webview (likely pre-empted by another
+            // listener calling preventDefault), so select explicitly.
+            if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+                el.select();
+            }
+        },
+        false,
     );
 
     const nativeExecCommand = Document.prototype.execCommand;

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -50,12 +50,19 @@ function handlePaste(el: HTMLElement, requestClipboard: () => Promise<string>): 
  *    Ctrl+A: browser native for `<input>`/`<textarea>`, `LabelClipboardModule`
  *    for the BPMN label overlay, CodeMirror 6 for the Camunda 8 FEEL editor.
  *    Bubble-phase lets those owners run first (capture + target phases).
- *    Then, at `document` during bubble, we call `stopImmediatePropagation()`
- *    if focus is on a text surface — that blocks bpmn-js's `Keyboard`
- *    listener, which is also on `document` in bubble phase and registered
- *    after us (modeler boots after this polyfill). When focus is elsewhere
- *    the listener returns without stopping, so bpmn-js's built-in
- *    `selectElements` binding handles the canvas case.
+ *    Then, at `document` during bubble, we always call `stopPropagation()`
+ *    so the event never reaches `window`. This is what blocks the Theia
+ *    standalone host from forwarding the keystroke to its outer shell:
+ *    Theia's webview pre-bootstrap (`@theia/plugin-ext/.../pre/main.js`)
+ *    listens on the inner iframe's `window` in bubble phase and posts the
+ *    event unconditionally (it does NOT gate on `defaultPrevented`). Without
+ *    `stopPropagation` here the outer shell receives a synthetic Ctrl+A and
+ *    runs `CommonCommands.SELECT_ALL` = `document.execCommand('selectAll')`
+ *    against the whole Theia shell, visibly selecting the file explorer,
+ *    toolbar, etc. `stopPropagation` (not `stopImmediatePropagation`) leaves
+ *    bpmn-js's `Keyboard` listener intact because it sits on the same node.
+ *    For text surfaces we additionally call `stopImmediatePropagation()` to
+ *    block bpmn-js (same-node, same-phase, registered after us).
  *
  * @param requestClipboard Async callback that reads clipboard text via the extension host.
  * @param writeClipboard Callback that writes text to the extension host clipboard.
@@ -101,8 +108,21 @@ export function installContentEditableClipboardPolyfill(
         (e: KeyboardEvent) => {
             if (!(e.metaKey || e.ctrlKey)) return;
             if (e.key !== "a") return;
+
+            // Stop the bubble before it reaches `window`. Theia's webview
+            // pre-bootstrap listens there and forwards keydowns to the
+            // outer shell unconditionally (it does NOT gate on
+            // defaultPrevented), which would otherwise run a global
+            // SELECT_ALL against the Theia chrome. Same-node listeners
+            // (bpmn-js's Keyboard) still fire because stopPropagation
+            // doesn't affect them.
+            e.stopPropagation();
+
             const el = document.activeElement;
-            if (!isTextEditingSurface(el)) return;
+            if (!isTextEditingSurface(el)) {
+                // Canvas / no text surface: let bpmn-js handle selectElements.
+                return;
+            }
 
             // Block bpmn-js's Keyboard listener (same node, same phase,
             // registered after us). stopPropagation alone would leave it
@@ -111,9 +131,8 @@ export function installContentEditableClipboardPolyfill(
 
             // Contenteditable surfaces (BPMN label, FEEL editor) own their
             // own selection via scoped handlers run in earlier phases.
-            // For `<input>`/`<textarea>`, the native default action is
-            // unreliable inside the webview (likely pre-empted by another
-            // listener calling preventDefault), so select explicitly.
+            // For `<input>`/`<textarea>`, the native Ctrl+A default action
+            // is unreliable inside webview iframes, so we select explicitly.
             if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
                 el.select();
             }

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -160,14 +160,12 @@ window.onload = async function () {
         // The FEEL editor (CodeMirror 6) in the C8 properties panel lives outside
         // the bpmn-js DI context, so the DI clipboard modules above don't reach it.
         // This polyfill intercepts Cmd/Ctrl+C/V on contenteditable elements and
-        // bridges them through the extension host clipboard.
+        // bridges them through the extension host clipboard, and guards Ctrl+A
+        // in text-editing surfaces from being stolen by bpmn-js's Keyboard
+        // service (canvas Ctrl+A is owned by bpmn-js's SelectionKeyBindings).
         installContentEditableClipboardPolyfill(
             requestTextClipboard,
             writeTextClipboard,
-            () => {
-                if (!modelerIsInitialized) return;
-                bpmnModeler.getService<any>("editorActions").trigger("selectElements");
-            },
         );
     }
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -11,7 +11,7 @@ const compat = new FlatCompat({
 
 module.exports = [
     {
-        ignores: ["**/dist", "**/lib", "**/src-gen", "**/plugins", "**/gen-webpack*.js", "docs/**"],
+        ignores: ["**/dist", "**/lib", "**/src-gen", "**/plugins", "**/gen-webpack*.js", "**/.browser_modules", "docs/**"],
     },
     {
         plugins: {


### PR DESCRIPTION
**Issue**

Closes: #986 

**Description**

Reorganize the webview-level keyboard guard into two distinct `keydown` listeners with deliberately chosen phases:

- Capture phase handles Ctrl/Cmd+C/V bridge for contenteditable surfaces, intercepting keys before bpmn-js's `DirectEditing._handleKey` calls `stopPropagation()`.
- Bubble phase handles Ctrl/Cmd+A guard, using `stopImmediatePropagation()` to block bpmn-js's `Keyboard` listener registered at the same node and phase. Explicitly select text in `<input>`/`<textarea>` since the native default action is unreliable in the webview.

This separation clarifies responsibility and improves phase ordering logic.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
