### PR TITLE
ci: weekly npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     labels:
       - "Technical Dept"
     schedule:
-      interval: daily
+      interval: weekly
       time: "05:00"
     commit-message:
       prefix: chore

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -71,7 +71,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --mode=skip-build
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Switch npm Dependabot from `daily` to `weekly` (matches github-actions ecosystem).
- Fix the standalone publish pipeline: the Linux `build-vsix` job was failing in `yarn install` because Theia/Electron transitive native modules (`native-keymap`, `node-pty`, `keytar`, `@parcel/watcher`, …) tried to compile via node-gyp and require X11 dev libs missing from `ubuntu-latest`. They aren't needed to package the VSIX, so install with `--mode=skip-build`. The macOS DMG job still runs a full install where those modules are actually used.

Repro of the failure: https://github.com/Miragon/bpmn-modeler/actions/runs/25728326102/job/75546841082

## Test plan
- [ ] Re-run the Release Standalone workflow (manual dispatch, dry-run) and confirm the `build-vsix` job succeeds.
- [ ] Confirm the macOS `package-dmg` job still produces a working signed DMG (full install runs there).
- [ ] Next Dependabot scan for npm fires on the weekly schedule rather than daily.