### PR TITLE
ci(standalone): publish DMG from the bump tag, not the dispatched SHA

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: true
+      ref:
+        description: 'Git ref to check out (e.g. the bump tag from prepare-release). Defaults to the triggering SHA.'
+        required: false
+        type: string
+        default: ''
     outputs:
       dmg-sha256:
         description: 'sha256 of the signed/notarized DMG'
@@ -60,6 +65,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Enable corepack
         run: corepack enable
@@ -101,6 +108,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Enable corepack
         run: corepack enable

--- a/.github/workflows/release-standalone.yml
+++ b/.github/workflows/release-standalone.yml
@@ -48,6 +48,7 @@ jobs:
     uses: ./.github/workflows/publish-standalone.yml
     with:
       dry-run: ${{ inputs.dry-run }}
+      ref: ${{ inputs.dry-run && '' || format('standalone-v{0}', needs.prepare.outputs.version) }}
     secrets: inherit
 
   homebrew:


### PR DESCRIPTION
## Summary

Fixes the release-standalone orchestrator failure observed in run [25728977583](https://github.com/Miragon/bpmn-modeler/actions/runs/25728977583/job/75549009107):

- `prepare` bumped `apps/standalone/package.json` to **0.0.5**, committed/tagged/released `standalone-v0.0.5`.
- `publish` then ran a bare `actions/checkout@v6`, which uses `github.sha` — the SHA the orchestrator was dispatched from, *before* the bump commit. So the runner still saw version **0.0.4**, electron-builder produced `Miragon BPMN Modeler-0.0.4-arm64.dmg`, and the upload step failed with:
  > Release standalone-v0.0.4 does not exist.

This PR forwards the new tag from `prepare` into `publish-standalone.yml` and checks it out, so the build, DMG filename, and release lookup all line up.

## Changes

- `publish-standalone.yml`: new optional `ref` input on `workflow_call`; both `actions/checkout@v6` steps honor it.
- `release-standalone.yml`: orchestrator passes `standalone-v<version>` from `prepare.outputs.version` as `ref` (empty string in dry-run, since no tag is created then).

## Test plan

- [ ] Trigger `Release Standalone` with `dry-run: true` → publish job still works against the dispatched SHA (no tag to check out).
- [ ] Trigger `Release Standalone` with `dry-run: false`, `release-type: patch` → DMG filename, GitHub release tag, and upload target all use the new version.
- [ ] Trigger `Publish Standalone (macOS)` standalone (workflow_dispatch) → still works without a ref input.