### PR TITLE
ci(standalone): single-click release orchestrator + cheaper macOS publish

### DIFF
--- a/.github/workflows/prepare-release-standalone.yml
+++ b/.github/workflows/prepare-release-standalone.yml
@@ -4,6 +4,10 @@ name: Prepare Release Standalone
 # commits and tags the bump, then creates a GitHub Release. Building,
 # signing, notarizing and publishing the DMG is handled by
 # publish-standalone.yml.
+#
+# Callable two ways:
+#   - workflow_dispatch (manual single-step run)
+#   - workflow_call (from release-standalone.yml orchestrator)
 
 on:
   workflow_dispatch:
@@ -21,6 +25,25 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      release-type:
+        description: 'Release type (patch/minor/major)'
+        required: true
+        type: string
+      dry-run:
+        description: 'Dry run (no commit, tag, or release)'
+        required: false
+        type: boolean
+        default: false
+    outputs:
+      version:
+        description: 'The new version (e.g. 0.0.4). The release tag is always standalone-v${version}.'
+        value: ${{ jobs.prepare.outputs.version }}
+    secrets:
+      RELEASE_PAT:
+        description: 'PAT with repo scope, used to push commits/tags and create the release'
+        required: true
 
 permissions:
   contents: write
@@ -33,6 +56,8 @@ jobs:
   prepare:
     name: Prepare release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout
@@ -46,6 +71,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: yarn
 
       - name: Configure Git
         run: |

--- a/.github/workflows/publish-standalone-homebrew.yml
+++ b/.github/workflows/publish-standalone-homebrew.yml
@@ -2,23 +2,50 @@ name: Publish Standalone (Homebrew)
 
 # Updates the Cask formula in Miragon/homebrew-tap after a standalone release.
 #
-# Triggers:
-#   - Manually via workflow_dispatch (supports dry_run for testing without pushing)
+# Callable two ways:
+#   - workflow_call (from release-standalone.yml orchestrator) — receives the
+#     DMG sha256 and filename as inputs, so no re-download of the ~150 MB DMG.
+#   - workflow_dispatch (manual rerun) — sha256 and filename are recomputed
+#     by downloading the DMG from the release.
 #
-# Required GitHub repo secret:
+# Required GitHub repo secret (or homebrew-tap environment secret):
 #   HOMEBREW_TAP_TOKEN   PAT with repo scope on Miragon/homebrew-tap
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Release tag (e.g. standalone-v0.0.1)"
+      version:
+        description: "Version without prefix (e.g. 0.0.1). Tag is always standalone-v<version>."
         required: true
         type: string
-      dry_run:
+      dry-run:
         description: "Generate formula without pushing to tap"
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Version without prefix (e.g. 0.0.4)"
+        required: true
+        type: string
+      dmg-sha256:
+        description: "sha256 of the DMG (skip recompute when provided)"
+        required: false
+        type: string
+        default: ""
+      dmg-filename:
+        description: "DMG filename (e.g. Miragon.BPMN.Modeler-0.0.4-arm64.dmg)"
+        required: false
+        type: string
+        default: ""
+      dry-run:
+        description: "Generate formula without pushing to tap"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      HOMEBREW_TAP_TOKEN:
+        required: true
 
 permissions: {}
 
@@ -26,24 +53,38 @@ jobs:
   update-tap:
     name: Update Cask formula
     runs-on: ubuntu-latest
+    environment: homebrew-tap
     permissions:
       contents: read
     steps:
-      - name: Resolve tag and version
+      - name: Resolve tag and DMG metadata
         id: meta
         env:
-          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SHA: ${{ inputs.dmg-sha256 }}
+          INPUT_FILENAME: ${{ inputs.dmg-filename }}
         run: |
-          TAG="$INPUT_TAG"
-          VERSION="${TAG#standalone-v}"
+          VERSION="$INPUT_VERSION"
+          TAG="standalone-v${VERSION}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Download DMG and compute sha256
+          if [ -n "$INPUT_SHA" ] && [ -n "$INPUT_FILENAME" ]; then
+            echo "skip-download=true" >> "$GITHUB_OUTPUT"
+            echo "sha256=$INPUT_SHA" >> "$GITHUB_OUTPUT"
+            echo "filename=$INPUT_FILENAME" >> "$GITHUB_OUTPUT"
+            echo "Using sha256 + filename from orchestrator inputs (skipping DMG download)."
+          else
+            echo "skip-download=false" >> "$GITHUB_OUTPUT"
+            echo "Will download DMG from release to recompute sha256 + filename."
+          fi
+
+      - name: Download DMG and compute sha256 (fallback)
+        if: steps.meta.outputs.skip-download == 'false'
         id: sha
         env:
           TAG: ${{ steps.meta.outputs.tag }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           DMG="Miragon.BPMN.Modeler-${VERSION}-arm64.dmg"
           URL="https://github.com/Miragon/bpmn-modeler/releases/download/${TAG}/${DMG}"
@@ -51,20 +92,39 @@ jobs:
           curl -fsSL -o "$DMG" "$URL"
           SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
           echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "filename=$DMG" >> "$GITHUB_OUTPUT"
           echo "sha256: $SHA"
 
-      - name: Generate Cask formula
-        id: formula
+      - name: Resolve final sha256 and filename
+        id: final
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
-          SHA: ${{ steps.sha.outputs.sha256 }}
+          ORCH_SHA: ${{ steps.meta.outputs.sha256 }}
+          ORCH_FILE: ${{ steps.meta.outputs.filename }}
+          FALLBACK_SHA: ${{ steps.sha.outputs.sha256 }}
+          FALLBACK_FILE: ${{ steps.sha.outputs.filename }}
         run: |
+          SHA="${ORCH_SHA:-$FALLBACK_SHA}"
+          FILE="${ORCH_FILE:-$FALLBACK_FILE}"
+          if [ -z "$SHA" ] || [ -z "$FILE" ]; then
+            echo "Failed to resolve DMG sha256/filename." && exit 1
+          fi
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "filename=$FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Cask formula
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          VERSION: ${{ inputs.version }}
+          SHA: ${{ steps.final.outputs.sha256 }}
+          FILENAME: ${{ steps.final.outputs.filename }}
+        run: |
+          URL_FILENAME="${FILENAME// /%20}"
           cat > miragon-bpmn-modeler.rb <<EOF
           cask "miragon-bpmn-modeler" do
             version "${VERSION}"
             sha256 "${SHA}"
 
-            url "https://github.com/Miragon/bpmn-modeler/releases/download/standalone-v#{version}/Miragon.BPMN.Modeler-#{version}-arm64.dmg"
+            url "https://github.com/Miragon/bpmn-modeler/releases/download/${TAG}/${URL_FILENAME}"
             name "Miragon BPMN Modeler"
             desc "Standalone BPMN/DMN process modeler"
             homepage "https://github.com/Miragon/bpmn-modeler"
@@ -76,9 +136,9 @@ jobs:
           cat miragon-bpmn-modeler.rb
 
       - name: Push to homebrew-tap
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry-run }}
         env:
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ inputs.version }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/Miragon/homebrew-tap.git" tap

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -1,5 +1,16 @@
 name: Publish Standalone (macOS)
 
+# Builds the VS Code extension on Linux, then signs, notarizes and uploads
+# the macOS DMG. Split into two jobs so the expensive macOS runner only
+# handles what genuinely needs macOS (codesign + notarytool + electron-builder).
+#
+# Callable two ways:
+#   - workflow_dispatch (manual single-step run; dry-run defaults to true)
+#   - workflow_call (from release-standalone.yml orchestrator)
+#
+# In workflow_call mode the workflow exposes the DMG's sha256 and filename
+# so the homebrew job can skip re-downloading the ~150 MB DMG.
+
 on:
   workflow_dispatch:
     inputs:
@@ -8,6 +19,31 @@ on:
         required: false
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      dry-run:
+        description: 'Dry run (build + sign + notarize, do not publish)'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      dmg-sha256:
+        description: 'sha256 of the signed/notarized DMG'
+        value: ${{ jobs.package-dmg.outputs.dmg-sha256 }}
+      dmg-filename:
+        description: 'Base filename of the DMG (e.g. Miragon BPMN Modeler-0.0.4-arm64.dmg)'
+        value: ${{ jobs.package-dmg.outputs.dmg-filename }}
+    secrets:
+      CSC_LINK:
+        required: true
+      CSC_KEY_PASSWORD:
+        required: true
+      APPLE_ID:
+        required: true
+      APPLE_APP_SPECIFIC_PASSWORD:
+        required: true
+      APPLE_TEAM_ID:
+        required: true
 
 permissions:
   contents: write
@@ -17,9 +53,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish-macos:
-    name: Build, sign, notarize, publish (macOS)
-    runs-on: macos-latest
+  build-vsix:
+    name: Build VS Code extension (.vsix)
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout sources
@@ -28,22 +64,63 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
-      - name: Setup NodeJS 22
+      - name: Setup Node 22
         uses: actions/setup-node@v6
         with:
           node-version: '22'
+          cache: yarn
 
       - name: Install dependencies
-        run: yarn
+        run: yarn install --immutable
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build extension
+      - name: Build (libs → webviews → modeler-plugin)
         run: yarn build
 
-      - name: Package extension as .vsix
+      - name: Package .vsix
         working-directory: dist/apps/modeler-plugin
         run: npx @vscode/vsce package --out bpmn-modeler-plugin.vsix --yarn --no-dependencies
+
+      - name: Upload .vsix artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: standalone-vsix
+          path: dist/apps/modeler-plugin/bpmn-modeler-plugin.vsix
+          retention-days: 1
+          if-no-files-found: error
+
+  package-dmg:
+    name: Sign, notarize, publish DMG (macOS)
+    runs-on: macos-latest
+    needs: build-vsix
+    outputs:
+      dmg-sha256: ${{ steps.dmg-meta.outputs.sha256 }}
+      dmg-filename: ${{ steps.dmg-meta.outputs.filename }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --immutable
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download .vsix from build-vsix job
+        uses: actions/download-artifact@v6
+        with:
+          name: standalone-vsix
+          path: dist/apps/modeler-plugin
 
       - name: Bundle extension into standalone plugins/
         run: yarn workspace @miragon/bpmn-modeler-standalone bundle
@@ -59,15 +136,7 @@ jobs:
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
-      - name: Upload DMG artifact (dry-run)
-        if: inputs.dry-run == true
-        uses: actions/upload-artifact@v7
-        with:
-          name: standalone-dmg-dry-run
-          path: apps/standalone/dist/*.dmg
-          retention-days: 7
-
-      - name: Build, sign, notarize DMG
+      - name: Build, sign, notarize DMG (release)
         if: inputs.dry-run == false
         run: yarn workspace @miragon/bpmn-modeler-standalone run package:release
         env:
@@ -77,6 +146,33 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Compute DMG metadata (sha256 + filename)
+        id: dmg-meta
+        run: |
+          shopt -s nullglob
+          DMG_FILES=(apps/standalone/dist/*.dmg)
+          if [ "${#DMG_FILES[@]}" -eq 0 ]; then
+            echo "No DMG produced in apps/standalone/dist/." && exit 1
+          fi
+          DMG_PATH="${DMG_FILES[0]}"
+          DMG_NAME="$(basename "$DMG_PATH")"
+          SHA="$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')"
+          echo "filename=$DMG_NAME" >> "$GITHUB_OUTPUT"
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "DMG: $DMG_NAME"
+          echo "sha256: $SHA"
+
+      - name: Upload DMG artifact (dry-run)
+        if: inputs.dry-run == true
+        uses: actions/upload-artifact@v7
+        with:
+          name: standalone-dmg-dry-run
+          path: |
+            apps/standalone/dist/*.dmg
+            apps/standalone/dist/*.dmg.blockmap
+            apps/standalone/dist/latest-mac.yml
+          retention-days: 7
 
       - name: Upload artifacts to release
         if: inputs.dry-run == false

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -1,0 +1,63 @@
+name: Release Standalone
+
+# Single-click orchestrator: prepare → publish → homebrew.
+# Each sub-workflow is also runnable on its own via workflow_dispatch for
+# debugging or partial reruns. Dry-run propagates to all three steps.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry-run:
+        description: 'Dry run (no commit, tag, release, upload, or tap push)'
+        required: false
+        type: boolean
+        default: false
+      skip-homebrew:
+        description: 'Skip the Homebrew tap update'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: standalone-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release
+    uses: ./.github/workflows/prepare-release-standalone.yml
+    with:
+      release-type: ${{ inputs.release-type }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit
+
+  publish:
+    name: Publish DMG
+    needs: prepare
+    uses: ./.github/workflows/publish-standalone.yml
+    with:
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit
+
+  homebrew:
+    name: Update Homebrew tap
+    needs: [prepare, publish]
+    if: ${{ !inputs.skip-homebrew }}
+    uses: ./.github/workflows/publish-standalone-homebrew.yml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      dmg-sha256: ${{ needs.publish.outputs.dmg-sha256 }}
+      dmg-filename: ${{ needs.publish.outputs.dmg-filename }}
+      dry-run: ${{ inputs.dry-run }}
+    secrets: inherit

--- a/apps/standalone/README.md
+++ b/apps/standalone/README.md
@@ -90,34 +90,43 @@ the login keychain. See [Releasing](#releasing) below for the full setup.
 
 ## Releasing
 
-CI handles releases via two workflows:
+CI handles releases via a single orchestrator workflow that chains three
+sub-workflows. Each sub-workflow remains independently runnable for reruns.
 
-- `.github/workflows/prepare-release-standalone.yml` — manual
-  (`workflow_dispatch`). Bumps `apps/standalone/package.json`, commits,
-  tags `standalone-vX.Y.Z`, creates the GitHub Release.
-- `.github/workflows/publish-standalone.yml` — fires on
-  `release: published` for `standalone-v*` tags. Runs on `macos-latest`,
-  builds the `.vsix`, bundles it, signs with the Apple Developer ID cert,
-  notarizes, and uploads the `.dmg` + `latest-mac.yml` to the release.
+- `.github/workflows/release-standalone.yml` — **single entry point**
+  (`workflow_dispatch`). Runs prepare → publish → homebrew in sequence,
+  propagating `dry-run` to every step.
+- `.github/workflows/prepare-release-standalone.yml` — bumps
+  `apps/standalone/package.json` + `libs/standalone-extension/package.json`,
+  commits, tags `standalone-vX.Y.Z`, creates the GitHub Release.
+- `.github/workflows/publish-standalone.yml` — two-job pipeline:
+  builds the `.vsix` on `ubuntu-latest`, then signs/notarizes the DMG on
+  `macos-latest` and uploads `.dmg` + `latest-mac.yml` to the release.
   Existing installs pick up updates via `electron-updater` on next launch.
+- `.github/workflows/publish-standalone-homebrew.yml` — updates the Cask
+  formula in [Miragon/homebrew-tap](https://github.com/Miragon/homebrew-tap)
+  so `brew upgrade --cask miragon-bpmn-modeler` picks up the new version.
 
 To cut a release:
 
-1. Go to **Actions** → **Prepare Release Standalone** → **Run workflow**,
-   pick `patch` / `minor` / `major`. The prepare workflow tags + creates
-   the release.
-2. The `release: published` event auto-triggers **Publish Standalone**,
-   which produces and uploads the signed DMG.
+1. Go to **Actions** → **Release Standalone** → **Run workflow**.
+2. Pick `release-type` (`patch` / `minor` / `major`), toggle `dry-run`
+   on/off (defaults to off), optionally tick `skip-homebrew` if you only
+   want the DMG.
+3. The orchestrator runs `prepare` → `publish` → `homebrew` automatically.
+   In dry-run mode nothing is committed, tagged, uploaded, or pushed; the
+   DMG lands as a workflow artifact and the cask formula is only logged.
 
-Both workflows accept a `dry-run` input. See
-[Release process](../../docs/vscode/contributing/release-process.md) for
-the full pipeline diagram and the equivalent flow for the VS Code
-extension and the c7 npm lib.
+The orchestrator pauses before the Homebrew step if the `homebrew-tap`
+environment has a required reviewer configured (see *Approval gate* below).
 
-After the release is published, `.github/workflows/standalone-homebrew.yml`
-automatically updates the Cask formula in
-[Miragon/homebrew-tap](https://github.com/Miragon/homebrew-tap) so that
-`brew upgrade --cask miragon-bpmn-modeler` picks up the new version.
+**Single-step reruns:** Each sub-workflow keeps its own `workflow_dispatch`
+trigger. Use these for debugging a single phase without re-running the
+whole chain.
+
+See [Release process](../../docs/vscode/contributing/release-process.md)
+for the equivalent flow for the VS Code extension and the c7 npm lib
+(which use a different `workflow_dispatch`-based pattern).
 
 **Required GitHub repo secrets** (one-time setup):
 
@@ -128,7 +137,27 @@ automatically updates the Cask formula in
 | `APPLE_ID` | Apple ID email of a Miragon team member |
 | `APPLE_APP_SPECIFIC_PASSWORD` | generated at appleid.apple.com |
 | `APPLE_TEAM_ID` | `G5JZQ328LJ` |
-| `HOMEBREW_TAP_TOKEN` | PAT with `repo` scope on `Miragon/homebrew-tap` |
+| `RELEASE_PAT` | PAT with `repo` scope, used by `prepare` to push commits/tags |
+| `HOMEBREW_TAP_TOKEN` | PAT with `repo` scope on `Miragon/homebrew-tap` (recommended: scope to the `homebrew-tap` environment, see below) |
+
+### Approval gate / environment setup
+
+The Homebrew tap update is the only step that publishes to a public
+destination outside this repo. The workflow expects a GitHub environment
+named `homebrew-tap`. To configure a manual approval gate before each
+tap push:
+
+1. Repo *Settings* → *Environments* → **New environment** → name it
+   `homebrew-tap`.
+2. *Deployment protection rules* → **Required reviewers** → add at least
+   one maintainer.
+3. (Recommended) move `HOMEBREW_TAP_TOKEN` from *Repository secrets* to
+   the `homebrew-tap` environment's *Environment secrets* — tightens
+   blast radius so the token is only usable from this gated job.
+
+The orchestrator pauses on the Homebrew job until a reviewer approves.
+Wait time is free in terms of runner minutes. If you skip step 2, the
+chain runs through without a gate; dry-run remains the only safety net.
 
 ## Structure
 

--- a/docs/vscode/contributing/release-process.md
+++ b/docs/vscode/contributing/release-process.md
@@ -6,39 +6,50 @@ version history lives on
 
 ## Overview
 
-Each shippable artefact has **two** workflows: a `prepare-*` and a `publish-*`.
-The split exists so the prepare workflow can create a GitHub Release without
-the publish workflow accidentally re-triggering itself in a loop. Splitting
-into separate files also keeps each workflow short and single-purpose.
+Each shippable artefact has a `prepare-*` and a `publish-*` workflow. The
+split keeps each file short, single-purpose, and individually rerunnable
+for debugging.
 
-- **`prepare-*`** — manual (`workflow_dispatch`). Bumps the version, runs the
-  sanity checks, commits the bump, pushes the tag, and creates a GitHub
-  Release. Does **not** publish anything.
-- **`publish-*`** — fires on `release: published`. Builds the artefact,
-  attaches it to the existing release, and pushes it to the relevant
-  registry (Marketplace / npm / GitHub Release assets). Also runnable
-  manually with `dry-run: true` to produce an artefact without uploading.
+- **`prepare-*`** — bumps the version, runs the sanity checks, commits the
+  bump, pushes the tag, creates a GitHub Release. Does **not** publish.
+- **`publish-*`** — builds the artefact, attaches it to the existing
+  release, and pushes it to the relevant registry (Marketplace / npm /
+  GitHub Release assets / Homebrew). Runnable manually with `dry-run: true`
+  to produce an artefact without uploading.
 
-Both workflows accept a `dry-run` input for safe local validation.
+All workflows accept a `dry-run` input for safe local validation.
+
+The **standalone** app additionally has an orchestrator
+(`release-standalone.yml`) that chains `prepare` → `publish` → `homebrew`
+via `workflow_call`. Other artefacts are launched with separate
+`workflow_dispatch` calls per phase.
 
 ## Pipeline flow
 
 ```mermaid
 flowchart LR
     user([Maintainer])
-    prepare[prepare-release-*.yml<br/>workflow_dispatch]
-    bump[Bump version<br/>commit + tag]
-    ghrelease[(GitHub Release<br/>tag prefix v* / standalone-v* / …)]
-    publish[publish-*.yml<br/>release: published]
-    artifact[(Marketplace / npm /<br/>signed DMG)]
 
-    user -->|Run workflow| prepare
-    prepare --> bump
-    bump --> ghrelease
-    ghrelease -.->|release event| publish
-    publish --> artifact
+    subgraph Standalone[Standalone macOS app]
+        orchestrator[release-standalone.yml<br/>workflow_dispatch]
+        s_prepare[prepare-release-standalone.yml<br/>workflow_call]
+        s_publish[publish-standalone.yml<br/>workflow_call<br/>Linux + macOS jobs]
+        s_brew[publish-standalone-homebrew.yml<br/>workflow_call<br/>env: homebrew-tap]
+        s_assets[(GitHub Release DMG<br/>+ Homebrew Cask)]
 
-    user -.->|workflow_dispatch<br/>dry-run=true| publish
+        orchestrator --> s_prepare --> s_publish --> s_brew --> s_assets
+    end
+
+    subgraph Other[VS Code extension / c7 npm lib]
+        o_prepare[prepare-release-*.yml<br/>workflow_dispatch]
+        o_publish[publish-*.yml<br/>workflow_dispatch]
+        o_assets[(Marketplace / npm)]
+
+        o_prepare --> o_publish --> o_assets
+    end
+
+    user -->|1 click| orchestrator
+    user -->|2 clicks| o_prepare
 ```
 
 ## Releases per artefact
@@ -49,13 +60,13 @@ Published to the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 
 | File | Trigger | Tag prefix |
 |---|---|---|
-| `prepare-release-vscode-modeler.yml` | manual | — |
-| `publish-vscode-modeler.yml` | `release: published`, `workflow_dispatch` | `v*` (e.g. `v0.9.3`) |
+| `prepare-release-vscode-modeler.yml` | `workflow_dispatch` | — |
+| `publish-vscode-modeler.yml` | `workflow_dispatch` | `v*` (e.g. `v0.9.3`) |
 
 `prepare` bumps `apps/modeler-plugin/package.json`, runs lint + test + build,
 then commits, tags `vX.Y.Z`, and creates a GitHub Release. `publish` packages
 the `.vsix`, attaches it to the release, and runs `vsce publish` against the
-VS Code Marketplace.
+VS Code Marketplace. Both steps are launched separately by the maintainer.
 
 ### create-append-c7-element-templates (npm lib)
 
@@ -63,49 +74,54 @@ Published to [npm](https://www.npmjs.com/package/@miragon/create-append-c7-eleme
 
 | File | Trigger | Tag prefix |
 |---|---|---|
-| `prepare-release-create-append-c7.yml` | manual | — |
-| `publish-create-append-c7.yml` | `release: published`, `workflow_dispatch` | `create-append-c7-element-templates/v*` |
+| `prepare-release-create-append-c7.yml` | `workflow_dispatch` | — |
+| `publish-create-append-c7.yml` | `workflow_dispatch` | `create-append-c7-element-templates/v*` |
 
 `prepare` bumps `libs/create-append-c7-element-templates/package.json` and
-builds the library; `publish` runs `npm publish --access public`.
+builds the library; `publish` runs `npm publish --access public`. Both
+steps are launched separately by the maintainer.
 
 ### Standalone macOS app
 
-Published as DMG assets on [GitHub Releases](https://github.com/Miragon/bpmn-modeler/releases?q=standalone-v).
+Published as DMG assets on [GitHub Releases](https://github.com/Miragon/bpmn-modeler/releases?q=standalone-v)
+and as a Cask in [Miragon/homebrew-tap](https://github.com/Miragon/homebrew-tap).
 
 | File | Trigger | Tag prefix |
 |---|---|---|
-| `prepare-release-standalone.yml` | manual | — |
-| `publish-standalone.yml` | `release: published`, `workflow_dispatch` | `standalone-v*` |
+| `release-standalone.yml` (orchestrator) | `workflow_dispatch` | — |
+| `prepare-release-standalone.yml` | `workflow_dispatch` + `workflow_call` | — |
+| `publish-standalone.yml` | `workflow_dispatch` + `workflow_call` | `standalone-v*` |
+| `publish-standalone-homebrew.yml` | `workflow_dispatch` + `workflow_call` | — |
 
-`prepare` bumps `apps/standalone/package.json`. `publish` runs on
-`macos-latest`, signs and notarizes the DMG with the Apple Developer ID
-cert, and attaches the DMG + `latest-mac.yml` manifest to the release
-(consumed by `electron-updater` for in-app auto-update).
+The standalone orchestrator chains prepare → publish → homebrew in one
+click. `publish-standalone.yml` is split across two jobs: the `.vsix` is
+built on `ubuntu-latest`, then the DMG is signed and notarized with the
+Apple Developer ID cert on `macos-latest`. The DMG + `latest-mac.yml`
+manifest are attached to the release (consumed by `electron-updater` for
+in-app auto-update), and the Cask formula is updated in `homebrew-tap`.
 
 ## How to release
 
-The flow is identical for all three artefacts. Example: VS Code extension.
+### VS Code extension and c7 npm lib
 
-1. Go to the **Actions** tab → **Prepare Release VS Code Modeler** → **Run workflow**.
-2. Pick the **release type** (`patch` / `minor` / `major`) and decide whether
-   to enable **Dry run**.
-3. Click **Run workflow**.
-4. The prepare workflow:
-   - Bumps `apps/modeler-plugin/package.json`.
-   - Runs lint, test, build.
-   - Commits the bump, pushes the `vX.Y.Z` tag, creates the GitHub Release.
-5. The new release fires a `release: published` event, which automatically
-   triggers **Publish VS Code Modeler**:
-   - Builds the extension at the tagged commit.
-   - Verifies `package.json` version matches the release tag.
-   - Packages the `.vsix`, attaches it to the release, publishes to the
-     VS Code Marketplace.
+1. Go to **Actions** → **Prepare Release …** → **Run workflow**.
+2. Pick the **release type** (`patch` / `minor` / `major`) and decide
+   whether to enable **Dry run**.
+3. Once the prepare workflow finishes, go to **Actions** → **Publish …**
+   → **Run workflow** and decide whether to dry-run.
 
-> Both workflows only run on the `main` branch (prepare) or against a
-> matching tag prefix (publish). Dry-run on prepare skips commit/tag/release.
-> Dry-run on publish builds the artefact and uploads it as a workflow
-> artifact instead of publishing it.
+### Standalone macOS app
+
+1. Go to **Actions** → **Release Standalone** → **Run workflow**.
+2. Pick `release-type`, toggle `dry-run`/`skip-homebrew`.
+3. Watch the chain run prepare → publish → homebrew. If the
+   `homebrew-tap` environment has a required reviewer, the run pauses
+   on the homebrew job until the reviewer approves.
+
+> Dry-run on prepare skips commit/tag/release. Dry-run on publish builds
+> the artefact and uploads it as a workflow artifact instead of pushing
+> to the release. Dry-run on homebrew generates the Cask formula and
+> only logs it.
 
 ## Tag/version drift safeguard
 


### PR DESCRIPTION
## Summary

- New `release-standalone.yml` orchestrator chains **prepare → publish → homebrew** via `workflow_call`. One click instead of three; `dry-run` and `skip-homebrew` propagate end-to-end.
- `publish-standalone.yml` is split into two jobs: `.vsix` is built on `ubuntu-latest`, only sign/notarize runs on `macos-latest`. Estimated ~40 % less macOS minute-equivalent per release.
- Homebrew job receives `dmg-sha256` + `dmg-filename` from the publish job (saves a 150 MB re-download). Manual `workflow_dispatch` keeps the curl-fallback for reruns.
- Adds `cache: yarn` to setup-node in prepare + publish.
- Homebrew job runs in `environment: homebrew-tap` so `HOMEBREW_TAP_TOKEN` can be env-scoped and a required-reviewer rule can gate the public tap push.
- Each sub-workflow keeps its own `workflow_dispatch` trigger for single-step reruns / debugging.
- Cleans up doc-drift: README and `docs/vscode/contributing/release-process.md` previously claimed an event-driven `release: published` chain that never existed in YAML.

Trigger surface stays tight — no `release: published` / `push.tags` triggers exist in any standalone workflow, so a `v*` vscode tag cannot cross-fire a standalone build (and vice versa). `workflow_call` is invokable only from the orchestrator.

## One-time setup (in GitHub UI)

To activate the approval gate on the homebrew step:
1. Settings → Environments → New environment → **homebrew-tap**
2. Deployment protection rules → Required reviewers → add a maintainer
3. Move `HOMEBREW_TAP_TOKEN` from repo secrets into the environment's secrets

Without this, the chain runs through end-to-end without a gate (dry-run remains the only safety).

## Test plan

- [ ] Run `actionlint` (or the rhysd/actionlint container) on `.github/workflows/` — expect zero errors.
- [ ] On this branch, trigger **Actions → Release Standalone** with `release-type=patch`, `dry-run=true`, `skip-homebrew=false`. Expect:
  - `prepare` runs, logs version bump, **no** commit/tag/release (also blocked by the `github.ref == 'refs/heads/main'` guard on non-default branches).
  - `publish` runs both jobs; macOS job's `dmg-meta` step exports a non-empty sha256; DMG lands as `standalone-dmg-dry-run` artifact.
  - `homebrew` runs (or pauses on approval), logs the generated Cask, **no** push to `Miragon/homebrew-tap`.
- [ ] Confirm macOS job wall-clock < 12 min (vs. ~16 min today).
- [ ] After merging to `main`: cut `standalone-v0.0.4` via the orchestrator with `dry-run=false`. Verify DMG on the release and the Cask commit on the tap.
- [ ] Verify each sub-workflow still works standalone via its own `workflow_dispatch` (rerun-debug path).

## Out of scope

- Electron native-rebuild caching (listed as future work in the plan; risky cache-path invalidation, low marginal win on top of `cache: yarn`).
- The misleading `release: published` mentions in the *create-append-c7* and *vscode-modeler* prepare workflow comments — those are unrelated to standalone and left untouched.