### PR TITLE
fix(standalone): pin DMG artifactName so GitHub doesn't rewrite spaces to dots

### DIFF
--- a/apps/standalone/electron-builder.yml
+++ b/apps/standalone/electron-builder.yml
@@ -67,6 +67,8 @@ mac:
   notarize: true
 dmg:
   format: ULFO
+  # GitHub Releases rewrites spaces in uploaded asset names to dots.
+  artifactName: Miragon.BPMN.Modeler-${version}-${arch}.${ext}
 win:
   target:
     - nsis


### PR DESCRIPTION
## Summary

GitHub Releases rewrites spaces in uploaded asset names to dots, so the DMG produced as `Miragon BPMN Modeler-0.0.6-arm64.dmg` ended up served as `Miragon.BPMN.Modeler-0.0.6-arm64.dmg`. This broke:

- the Homebrew cask URL (workflow encoded spaces as `%20` → 404, see https://github.com/Miragon/bpmn-modeler/releases/download/standalone-v0.0.6/Miragon%20BPMN%20Modeler-0.0.6-arm64.dmg)
- electron-updater's `latest-mac.yml` (still references the spaces-name)

Set `dmg.artifactName` explicitly to the dotted form so on-disk filename, `latest-mac.yml`, the uploaded asset, and the cask URL all agree.

The 0.0.6 cask in `Miragon/homebrew-tap` was already patched manually (https://github.com/Miragon/homebrew-tap/commit/72a4e97b440b0f6ae84684020d347e8134b12480) so `brew upgrade` works today.

## Test plan

- [ ] Trigger `Release Standalone` (patch, dry-run=false). Confirm:
  - DMG produced locally as `Miragon.BPMN.Modeler-<version>-arm64.dmg` (no spaces).
  - Release asset name matches (no GitHub mangling).
  - Homebrew tap update produces a cask URL that returns 200.
  - `latest-mac.yml` references the dotted filename.