### PR TITLE
feat: Git Source Control & auto-save

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,22 @@ Discussing scope in an issue *before* writing code saves everyone time.
 ### Prerequisites
 
 - **Node.js** v20 or later
-- [`corepack`](https://nodejs.org/api/corepack.html) enabled: `corepack enable`
+- [`corepack`](https://nodejs.org/api/corepack.html) **on your `PATH`** and
+  enabled. This repo pins Yarn via `packageManager` in `package.json` and the
+  build scripts invoke `corepack yarn …` directly, so `corepack --version` must
+  resolve in the same shell you run `yarn install` from.
+
+  Some Node version managers do not ship a `corepack` shim — Volta is a known
+  example. If `corepack --version` prints `command not found`, install it
+  explicitly and then enable it:
+
+  ```bash
+  npm install -g corepack@latest
+  corepack enable
+  ```
+
+  Standard Node distributions already include `corepack`; running
+  `corepack enable` once is enough.
 - **VS Code**
 
 ### Clone and install

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ quietly grew into more places where process work actually happens:
 
 - **In VS Code**, as the public extension — the original product.
 - **On the desktop**, as a standalone Theia/Electron app for users and
-  organisations not on VS Code, with the exact same modeling surface.
+  organisations not on VS Code — same modeling surface, plus a built-in
+  Source Control view, BPMN-aware diff against working-tree changes, and
+  auto-save out of the box.
 - **And next: AI-assisted BPMN tooling** — bringing the same modeling
   context into your AI assistant. *Stay tuned.* ✨
 

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -35,6 +35,15 @@ import { DiffPaneEntry, DiffSession } from "./DiffSession";
 const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
 
 /**
+ * URI schemes used by Git-provider extensions to surface ref/index/working-tree
+ * documents. VS Code's built-in Git extension uses `git:`; Theia's `@theia/git`
+ * (used by the standalone desktop shell) uses `gitfs:`. Both are always
+ * readonly and always belong to a diff, so the scheme alone is a sufficient
+ * signal for `shouldResolveAsDiff`.
+ */
+const GIT_PROVIDED_SCHEMES = new Set<string>(["git", "gitfs"]);
+
+/**
  * Milliseconds a pre-registered `compare-files` session stays alive with no
  * panes attached before it is swept.  Covers the "user triggered the command
  * but the diff tab never opened" edge case.  Longer than any realistic
@@ -90,9 +99,9 @@ export class BpmnDiffService {
     private readonly sessionByUri = new Map<string, DiffSession>();
 
     /**
-     * SCM panes awaiting their partner.  Keyed by `document.uri.path` so
-     * `git:foo.bpmn` and `file:foo.bpmn` meet here before being promoted into
-     * a session.
+     * SCM panes awaiting their partner.  Keyed by {@link scmPairingKey} so
+     * the Git-provided URI (`git:` in VS Code, `gitfs:` in Theia) and the
+     * working-tree `file:` URI meet here before being promoted into a session.
      */
     private readonly pendingScm = new Map<string, PendingScmPane>();
 
@@ -205,8 +214,10 @@ export class BpmnDiffService {
      *      the SCM diff was already open — that second tab is an editable
      *      modeler, not another diff pane.
      *   2. A pre-registered `compare-files` session exists → true.
-     *   3. The URI is a `git:` scheme → true.  Git-provided documents are
-     *      always readonly and always belong to a diff.
+     *   3. The URI uses a Git-provided scheme (see
+     *      {@link GIT_PROVIDED_SCHEMES}) → true. Covers VS Code's `git:` and
+     *      Theia's `gitfs:` — both are always readonly and always belong to a
+     *      diff.
      *   4. The URI sits in a diff tab per the label heuristic → true.  This
      *      is the only signal for SCM diffs when both URIs share the `file:`
      *      scheme (uncommon but possible for some diff-to-working-tree flows).
@@ -218,7 +229,7 @@ export class BpmnDiffService {
         if (this.findSessionFor(uri)) {
             return true;
         }
-        if (uri.scheme === "git") {
+        if (GIT_PROVIDED_SCHEMES.has(uri.scheme)) {
             return true;
         }
         return this.isPartOfDiff(uri);
@@ -329,15 +340,15 @@ export class BpmnDiffService {
      *     order VS Code's SCM diff chose.
      */
     private attachOrPendScmPane(entry: DiffPaneEntry): void {
-        const path = entry.document.uri.path;
-        const pending = this.pendingScm.get(path);
+        const key = this.scmPairingKey(entry.document.uri);
+        const pending = this.pendingScm.get(key);
 
         if (!pending) {
-            this.pendingScm.set(path, { entry });
+            this.pendingScm.set(key, { entry });
             return;
         }
 
-        this.pendingScm.delete(path);
+        this.pendingScm.delete(key);
         const { session, before, after } = DiffSession.forScm(
             pending.entry,
             entry,
@@ -345,6 +356,19 @@ export class BpmnDiffService {
         session.attachPane(before);
         session.attachPane(after);
         this.indexSession(session);
+    }
+
+    /**
+     * Pairing key for matching the two panes of an SCM diff. Both VS Code
+     * (`git:foo.bpmn` ↔ `file:foo.bpmn`) and Theia (`gitfs:foo.bpmn` ↔
+     * `file:foo.bpmn`) surface the two sides with different schemes but the
+     * same workspace-relative `uri.path`, so the raw path is the pairing key.
+     *
+     * If a future host bakes ref metadata into the path (e.g.
+     * `/foo.bpmn@HEAD`), normalize it here so the two paths still meet.
+     */
+    private scmPairingKey(uri: Uri): string {
+        return uri.path;
     }
 
     /**

--- a/apps/modeler-plugin/src/service/DiffSession.ts
+++ b/apps/modeler-plugin/src/service/DiffSession.ts
@@ -77,9 +77,9 @@ export class DiffSession {
      * the SCM side-assignment rule:
      *
      *   - If one URI is `file:` it is the working tree → `after`.
-     *   - Otherwise (ref-vs-ref, both `git:`) the first-resolved pane is
-     *     `before`, second is `after` — arbitrary but matches the visual
-     *     order VS Code's SCM diff chose.
+     *   - Otherwise (ref-vs-ref, both `git:` / both `gitfs:`) the
+     *     first-resolved pane is `before`, second is `after` — arbitrary but
+     *     matches the visual order VS Code's / Theia's SCM diff chose.
      *
      * The panes are returned alongside the session so the caller can attach
      * them without re-deriving the pairing.
@@ -206,8 +206,8 @@ export class DiffSession {
  * Resolves SCM-diff side assignment for two panes that share a path.
  *
  * Invariant: `file:` URIs represent the working tree and must be `after`.
- * For ref-vs-ref diffs (both `git:`) side follows resolution order, which
- * mirrors VS Code's own visual ordering choice.
+ * For ref-vs-ref diffs (both `git:` in VS Code, both `gitfs:` in Theia) side
+ * follows resolution order, which mirrors the host's own visual ordering.
  */
 function resolveScmSides(
     first: DiffPaneEntry,

--- a/apps/standalone/.gitignore
+++ b/apps/standalone/.gitignore
@@ -2,8 +2,7 @@ node_modules/
 lib/
 src-gen/
 dist/
-plugins/*.vsix
-plugins/bpmn-modeler-plugin/
+plugins/
 gen-webpack*.js
 *.log
 .theia-ide/

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -22,6 +22,8 @@
         },
         "preferences": {
           "files.enableTrash": false,
+          "files.autoSave": "afterDelay",
+          "files.autoSaveDelay": 1000,
           "security.workspace.trust.enabled": false
         },
         "electron": {
@@ -59,11 +61,17 @@
     "@theia/plugin-ext-vscode": "1.70.2",
     "@theia/preferences": "1.70.2",
     "@theia/process": "1.70.2",
+    "@theia/scm": "1.70.2",
+    "@theia/scm-extra": "1.70.2",
     "@theia/terminal": "1.70.2",
     "@theia/variable-resolver": "1.70.2",
     "@theia/workspace": "1.70.2",
     "electron-updater": "6.8.3",
     "yauzl": "3.3.0"
+  },
+  "theiaPluginsDir": "plugins",
+  "theiaPlugins": {
+    "vscode.git": "https://open-vsx.org/api/vscode/git/1.95.3/file/vscode.git-1.95.3.vsix"
   },
   "devDependencies": {
     "@theia/cli": "1.70.2",
@@ -86,7 +94,8 @@
     "build:prod:theia": "theia build --app-target=\"electron\"",
     "build:repo": "corepack yarn --cwd ../.. build",
     "package-plugin": "node scripts/package-plugin.mjs",
-    "prepare-plugin": "npm-run-all -s package-plugin bundle",
+    "download:plugins": "theia download:plugins",
+    "prepare-plugin": "npm-run-all -s download:plugins package-plugin bundle",
     "dev": "npm-run-all -s build:repo prepare-plugin build start",
     "dev:fast": "npm-run-all -s build start",
     "start": "electron scripts/theia-electron-main.js",

--- a/apps/standalone/scripts/bundle-extension.mjs
+++ b/apps/standalone/scripts/bundle-extension.mjs
@@ -9,7 +9,7 @@
 //   (cd dist/apps/modeler-plugin && npx @vscode/vsce package --out bpmn-modeler-plugin.vsix --yarn --no-dependencies)
 //   corepack yarn workspace standalone bundle
 
-import { createWriteStream, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { createWriteStream, existsSync, mkdirSync, rmSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -40,14 +40,12 @@ if (!existsSync(vsixSrc)) {
   process.exit(1);
 }
 
-if (existsSync(pluginsDir)) {
-  for (const entry of readdirSync(pluginsDir)) {
-    rmSync(resolve(pluginsDir, entry), { recursive: true, force: true });
-  }
-} else {
-  mkdirSync(pluginsDir, { recursive: true });
-}
-
+// Only wipe our own plugin subdirectory — other entries (notably
+// vscode-builtin-git, downloaded by `theia download:plugins`) must survive
+// re-bundling. Theia treats every subdirectory of `theiaPluginsDir` as a
+// plugin and a `rm -rf plugins/*` would drop them every dev cycle.
+mkdirSync(pluginsDir, { recursive: true });
+rmSync(unpackedDir, { recursive: true, force: true });
 mkdirSync(unpackedDir, { recursive: true });
 
 await new Promise((resolveP, reject) => {

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -29,7 +29,7 @@ const showSiteFooter = computed(() =>
             <p class="hero-tagline">
                 Design, diff, and deploy BPMN and DMN workflows without
                 leaving your editor. Full Camunda 7 and 8 support,
-                professional modeling, zero context switching.
+                built-in Git, professional modeling, zero context switching.
             </p>
             <div class="hero-actions">
                 <a class="btn btn-primary" :href="withBase('/download')">

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ features:
     linkText: Explore modeling
   - icon: ⇌
     title: Visual BPMN diff
-    details: Element-level change review. Catch silent process drift the same way you review code.
+    details: Element-level review of process drift — Git-friendly in both VS Code and standalone. Catch drift like you review code.
     link: /vscode/features/bpmn-diff
     linkText: See diff view
   - icon: ↗
@@ -32,6 +32,8 @@ Professional BPMN and DMN modeling that fits how you work — embedded in VS Cod
 |---------|----------------------|---------------------------|---------------|
 | Available as | <span class="ok">✓</span> VS Code extension + Standalone app | Standalone app only | Web only |
 | Visual BPMN diff | <span class="ok">✓</span> | <span class="no">✕</span> | <span class="no">✕</span> |
+| Git Source Control (standalone) | <span class="ok">✓</span> Built-in | <span class="no">✕</span> | <span class="no">✕</span> |
+| Auto-save (standalone default) | <span class="ok">✓</span> | <span class="no">✕</span> | n/a |
 | Light & dark mode | <span class="ok">✓</span> | <span class="no">✕</span> | <span class="no">✕</span> |
 | One-click deploy to Camunda 7 & 8 | <span class="ok">✓</span> | <span class="ok">✓</span> | <span class="no">✕</span> |
 | Element template discovery | <span class="ok">✓</span> Auto by convention | <span class="ok">✓</span> Manual config | <span class="no">✕</span> |

--- a/docs/standalone/getting-started.md
+++ b/docs/standalone/getting-started.md
@@ -82,6 +82,26 @@ engine, same element templates, same diff view, same deploy flow. Explore:
 - [Element Template Chooser](/vscode/features/element-template-chooser)
 - [Language Support](/vscode/features/language-support)
 
-A few things differ from the VS Code surface — no Extensions view, no Source
-Control, no Command Palette keybindings for VS Code-specific commands. The
-modeler itself behaves identically.
+A few things differ from the VS Code surface — no Extensions view and no
+Command Palette keybindings for VS Code-specific commands. The modeler
+itself behaves identically.
+
+## Auto-save
+
+The standalone saves every change ~1 second after the last edit, so the file
+on disk always matches what you see in the canvas and the Source Control
+view reflects modifications immediately. Disable or change the delay in
+**Settings → Files: Auto Save**.
+
+## Source Control
+
+The standalone ships with the same VS Code Git extension that powers the
+Source Control view in VS Code, including BPMN-aware diffs for modified
+diagrams. Git operations rely on the system `git` binary:
+
+- **macOS** — install Xcode Command Line Tools (`xcode-select --install`)
+  or [git-scm.com](https://git-scm.com/).
+- **Windows** — [git-scm.com](https://git-scm.com/).
+
+If `git --version` works in your terminal, the standalone app will pick it
+up on launch.

--- a/docs/vscode/contributing/architecture/bpmn-diff.md
+++ b/docs/vscode/contributing/architecture/bpmn-diff.md
@@ -18,10 +18,11 @@ description.
 A **diff session** is two `CustomTextEditor` webviews that together render one
 diff tab. Sessions come from two origins:
 
-- **`scm`** — VS Code opened the diff via Source Control, `git diff`, a PR
-  review, etc. One URI is typically `git:` (ref), the other `file:` (working
-  tree). The session is created lazily via `DiffSession.forScm(…)`: the
-  first pane to resolve is stashed in a "pending SCM" slot keyed by
+- **`scm`** — The host (VS Code or Theia) opened the diff via Source Control,
+  `git diff`, a PR review, etc. One URI is typically the Git-provided ref
+  (`git:` in VS Code, `gitfs:` in Theia's `@theia/git`), the other `file:`
+  (working tree). The session is created lazily via `DiffSession.forScm(…)`:
+  the first pane to resolve is stashed in a "pending SCM" slot keyed by
   `uri.path`; when the second pane resolves with the same path, both are
   promoted into a `DiffSession("scm", …)`. The factory encapsulates the
   side-assignment rule (`file:` URI → `after`, otherwise resolution order).
@@ -36,8 +37,8 @@ diff tab. Sessions come from two origins:
 `BpmnDiffService.shouldResolveAsDiff(uri)` for each resolving pane. That
 method runs an ordered decision tree: already-has-a-pane → no (the caller is
 a second resolve for a file already open elsewhere); pre-registered session →
-yes; `git:` scheme → yes; label heuristic matches a diff tab → yes;
-otherwise → no.
+yes; Git-provided scheme (`git:` or `gitfs:`) → yes; label heuristic matches a
+diff tab → yes; otherwise → no.
 
 ```mermaid
 sequenceDiagram
@@ -199,13 +200,21 @@ the differ is upgraded.
 
 ## Gotchas
 
-- **Editor id is the full URI string**, not just the path. `git:` and `file:`
-  URIs for the same file produce different editor ids, so the `EditorStore`
-  can hold both panes side by side without collision.
+- **Editor id is the full URI string**, not just the path. Git-provided URIs
+  (`git:` in VS Code, `gitfs:` in Theia) and `file:` URIs for the same file
+  produce different editor ids, so the `EditorStore` can hold both panes side
+  by side without collision.
+- **Dual-host Git scheme handling.** `shouldResolveAsDiff` recognises both
+  VS Code's `git:` and Theia's `gitfs:` schemes via the
+  `GIT_PROVIDED_SCHEMES` set in `BpmnDiffService.ts`. Add new schemes there
+  if porting to another host; do not branch on a single hardcoded scheme.
 - **SCM pairing is keyed by `uri.path`, not by the full URI.** That is the
-  only thing `git:foo.bpmn` and `file:foo.bpmn` share. The two paths of a
-  `compare-files` session deliberately differ, which is why that origin must
-  be pre-registered — lazy pairing would never match them.
+  only thing `git:foo.bpmn` / `gitfs:foo.bpmn` and `file:foo.bpmn` share.
+  Pairing flows through `scmPairingKey(uri)` so future hosts that bake ref
+  metadata into the path (e.g. `/foo.bpmn@HEAD`) can normalize in one place.
+  The two paths of a `compare-files` session deliberately differ, which is
+  why that origin must be pre-registered — lazy pairing would never match
+  them.
 - **`shouldResolveAsDiff` short-circuits when a pane already exists for the
   URI.** Without this, opening a working-tree file in a normal editor tab
   while the SCM diff is still open would trigger a second resolve, and the

--- a/docs/vscode/contributing/development.md
+++ b/docs/vscode/contributing/development.md
@@ -13,7 +13,16 @@
 ## Prerequisites
 
 - **Node.js** v20 or later
-- **corepack** enabled: `corepack enable`
+- **corepack on `PATH`** and enabled. `corepack --version` must resolve in the
+  shell you run `yarn install` from — the build scripts invoke
+  `corepack yarn …` directly. If it prints `command not found` (Volta and a
+  few other version managers don't ship a `corepack` shim), install it first:
+  ```bash
+  npm install -g corepack@latest
+  corepack enable
+  ```
+  Standard Node distributions already include `corepack`; `corepack enable` is
+  enough.
 - **VS Code**
 
 The webview `dev:*` scripts (standalone browser preview) use

--- a/yarn.lock
+++ b/yarn.lock
@@ -3193,6 +3193,8 @@ __metadata:
     "@theia/plugin-ext-vscode": "npm:1.70.2"
     "@theia/preferences": "npm:1.70.2"
     "@theia/process": "npm:1.70.2"
+    "@theia/scm": "npm:1.70.2"
+    "@theia/scm-extra": "npm:1.70.2"
     "@theia/terminal": "npm:1.70.2"
     "@theia/variable-resolver": "npm:1.70.2"
     "@theia/workspace": "npm:1.70.2"
@@ -4697,6 +4699,20 @@ __metadata:
     https-proxy-agent: "npm:^5.0.0"
     tslib: "npm:^2.6.2"
   checksum: 10c0/7461d937e4c1bb36bc8a646bd3276d77a1c2a4f1b4af685e4f0b0940e10a8486eafe6a739dbccd8575705bcf6b668967599f45ce69058820b363710af49732ab
+  languageName: node
+  linkType: hard
+
+"@theia/scm-extra@npm:1.70.2":
+  version: 1.70.2
+  resolution: "@theia/scm-extra@npm:1.70.2"
+  dependencies:
+    "@theia/core": "npm:1.70.2"
+    "@theia/editor": "npm:1.70.2"
+    "@theia/filesystem": "npm:1.70.2"
+    "@theia/navigator": "npm:1.70.2"
+    "@theia/scm": "npm:1.70.2"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3d61e346b6c74fc70e0bf099c34c367f6051d83f8741e72b9ad77a4373096ca26d668eb1bcb55bc239fe4c6cf491d6c13aa21147c4aa1581c392c7b18c87a004
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Closes #978. Adds Source Control / Git to the standalone Theia desktop app and hardens the BPMN diff service so it routes Theia-provided Git URIs through the BPMN viewer instead of falling back to the raw text diff. Smaller follow-ups bundle auto-save defaults, plugin-bundle plumbing, and docs.

## What's in here

### `feat(standalone)` — Git Source Control + auto-save defaults
- `@theia/scm` + `@theia/scm-extra` (1.70.2) for the activity-bar Source Control view and dirty-diff gutter.
- `vscode.git@1.95.3` pinned via `theiaPlugins` so the standalone bundles the same Git extension VS Code ships. `vscode.git-base` auto-resolves through `theia download:plugins`.
- `files.autoSave: "afterDelay"` (1000 ms) as the standalone default — flushes edits to disk so the SCM view reflects modifications instead of staying empty.
- `bundle-extension.mjs` no longer wipes the entire `plugins/` directory each run; it only recreates its own subdir so the downloaded Git plugin survives re-bundling.
- `apps/standalone/.gitignore` now ignores `plugins/` wholesale (every entry is a build artifact).

### `refactor(bpmn-diff)` — scheme-agnostic Theia compatibility
- `BpmnDiffService.shouldResolveAsDiff` uses a `GIT_PROVIDED_SCHEMES` set (`git`, `gitfs`) instead of a hardcoded `=== "git"` check.
- New `scmPairingKey(uri)` helper centralises the pending-SCM pairing key. Returns `uri.path` today — single place to normalise host-specific URI quirks later.
- `DiffSession` comments updated to mention dual-host scheme handling.
- `docs/vscode/contributing/architecture/bpmn-diff.md` Gotchas section refreshed.

### `docs` — landing-page + corepack prerequisite
- Hero tagline + Visual BPMN diff card mention built-in Git.
- Comparison table adds Git Source Control and Auto-save rows (standalone-specific).
- Standalone getting-started gets Auto-save and Source Control sections (incl. system-git prerequisite for macOS/Windows).
- `CONTRIBUTING.md` + dev guide clarify the corepack-on-PATH prerequisite — Volta and a few other Node managers don't ship the shim.

## Test plan

Local checks already run:
- [x] `corepack yarn install` ✓
- [x] `corepack yarn test` — 74/74 pass
- [x] `corepack yarn lint` — 0 errors (pre-existing warnings only)
- [x] `corepack yarn build` — full repo build
- [x] `corepack yarn workspace @miragon/bpmn-modeler-standalone build:theia` — `src-gen/frontend/index.js` includes `@theia/scm` + `@theia/scm-extra`
- [x] `corepack yarn workspace @miragon/bpmn-modeler-standalone download:plugins` — `vscode.git` + auto-resolved `vscode.git-base` land in `plugins/`
- [x] `corepack yarn workspace @miragon/bpmn-modeler-standalone prepare-plugin` — all three plugins coexist in `plugins/`
- [x] `corepack yarn workspace @miragon/bpmn-modeler-docs build` — VitePress builds clean

End-to-end (manual, against `yarn workspace @miragon/bpmn-modeler-standalone dev`):
- [ ] Source Control icon appears in the activity bar, repo auto-detected, working changes listed.
- [ ] Modify a `.bpmn` file in a Git repo, click it in the SCM panel → BPMN diff renders (not raw text diff).
- [ ] Auto-save kicks in ~1 s after the last edit; SCM view updates.
- [ ] Explorer compare-files flow ("Select for Compare" → "Compare with Selected") still opens the BPMN diff with the swap button.
- [ ] VS Code extension host regression check — same SCM-diff + compare-files flows still work via F5.

## Notes for reviewers

- `@theia/git` was deprecated upstream at 1.60.x — there is no 1.70.x release. The canonical post-1.61 path is bundling VS Code's `vscode.git` extension via `theiaPlugins`, which is what this PR does.
- VS Code users won't see any behavioural change: `git:` scheme still matches, `scmPairingKey` returns `uri.path` (same as the old inline access), label heuristic untouched.
- Auto-save default only changes the *standalone* — the VS Code extension respects the user's global `files.autoSave` setting as before.

Draft until end-to-end smoke-test in the running Electron app is signed off.