### PR TITLE
fix(standalone): include vscode.git plugin in production DMG

### DIFF
--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -100,8 +100,8 @@
     "dev:fast": "npm-run-all -s build start",
     "start": "electron scripts/theia-electron-main.js",
     "start:debug": "yarn start --log-level=debug",
-    "package": "yarn clean:dist && yarn rebuild && yarn build:prod && electron-builder -c.mac.identity=null -c.mac.notarize=false -c.mac.hardenedRuntime=false --publish never --mac dmg",
-    "package:signed": "yarn clean:dist && yarn rebuild && yarn build:prod && electron-builder --publish never --mac dmg",
-    "package:release": "yarn clean:dist && yarn rebuild && yarn build:prod && electron-builder --publish never --mac dmg"
+    "package": "yarn clean:dist && yarn download:plugins && yarn rebuild && yarn build:prod && electron-builder -c.mac.identity=null -c.mac.notarize=false -c.mac.hardenedRuntime=false --publish never --mac dmg",
+    "package:signed": "yarn clean:dist && yarn download:plugins && yarn rebuild && yarn build:prod && electron-builder --publish never --mac dmg",
+    "package:release": "yarn clean:dist && yarn download:plugins && yarn rebuild && yarn build:prod && electron-builder --publish never --mac dmg"
   }
 }


### PR DESCRIPTION
## Summary

Standalone v0.0.2 shipped without the VS Code Git extension, so the Source Control view and the auto-save / version-control flow added in #1000 were inert in the released DMG while working fine in `yarn dev`.

Root cause: the `package`, `package:signed`, and `package:release` scripts in `apps/standalone/package.json` never ran `theia download:plugins`, so the `vscode.git` entry under `theiaPlugins` (line 73-75) was never fetched into `apps/standalone/plugins/`. `electron-builder.yml` then packed an empty/Git-less `plugins/` into the DMG via `extraResources`. Locally, `yarn dev` masked this because it chains `prepare-plugin` → `download:plugins` → `package-plugin` → `bundle`.

Fix: chain `yarn download:plugins` into all three `package*` scripts, after `clean:dist` and before `rebuild`. `download:plugins` is idempotent and `clean:dist` only wipes `dist/`, so plugin order is safe. The bundle script already documents that it preserves sibling plugins like `vscode-builtin-git/` (`apps/standalone/scripts/bundle-extension.mjs:44-46`).

This also keeps local `yarn workspace @miragon/bpmn-modeler-standalone package` in sync with CI, so the regression can't slip back in.

## Test plan

- [ ] Local: `yarn workspace @miragon/bpmn-modeler-standalone package` then verify `apps/standalone/plugins/` contains both `bpmn-modeler-plugin/` and `vscode-builtin-git/`
- [ ] Local: `hdiutil attach apps/standalone/dist/*.dmg` and confirm `Contents/Resources/app/plugins/vscode-builtin-git/` is present in the mounted DMG
- [ ] Open the installed app on a git repo, confirm the Source Control view shows changes and commit / auto-save flow works
- [ ] Trigger `Publish Standalone (macOS)` workflow with `dry-run: true`, download artifact DMG, repeat the `hdiutil` check
- [ ] Cut v0.0.3 via `prepare-release-standalone` once verified