### PR TITLE
ci(standalone): drop broken yarn cache hint from prepare-release

### DIFF
--- a/.github/workflows/prepare-release-standalone.yml
+++ b/.github/workflows/prepare-release-standalone.yml
@@ -71,7 +71,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: yarn
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary

Unblocks the new orchestrator: `actions/setup-node@v6` with `cache: yarn` calls `yarn cache dir` before corepack is enabled, hitting the system yarn 1.22 which conflicts with the repo's `packageManager: yarn@4.14.1` and aborts the job.

The prepare job never runs `yarn install` or `yarn build` — the version bump uses plain `node` — so the cache hint provided zero benefit and only introduced this trap.

Observed in run https://github.com/Miragon/bpmn-modeler/actions/runs/25728079136 (the first 0.0.4 attempt).

## Test plan

- [x] After merge, retrigger **Release Standalone** (`release-type=patch`, `dry-run=false`) on `main` and confirm `prepare` reaches the bump-version step.