### PR TITLE
fix(modeler-plugin): navigate to declaring process works in standalone (#1011)

### DIFF
--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -64,10 +64,16 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      * Registers this provider as the custom editor for `.bpmn` files and adds
      * the resulting disposable to the extension context.
      *
+     * `retainContextWhenHidden: true` keeps the live bpmn-js modeler instance
+     * alive across tab hides — without it, re-show races `importXML` and
+     * occasionally paints only token-simulation markers on an empty canvas.
+     *
      * @param context The VS Code extension context.
      */
     register(context: ExtensionContext): void {
-        const provider = window.registerCustomEditorProvider(BPMN_VIEW_TYPE, this);
+        const provider = window.registerCustomEditorProvider(BPMN_VIEW_TYPE, this, {
+            webviewOptions: { retainContextWhenHidden: true },
+        });
         context.subscriptions.push(provider);
     }
 

--- a/apps/modeler-plugin/src/controller/DmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/DmnEditorController.ts
@@ -39,10 +39,16 @@ export class DmnEditorController implements CustomTextEditorProvider {
      * Registers this provider as the custom editor for `.dmn` files and adds
      * the resulting disposable to the extension context.
      *
+     * `retainContextWhenHidden: true` keeps the live dmn-js modeler instance
+     * alive across tab hides — without it, re-show races `importXML` and
+     * occasionally paints only stale overlay markers on an empty canvas.
+     *
      * @param context The VS Code extension context.
      */
     register(context: ExtensionContext): void {
-        const provider = window.registerCustomEditorProvider(DMN_VIEW_TYPE, this);
+        const provider = window.registerCustomEditorProvider(DMN_VIEW_TYPE, this, {
+            webviewOptions: { retainContextWhenHidden: true },
+        });
         context.subscriptions.push(provider);
     }
 

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -15,6 +15,7 @@ import { BpmnDiffService } from "./service/BpmnDiffService";
 import { BpmnModelerService } from "./service/BpmnModelerService";
 import { DmnModelerService } from "./service/DmnModelerService";
 import { ModelNavigationService } from "./service/ModelNavigationService";
+import { ReferencedModelLocator } from "./service/modelNavigation/ReferencedModelLocator";
 import { BpmnCompareController } from "./controller/BpmnCompareController";
 import { CommandController } from "./controller/CommandController";
 import { BpmnEditorController } from "./controller/BpmnEditorController";
@@ -98,7 +99,11 @@ export function activate(context: ExtensionContext): void {
         vsUI,
         artifactSvc,
     );
-    const modelNavigationService = new ModelNavigationService(vsWorkspace, vsUI);
+    const referencedModelLocator = new ReferencedModelLocator(vsWorkspace, vsUI);
+    const modelNavigationService = new ModelNavigationService(
+        referencedModelLocator,
+        vsUI,
+    );
 
     // 4. Controllers
     const commandController = new CommandController(editorStore, vsDocument, vsUI, bpmnService);

--- a/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
@@ -1,50 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const configStore: { files: Record<string, boolean>; search: Record<string, boolean> } = {
-    files: {},
-    search: {},
-};
-
 vi.mock("vscode", () => ({
     commands: { executeCommand: vi.fn() },
     Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
-    workspace: {
-        getConfiguration: () => ({
-            get: <T>(key: string, fallback: T): T => {
-                if (key === "files.exclude") return configStore.files as T;
-                if (key === "search.exclude") return configStore.search as T;
-                return fallback;
-            },
-        }),
+    ProgressLocation: { SourceControl: 1, Window: 10, Notification: 15 },
+    window: {
+        withProgress: <T>(
+            _opts: unknown,
+            task: () => Promise<T>,
+        ): Promise<T> => task(),
     },
 }));
 
-import { commands } from "vscode";
+import { commands, ProgressLocation, window } from "vscode";
 
-import {
-    buildExcludeGlob,
-    buildIdRegex,
-    findExcludedRanges,
-    matchesOutsideComments,
-    ModelNavigationService,
-} from "./ModelNavigationService";
+import { ModelNavigationService } from "./ModelNavigationService";
+import { LocateResult } from "./modelNavigation/ReferencedModelLocator";
 
-function createMocks(files: Record<string, string>) {
-    const vsWorkspace = {
-        findFiles: vi.fn().mockImplementation((glob: string) => {
-            const wantsBpmn = glob.endsWith(".bpmn");
-            return Promise.resolve(
-                Object.keys(files).filter((path) =>
-                    wantsBpmn ? path.endsWith(".bpmn") : path.endsWith(".dmn"),
-                ),
-            );
-        }),
-        readFile: vi.fn().mockImplementation((path: string) => {
-            if (path in files) return Promise.resolve(files[path]);
-            return Promise.reject(new Error("not found"));
-        }),
+function createService(result: LocateResult) {
+    const locator = {
+        findDeclaringFiles: vi.fn().mockResolvedValue(result),
     };
-
     const vsUI = {
         showInfo: vi.fn(),
         showError: vi.fn(),
@@ -53,51 +29,56 @@ function createMocks(files: Record<string, string>) {
         logError: vi.fn(),
         pickReferencedModel: vi.fn(),
     };
-
-    const service = new ModelNavigationService(
-        vsWorkspace as never,
-        vsUI as never,
-    );
-
-    return { service, vsWorkspace, vsUI };
+    const service = new ModelNavigationService(locator as never, vsUI as never);
+    return { service, locator, vsUI };
 }
-
-const bpmnWithProcess = (id: string) =>
-    `<?xml version="1.0"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
-  <bpmn:process id="${id}" isExecutable="true"/>
-</bpmn:definitions>`;
-
-const dmnWithDecision = (id: string) =>
-    `<?xml version="1.0"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/">
-  <decision id="${id}" name="d"/>
-</definitions>`;
 
 beforeEach(() => {
     vi.mocked(commands.executeCommand).mockReset();
-    configStore.files = {};
-    configStore.search = {};
 });
 
 describe("ModelNavigationService.navigate", () => {
-    it("shows an info notification when no match is found", async () => {
-        const { service, vsUI } = createMocks({
-            "/a.bpmn": bpmnWithProcess("Other"),
+    it("wraps the search in a status-bar progress indicator", async () => {
+        const progressSpy = vi.spyOn(window, "withProgress");
+        const { service } = createService({
+            kind: "matches",
+            paths: ["/a.bpmn"],
+            readFailures: [],
         });
 
-        await service.navigate("Missing", "process");
+        await service.navigate("ProcessB", "process");
 
-        expect(vsUI.showInfo).toHaveBeenCalledWith(
-            expect.stringContaining("Missing"),
+        expect(progressSpy).toHaveBeenCalledTimes(1);
+        const [opts] = progressSpy.mock.calls[0];
+        expect((opts as { location: number }).location).toBe(
+            ProgressLocation.Window,
         );
-        expect(commands.executeCommand).not.toHaveBeenCalled();
+        expect((opts as { title: string }).title).toContain("ProcessB");
+        progressSpy.mockRestore();
     });
 
-    it("opens the unique match directly via vscode.open", async () => {
-        const { service, vsUI } = createMocks({
-            "/a.bpmn": bpmnWithProcess("ProcessB"),
-            "/b.bpmn": bpmnWithProcess("Other"),
+    it("delegates to the locator with the same arguments", async () => {
+        const { service, locator } = createService({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
+        });
+        const documentUri = { scheme: "file", path: "/x.bpmn" } as never;
+
+        await service.navigate("Id", "process", documentUri);
+
+        expect(locator.findDeclaringFiles).toHaveBeenCalledWith(
+            "Id",
+            "process",
+            documentUri,
+        );
+    });
+
+    it("opens the file directly via vscode.open when the locator returns a single match", async () => {
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: ["/a.bpmn"],
+            readFailures: [],
         });
 
         await service.navigate("ProcessB", "process");
@@ -109,10 +90,11 @@ describe("ModelNavigationService.navigate", () => {
         );
     });
 
-    it("opens the chosen file when multiple matches exist", async () => {
-        const { service, vsUI } = createMocks({
-            "/a.bpmn": bpmnWithProcess("Shared"),
-            "/b.bpmn": bpmnWithProcess("Shared"),
+    it("opens the user's QuickPick selection when the locator returns multiple matches", async () => {
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: ["/a.bpmn", "/b.bpmn"],
+            readFailures: [],
         });
         vsUI.pickReferencedModel.mockResolvedValue("/b.bpmn");
 
@@ -129,9 +111,10 @@ describe("ModelNavigationService.navigate", () => {
     });
 
     it("does not open anything when the user cancels the QuickPick", async () => {
-        const { service, vsUI } = createMocks({
-            "/a.bpmn": bpmnWithProcess("Shared"),
-            "/b.bpmn": bpmnWithProcess("Shared"),
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: ["/a.bpmn", "/b.bpmn"],
+            readFailures: [],
         });
         vsUI.pickReferencedModel.mockResolvedValue(undefined);
 
@@ -140,84 +123,71 @@ describe("ModelNavigationService.navigate", () => {
         expect(commands.executeCommand).not.toHaveBeenCalled();
     });
 
-    it("matches DMN decisions via the .dmn glob", async () => {
-        const { service } = createMocks({
-            "/a.dmn": dmnWithDecision("Decision_1"),
-            "/b.bpmn": bpmnWithProcess("Decision_1"),
+    it("shows an info notification when matches is empty", async () => {
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
         });
 
-        await service.navigate("Decision_1", "decision");
+        await service.navigate("Missing", "process");
 
-        expect(commands.executeCommand).toHaveBeenCalledWith(
-            "vscode.open",
-            expect.objectContaining({ path: "/a.dmn" }),
+        expect(vsUI.showInfo).toHaveBeenCalledWith(
+            expect.stringContaining("Missing"),
         );
+        expect(commands.executeCommand).not.toHaveBeenCalled();
     });
 
-    it("skips files that fail to read but keeps looking", async () => {
-        const { service, vsWorkspace, vsUI } = createMocks({
-            "/bad.bpmn": bpmnWithProcess("anything"),
-            "/good.bpmn": bpmnWithProcess("ProcessB"),
-        });
-        vsWorkspace.readFile.mockImplementationOnce(() =>
-            Promise.reject(new Error("EACCES")),
-        );
+    it("shows the 'open a folder' hint when the locator reports no-search-scope", async () => {
+        const { service, vsUI } = createService({ kind: "no-search-scope" });
 
         await service.navigate("ProcessB", "process");
 
-        expect(vsUI.logWarning).toHaveBeenCalled();
+        expect(vsUI.showInfo).toHaveBeenCalledWith(
+            expect.stringContaining("Open a folder"),
+        );
+        expect(commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it("logs each failure and shows an error when the locator reports all-unreadable", async () => {
+        const { service, vsUI } = createService({
+            kind: "all-unreadable",
+            attempted: 2,
+            failures: ["read /bad1 failed: EACCES", "read /bad2 failed: EACCES"],
+        });
+
+        await service.navigate("ProcessB", "process");
+
+        expect(vsUI.logWarning).toHaveBeenCalledTimes(2);
+        expect(vsUI.showError).toHaveBeenCalledWith(
+            expect.stringContaining("none of the candidate files were readable"),
+        );
+        expect(commands.executeCommand).not.toHaveBeenCalled();
+    });
+
+    it("logs partial read failures alongside a successful match", async () => {
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: ["/good.bpmn"],
+            readFailures: ["read /bad failed: EACCES"],
+        });
+
+        await service.navigate("ProcessB", "process");
+
+        expect(vsUI.logWarning).toHaveBeenCalledWith(
+            expect.stringContaining("EACCES"),
+        );
         expect(commands.executeCommand).toHaveBeenCalledWith(
             "vscode.open",
             expect.objectContaining({ path: "/good.bpmn" }),
         );
     });
 
-    it("shows an error notification when every candidate is unreadable", async () => {
-        const { service, vsWorkspace, vsUI } = createMocks({
-            "/bad.bpmn": bpmnWithProcess("ProcessB"),
-        });
-        vsWorkspace.readFile.mockRejectedValue(new Error("EACCES"));
-
-        await service.navigate("ProcessB", "process");
-
-        expect(vsUI.showError).toHaveBeenCalledWith(
-            expect.stringContaining("none of the candidate files were readable"),
-        );
-        expect(vsUI.showInfo).not.toHaveBeenCalled();
-        expect(commands.executeCommand).not.toHaveBeenCalled();
-    });
-
-    it("ignores commented-out process tags", async () => {
-        const xml = `<?xml version="1.0"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
-  <!-- <bpmn:process id="ProcessB"/> -->
-  <bpmn:process id="Other"/>
-</bpmn:definitions>`;
-        const { service, vsUI } = createMocks({ "/a.bpmn": xml });
-
-        await service.navigate("ProcessB", "process");
-
-        expect(vsUI.showInfo).toHaveBeenCalled();
-        expect(commands.executeCommand).not.toHaveBeenCalled();
-    });
-
-    it("ignores process tags inside CDATA blocks", async () => {
-        const xml = `<?xml version="1.0"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
-  <docs><![CDATA[<bpmn:process id="ProcessB"/>]]></docs>
-  <bpmn:process id="Other"/>
-</bpmn:definitions>`;
-        const { service, vsUI } = createMocks({ "/a.bpmn": xml });
-
-        await service.navigate("ProcessB", "process");
-
-        expect(vsUI.showInfo).toHaveBeenCalled();
-        expect(commands.executeCommand).not.toHaveBeenCalled();
-    });
-
     it("surfaces an error when vscode.open rejects", async () => {
-        const { service, vsUI } = createMocks({
-            "/a.bpmn": bpmnWithProcess("ProcessB"),
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: ["/a.bpmn"],
+            readFailures: [],
         });
         vi.mocked(commands.executeCommand).mockRejectedValueOnce(
             new Error("File not found"),
@@ -231,300 +201,19 @@ describe("ModelNavigationService.navigate", () => {
         expect(vsUI.logError).toHaveBeenCalled();
     });
 
-    it("truncates very long reference ids in the no-match notification", async () => {
+    it("truncates very long reference ids in user-facing notifications", async () => {
         const huge = "x".repeat(500);
-        const { service, vsUI } = createMocks({
-            "/a.bpmn": bpmnWithProcess("Other"),
+        const { service, vsUI } = createService({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
         });
 
         await service.navigate(huge, "process");
 
         const message = vsUI.showInfo.mock.calls[0][0] as string;
-        expect(message.length).toBeLessThan(200);
+        // The 500-char id must NOT appear in full — truncation kicks in.
+        expect(message).not.toContain(huge);
         expect(message).toContain("…");
-    });
-
-    it("forwards the source document URI to getConfiguration", async () => {
-        const { service } = createMocks({
-            "/a.bpmn": bpmnWithProcess("ProcessB"),
-        });
-        const { workspace: vscodeWorkspace } = await import("vscode");
-        const spy = vi.spyOn(vscodeWorkspace, "getConfiguration");
-        const documentUri = { scheme: "file", path: "/src/a.bpmn" } as never;
-
-        await service.navigate("ProcessB", "process", documentUri);
-
-        expect(spy).toHaveBeenCalledWith(undefined, documentUri);
-        spy.mockRestore();
-    });
-
-    it("reads candidate files in parallel, not serially", async () => {
-        // Arrange a deferred resolution for each path.  If reads were serial,
-        // the second readFile would only START after the first resolves —
-        // therefore `pendingResolvers.length` would be 1 at any time.  With
-        // parallel reads it reaches the file count before any resolves.
-        const { service, vsWorkspace } = createMocks({
-            "/a.bpmn": "<doc/>",
-            "/b.bpmn": "<doc/>",
-            "/c.bpmn": "<doc/>",
-        });
-        const pendingResolvers: ((value: string) => void)[] = [];
-        vsWorkspace.readFile.mockImplementation(
-            () => new Promise<string>((resolve) => pendingResolvers.push(resolve)),
-        );
-
-        const navigation = service.navigate("ProcessB", "process");
-        // Microtask queue drained — all three readFile() calls should have
-        // landed in pendingResolvers if reads are parallel.
-        await Promise.resolve();
-        await Promise.resolve();
-
-        expect(pendingResolvers).toHaveLength(3);
-
-        // Resolve everything so the navigate promise settles cleanly.
-        pendingResolvers.forEach((resolve) => resolve("<doc/>"));
-        await navigation;
-    });
-
-    it("shows the no-match info notification when the workspace contains no .bpmn files", async () => {
-        const { service, vsUI } = createMocks({});
-
-        await service.navigate("ProcessB", "process");
-
-        expect(vsUI.showInfo).toHaveBeenCalledWith(
-            expect.stringContaining("No model declaring"),
-        );
-        // Empty workspace must NOT trigger the "all unreadable" error path.
-        expect(vsUI.showError).not.toHaveBeenCalled();
-        expect(commands.executeCommand).not.toHaveBeenCalled();
-    });
-});
-
-describe("ModelNavigationService.navigate — exclude glob", () => {
-    it("forwards the composed exclude glob to vsWorkspace.findFiles", async () => {
-        const { service, vsWorkspace } = createMocks({
-            "/a.bpmn": bpmnWithProcess("ProcessB"),
-        });
-
-        await service.navigate("ProcessB", "process");
-
-        expect(vsWorkspace.findFiles).toHaveBeenCalledTimes(1);
-        const [glob, exclude] = vsWorkspace.findFiles.mock.calls[0];
-        expect(glob).toBe("**/*.bpmn");
-        expect(typeof exclude).toBe("string");
-        expect(exclude).toMatch(/\*\*\/dist\/\*\*/);
-        expect(exclude).toMatch(/\*\*\/node_modules\/\*\*/);
-    });
-
-    it("merges files.exclude entries into the glob", async () => {
-        configStore.files = { "**/private/**": true, "**/draft/**": false };
-        const { service, vsWorkspace } = createMocks({
-            "/a.bpmn": bpmnWithProcess("ProcessB"),
-        });
-
-        await service.navigate("ProcessB", "process");
-
-        const exclude = vsWorkspace.findFiles.mock.calls[0][1] as string;
-        expect(exclude).toContain("**/private/**");
-        expect(exclude).not.toContain("**/draft/**");
-    });
-
-    it("merges search.exclude entries into the glob", async () => {
-        configStore.search = { "**/generated/**": true };
-        const { service, vsWorkspace } = createMocks({
-            "/a.bpmn": bpmnWithProcess("ProcessB"),
-        });
-
-        await service.navigate("ProcessB", "process");
-
-        const exclude = vsWorkspace.findFiles.mock.calls[0][1] as string;
-        expect(exclude).toContain("**/generated/**");
-    });
-});
-
-describe("buildExcludeGlob", () => {
-    it("returns a brace-glob containing the baseline even when configs are empty", () => {
-        const config = {
-            get: <T>(_key: string, fallback: T): T => fallback,
-        } as never;
-
-        const result = buildExcludeGlob(config);
-
-        expect(result.startsWith("{")).toBe(true);
-        expect(result.endsWith("}")).toBe(true);
-        for (const name of [
-            "node_modules",
-            "dist",
-            "build",
-            "out",
-            "target",
-            "coverage",
-        ]) {
-            expect(result).toContain(`**/${name}/**`);
-        }
-    });
-
-    it("deduplicates patterns that appear in both settings and baseline", () => {
-        const config = {
-            get: <T>(key: string, fallback: T): T => {
-                if (key === "files.exclude") return { "**/dist/**": true } as T;
-                if (key === "search.exclude") return {} as T;
-                return fallback;
-            },
-        } as never;
-
-        const result = buildExcludeGlob(config);
-        const occurrences = result.split("**/dist/**").length - 1;
-        expect(occurrences).toBe(1);
-    });
-
-    it("ignores disabled patterns (value === false)", () => {
-        const config = {
-            get: <T>(key: string, fallback: T): T => {
-                if (key === "files.exclude") return { "**/keep-me/**": false } as T;
-                if (key === "search.exclude") return {} as T;
-                return fallback;
-            },
-        } as never;
-
-        const result = buildExcludeGlob(config);
-        expect(result).not.toContain("**/keep-me/**");
-    });
-
-    it("drops patterns containing comma or brace to keep the brace-group well-formed", () => {
-        const config = {
-            get: <T>(key: string, fallback: T): T => {
-                if (key === "files.exclude")
-                    return {
-                        "**/{a,b}/**": true,
-                        "src,test/**": true,
-                        "**/safe/**": true,
-                    } as T;
-                if (key === "search.exclude") return {} as T;
-                return fallback;
-            },
-        } as never;
-
-        const result = buildExcludeGlob(config);
-        expect(result).toContain("**/safe/**");
-        expect(result).not.toContain("**/{a,b}/**");
-        expect(result).not.toContain("src,test/**");
-    });
-
-    it("drops patterns containing only a stray close-brace (would unbalance the group)", () => {
-        // `}` is the inverse of `{`: a literal close-brace would terminate
-        // the wrapping brace-group prematurely.  Although `isBraceSafe`
-        // primarily filters `,` and `{`, this test pins the close-brace
-        // behaviour so a future refactor can't silently regress it.
-        const config = {
-            get: <T>(key: string, fallback: T): T => {
-                if (key === "files.exclude")
-                    return {
-                        "**/weird}/**": true,
-                        "**/normal/**": true,
-                    } as T;
-                if (key === "search.exclude") return {} as T;
-                return fallback;
-            },
-        } as never;
-
-        const result = buildExcludeGlob(config);
-        // The "normal" pattern must survive.
-        expect(result).toContain("**/normal/**");
-        // The wrapping outer braces must be exactly one open and one close.
-        const openBraces = (result.match(/\{/g) ?? []).length;
-        const closeBraces = (result.match(/\}/g) ?? []).length;
-        expect(openBraces).toBe(1);
-        expect(closeBraces).toBe(1);
-    });
-});
-
-describe("findExcludedRanges", () => {
-    it("returns comment offsets", () => {
-        const xml = `<a/><!--hide--><b/>`;
-        const ranges = findExcludedRanges(xml);
-
-        expect(ranges).toHaveLength(1);
-        expect(xml.slice(ranges[0][0], ranges[0][1])).toBe("<!--hide-->");
-    });
-
-    it("returns CDATA offsets", () => {
-        const xml = `<a><![CDATA[<bpmn:process id="X"/>]]></a>`;
-        const ranges = findExcludedRanges(xml);
-
-        expect(ranges).toHaveLength(1);
-        expect(xml.slice(ranges[0][0], ranges[0][1])).toContain("CDATA");
-    });
-
-    it("returns empty array when nothing matches", () => {
-        expect(findExcludedRanges("<a/>")).toEqual([]);
-    });
-});
-
-describe("matchesOutsideComments", () => {
-    const idRe = (id: string) => new RegExp(`<process id="${id}"/>`);
-
-    it("returns true when the id occurs in plain XML", () => {
-        expect(matchesOutsideComments("<process id=\"X\"/>", idRe("X"))).toBe(true);
-    });
-
-    it("returns false when the only occurrence is inside a comment", () => {
-        const xml = `<a/><!-- <process id="X"/> --><b/>`;
-        expect(matchesOutsideComments(xml, idRe("X"))).toBe(false);
-    });
-
-    it("returns false when the only occurrence is inside CDATA", () => {
-        const xml = `<a><![CDATA[<process id="X"/>]]></a>`;
-        expect(matchesOutsideComments(xml, idRe("X"))).toBe(false);
-    });
-
-    it("returns true when a real match exists alongside a commented decoy", () => {
-        const xml = `<!-- <process id="X"/> --><process id="X"/>`;
-        expect(matchesOutsideComments(xml, idRe("X"))).toBe(true);
-    });
-});
-
-describe("buildIdRegex", () => {
-    it("matches namespaced and non-namespaced process tags", () => {
-        const re = buildIdRegex("ProcessB", "process");
-
-        expect(re.test("<bpmn:process id=\"ProcessB\" >")).toBe(true);
-        expect(re.test("<process id=\"ProcessB\"/>")).toBe(true);
-        expect(re.test("<bpmn2:process  id='ProcessB'>")).toBe(true);
-    });
-
-    it("does not match an id with the same prefix but a longer value", () => {
-        const re = buildIdRegex("ProcessB", "process");
-
-        expect(re.test("<bpmn:process id=\"ProcessB_v2\"/>")).toBe(false);
-    });
-
-    it("does not confuse <process> with <participant>", () => {
-        const re = buildIdRegex("ProcessB", "process");
-
-        expect(re.test("<bpmn:participant id=\"ProcessB\" processRef=\"ProcessB\"/>")).toBe(
-            false,
-        );
-    });
-
-    it("matches decision tags with optional dmn: prefix", () => {
-        const re = buildIdRegex("Decision_1", "decision");
-
-        expect(re.test("<decision id=\"Decision_1\"/>")).toBe(true);
-        expect(re.test("<dmn:decision id=\"Decision_1\">")).toBe(true);
-    });
-
-    it("escapes regex metacharacters in the id", () => {
-        const re = buildIdRegex("a.b+c", "process");
-
-        expect(re.test("<bpmn:process id=\"a.b+c\"/>")).toBe(true);
-        expect(re.test("<bpmn:process id=\"aXbZc\"/>")).toBe(false);
-    });
-
-    it("tolerates whitespace around the = in id=", () => {
-        const re = buildIdRegex("ProcessB", "process");
-
-        expect(re.test("<bpmn:process id = \"ProcessB\"/>")).toBe(true);
-        expect(re.test("<bpmn:process id\t=\t'ProcessB'/>")).toBe(true);
     });
 });

--- a/apps/modeler-plugin/src/service/ModelNavigationService.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.ts
@@ -1,108 +1,84 @@
-import { commands, Uri, workspace, WorkspaceConfiguration } from "vscode";
+import { commands, ProgressLocation, Uri, window } from "vscode";
 
 import { VsCodeUI } from "../infrastructure/VsCodeUI";
-import { VsCodeWorkspace } from "../infrastructure/VsCodeWorkspace";
 
-/**
- * Folder names that are universally generated output, regardless of project
- * tooling.  Used as a fallback so a fresh workspace without a customised
- * `files.exclude` / `search.exclude` still hides build copies that would
- * otherwise produce phantom QuickPick entries.
- */
-const NAVIGATION_BASELINE_EXCLUDES = [
-    "node_modules",
-    "dist",
-    "build",
-    "out",
-    "target",
-    "coverage",
-    ".git",
-    ".svn",
-    ".hg",
-];
+import { ReferencedModelLocator } from "./modelNavigation/ReferencedModelLocator";
 
 /** Maximum length of a reference id echoed back into a user-facing notification. */
 const REFERENCE_ID_DISPLAY_LIMIT = 100;
+
+/** Tighter cap for the status-bar progress label — it's space-constrained. */
+const PROGRESS_LABEL_LIMIT = 40;
 
 /**
  * Resolves a process or decision id to a workspace file and opens it in its
  * registered custom editor.  Triggered by
  * `NavigateToReferencedModelCommand` from the BPMN webview.
+ *
+ * This service is a thin orchestrator: it delegates the search to
+ * {@link ReferencedModelLocator} and maps the structured result to user-facing
+ * notifications, a QuickPick (for multi-match), and `vscode.open`.
  */
 export class ModelNavigationService {
-    /**
-     * @param vsWorkspace Workspace filesystem helper for `findFiles`/`readFile`.
-     * @param vsUI User-facing notifications, logging, and QuickPick.
-     */
     constructor(
-        private readonly vsWorkspace: VsCodeWorkspace,
+        private readonly locator: ReferencedModelLocator,
         private readonly vsUI: VsCodeUI,
     ) {}
 
-    /**
-     * Searches the workspace for a `.bpmn` / `.dmn` file that declares a
-     * `process` / `decision` with the given id and opens it.
-     *
-     * - 0 matches → info notification.
-     * - 1 match → open the file in its custom editor via `vscode.open`.
-     * - ≥2 matches → QuickPick; on selection open the chosen file.
-     *
-     * @param referenceId The process / decision id to resolve.
-     * @param kind `"process"` for Call Activities, `"decision"` for Business Rule Tasks.
-     * @param sourceDocumentUri URI of the document the navigation was triggered
-     *   from.  Used to scope `workspace.getConfiguration` so multi-root
-     *   workspaces honour per-folder `files.exclude` / `search.exclude`.
-     */
     async navigate(
         referenceId: string,
         kind: "process" | "decision",
         sourceDocumentUri?: Uri,
     ): Promise<void> {
-        const glob = kind === "process" ? "**/*.bpmn" : "**/*.dmn";
-        const pattern = buildIdRegex(referenceId, kind);
-        const exclude = buildExcludeGlob(
-            workspace.getConfiguration(undefined, sourceDocumentUri),
+        const display = truncate(referenceId, REFERENCE_ID_DISPLAY_LIMIT);
+        // Only the search itself is wrapped — the QuickPick (multi-match) and
+        // vscode.open are user-driven and must not keep a spinner visible.
+        const result = await window.withProgress(
+            {
+                location: ProgressLocation.Window,
+                title: `Searching for ${kind} "${truncate(
+                    referenceId,
+                    PROGRESS_LABEL_LIMIT,
+                )}"…`,
+            },
+            () =>
+                this.locator.findDeclaringFiles(
+                    referenceId,
+                    kind,
+                    sourceDocumentUri,
+                ),
         );
 
-        const paths = await this.vsWorkspace.findFiles(glob, exclude);
-
-        let readFailures = 0;
-        const results = await Promise.all(
-            paths.map(async (path) => {
-                try {
-                    const xml = await this.vsWorkspace.readFile(path);
-                    return matchesOutsideComments(xml, pattern) ? path : undefined;
-                } catch (error) {
-                    readFailures++;
-                    this.vsUI.logWarning(
-                        `Could not read ${path} while resolving reference "${referenceId}": ${
-                            (error as Error).message
-                        }`,
-                    );
-                    return undefined;
-                }
-            }),
-        );
-        const matches = results.filter((path): path is string => path !== undefined);
-
-        if (matches.length === 0) {
-            const display = truncate(referenceId, REFERENCE_ID_DISPLAY_LIMIT);
-            if (paths.length > 0 && readFailures === paths.length) {
-                this.vsUI.showError(
-                    `Could not search for "${display}" — none of the candidate files were readable.`,
-                );
-            } else {
-                this.vsUI.showInfo(
-                    `No model declaring "${display}" was found in the workspace.`,
-                );
-            }
+        if (result.kind === "no-search-scope") {
+            this.vsUI.showInfo(
+                `No model declaring "${display}" was found. Open a folder to enable cross-file navigation.`,
+            );
             return;
         }
 
-        const chosen =
-            matches.length === 1
-                ? matches[0]
-                : await this.vsUI.pickReferencedModel(matches);
+        if (result.kind === "all-unreadable") {
+            result.failures.forEach((message) => this.vsUI.logWarning(message));
+            this.vsUI.showError(
+                `Could not search for "${display}" — none of the candidate files were readable.`,
+            );
+            return;
+        }
+
+        result.readFailures.forEach((message) => this.vsUI.logWarning(message));
+
+        let chosen: string | undefined;
+        if (result.paths.length === 0) {
+            this.vsUI.showInfo(
+                `No model declaring "${display}" was found in the workspace. ` +
+                    `(See Output → bpmn.modeler for what was searched.)`,
+            );
+            return;
+        } else if (result.paths.length === 1) {
+            chosen = result.paths[0];
+        } else {
+            chosen = await this.vsUI.pickReferencedModel(result.paths);
+        }
+
         if (!chosen) {
             return;
         }
@@ -116,130 +92,6 @@ export class ModelNavigationService {
             );
         }
     }
-}
-
-/**
- * Escapes regex metacharacters in user-supplied ids before embedding them in
- * a pattern.  Process / decision ids are XML NCName tokens in well-formed
- * files, but we cannot rely on that for arbitrary workspace content.
- */
-function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-/**
- * Returns the start/end offset pairs of every XML comment and CDATA section
- * in `xml`.  Used to reject id matches that fall inside one of those
- * regions: a commented-out `<!-- <bpmn:process id="X"/> -->` or a sample
- * id inside `<![CDATA[…]]>` must not count as a real declaration.
- *
- * Note: we deliberately *enumerate* ranges rather than `.replace()` the
- * comments away — string-replace based "sanitisation" of HTML-like
- * patterns trips CodeQL's `js/incomplete-multi-character-sanitization`
- * rule, even when run to a fixed point.  We're not sanitising for
- * rendering anyway; we're filtering match positions against known
- * exclusion ranges.
- *
- * Exported for use in tests.
- */
-export function findExcludedRanges(xml: string): Array<[number, number]> {
-    const ranges: Array<[number, number]> = [];
-    for (const re of [
-        /<!--[\s\S]*?-->/g,
-        /<!\[CDATA\[[\s\S]*?\]\]>/g,
-    ]) {
-        let match;
-        while ((match = re.exec(xml)) !== null) {
-            ranges.push([match.index, match.index + match[0].length]);
-        }
-    }
-    return ranges;
-}
-
-/**
- * Returns true if `pattern` matches at least one position in `xml` that is
- * not inside a comment or CDATA section.
- *
- * Exported for use in tests.
- */
-export function matchesOutsideComments(xml: string, pattern: RegExp): boolean {
-    const excluded = findExcludedRanges(xml);
-    const global = new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`);
-    let match;
-    while ((match = global.exec(xml)) !== null) {
-        if (!excluded.some(([start, end]) => match!.index >= start && match!.index < end)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * Builds a regex matching `<…:process id="X">` or `<…:decision id="X">`,
- * tolerating optional namespace prefixes, whitespace around `=`, and either
- * quote style.  The trailing `["']` anchor prevents accidental matches
- * against `"X-suffix"`.
- *
- * Note: the namespace-prefix character class is `[\w-]+`, which is narrower
- * than the full XML NCName production but covers every prefix that occurs in
- * practice (`bpmn`, `bpmn2`, `dmn`, `camunda`, `zeebe`, …).
- *
- * Exported for use in tests.
- */
-export function buildIdRegex(
-    referenceId: string,
-    kind: "process" | "decision",
-): RegExp {
-    const tag = kind === "process" ? "process" : "decision";
-    return new RegExp(
-        `<(?:[\\w-]+:)?${tag}\\b[^>]*\\bid\\s*=\\s*["']${escapeRegex(referenceId)}["']`,
-    );
-}
-
-/**
- * @internal
- *
- * Composes the exclude glob handed to `workspace.findFiles`.  Merges the
- * user's `files.exclude` and `search.exclude` settings with a baseline of
- * universally generated output dirs so that build copies of the source
- * BPMN/DMN files do not surface as duplicate matches.
- *
- * Re-read on every navigate call so a settings edit takes effect without
- * an extension reload.  Patterns containing `,` or `{` are skipped because
- * they would corrupt the brace-group VS Code consumes.
- *
- * Exported for use in tests.
- */
-export function buildExcludeGlob(config: WorkspaceConfiguration): string {
-    const filesExcl = config.get<Record<string, boolean>>("files.exclude", {});
-    const searchExcl = config.get<Record<string, boolean>>("search.exclude", {});
-
-    const fromSettings = [
-        ...Object.entries(filesExcl),
-        ...Object.entries(searchExcl),
-    ]
-        .filter(([pattern, enabled]) => enabled && isBraceSafe(pattern))
-        .map(([pattern]) => pattern);
-
-    const baseline = NAVIGATION_BASELINE_EXCLUDES.map((name) => `**/${name}/**`);
-
-    const merged = Array.from(new Set([...fromSettings, ...baseline]));
-    return `{${merged.join(",")}}`;
-}
-
-/**
- * A glob pattern is "brace-safe" if it doesn't itself contain `,`, `{`, or
- * `}` — any of which would unbalance the wrapping brace-group when
- * concatenated.  Disqualified patterns are dropped from the composed
- * exclude; the user loses that particular exclude entry, but the overall
- * navigation glob stays well-formed.
- */
-function isBraceSafe(pattern: string): boolean {
-    return (
-        !pattern.includes(",") &&
-        !pattern.includes("{") &&
-        !pattern.includes("}")
-    );
 }
 
 function truncate(value: string, max: number): string {

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
@@ -1,0 +1,451 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeWorkspaceFolder {
+    uri: { scheme: string; path: string; fsPath: string };
+}
+
+const workspaceState: {
+    folders: FakeWorkspaceFolder[];
+    folderForUri: (uri: { path: string }) => FakeWorkspaceFolder | undefined;
+} = {
+    folders: [{ uri: { scheme: "file", path: "/", fsPath: "/" } }],
+    folderForUri: () => ({ uri: { scheme: "file", path: "/", fsPath: "/" } }),
+};
+
+vi.mock("vscode", () => ({
+    Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
+    workspace: {
+        get workspaceFolders() {
+            return workspaceState.folders;
+        },
+        getWorkspaceFolder: (uri: { path: string }) =>
+            workspaceState.folderForUri(uri),
+    },
+}));
+
+import { ReferencedModelLocator } from "./ReferencedModelLocator";
+
+const bpmnWithProcess = (id: string) =>
+    `<?xml version="1.0"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="${id}" isExecutable="true"/>
+</bpmn:definitions>`;
+
+const dmnWithDecision = (id: string) =>
+    `<?xml version="1.0"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/">
+  <decision id="${id}" name="d"/>
+</definitions>`;
+
+/**
+ * `tree` describes a directory layout:
+ *   { "/work": ["parent.bpmn", { name: "sub", type: "directory" }],
+ *     "/work/sub": ["child.bpmn"] }
+ * Every file path that appears as a key in `fileContents` is readable.
+ */
+type DirTree = Record<string, Array<string | { name: string; type: "directory" }>>;
+
+function createLocator(opts: {
+    fileContents: Record<string, string>;
+    tree?: DirTree;
+}) {
+    const { fileContents, tree = {} } = opts;
+    const vsWorkspace = {
+        findFiles: vi.fn().mockImplementation((glob: string) => {
+            const wantsBpmn = glob.endsWith(".bpmn");
+            return Promise.resolve(
+                Object.keys(fileContents).filter((path) =>
+                    wantsBpmn ? path.endsWith(".bpmn") : path.endsWith(".dmn"),
+                ),
+            );
+        }),
+        readDirectory: vi.fn().mockImplementation((dir: string) => {
+            const entries = tree[dir];
+            if (!entries) return Promise.reject(new Error("ENOENT"));
+            return Promise.resolve(
+                entries.map((e) =>
+                    typeof e === "string" ? [e, "file"] : [e.name, e.type],
+                ),
+            );
+        }),
+        readFile: vi.fn().mockImplementation((path: string) => {
+            if (path in fileContents) return Promise.resolve(fileContents[path]);
+            return Promise.reject(new Error("not found"));
+        }),
+    };
+    const vsUI = { logInfo: vi.fn(), logWarning: vi.fn() };
+    const locator = new ReferencedModelLocator(
+        vsWorkspace as never,
+        vsUI as never,
+    );
+    return { locator, vsWorkspace, vsUI };
+}
+
+beforeEach(() => {
+    workspaceState.folders = [{ uri: { scheme: "file", path: "/", fsPath: "/" } }];
+    workspaceState.folderForUri = () => ({
+        uri: { scheme: "file", path: "/", fsPath: "/" },
+    });
+});
+
+describe("findDeclaringFiles — workspace folder open (findFiles path)", () => {
+    it("returns the single matching path", async () => {
+        const { locator } = createLocator({
+            fileContents: {
+                "/a.bpmn": bpmnWithProcess("ProcessB"),
+                "/b.bpmn": bpmnWithProcess("Other"),
+            },
+        });
+
+        const result = await locator.findDeclaringFiles("ProcessB", "process");
+
+        expect(result).toEqual({
+            kind: "matches",
+            paths: ["/a.bpmn"],
+            readFailures: [],
+        });
+    });
+
+    it("returns multiple matches in workspace order", async () => {
+        const { locator } = createLocator({
+            fileContents: {
+                "/a.bpmn": bpmnWithProcess("Shared"),
+                "/b.bpmn": bpmnWithProcess("Shared"),
+            },
+        });
+
+        const result = await locator.findDeclaringFiles("Shared", "process");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/a.bpmn", "/b.bpmn"]);
+        }
+    });
+
+    it("matches DMN decisions via the .dmn extension", async () => {
+        const { locator } = createLocator({
+            fileContents: {
+                "/a.dmn": dmnWithDecision("Decision_1"),
+                "/b.bpmn": bpmnWithProcess("Decision_1"),
+            },
+        });
+
+        const result = await locator.findDeclaringFiles("Decision_1", "decision");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/a.dmn"]);
+        }
+    });
+
+    it("returns no matches when nothing declares the id (empty paths array)", async () => {
+        const { locator } = createLocator({
+            fileContents: { "/a.bpmn": bpmnWithProcess("Other") },
+        });
+
+        const result = await locator.findDeclaringFiles("Missing", "process");
+
+        expect(result).toEqual({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
+        });
+    });
+
+    it("passes undefined as exclude — VS Code applies files.exclude automatically", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: { "/a.bpmn": bpmnWithProcess("ProcessB") },
+        });
+
+        await locator.findDeclaringFiles("ProcessB", "process");
+
+        // Only one positional arg → second is implicitly undefined.
+        expect(vsWorkspace.findFiles).toHaveBeenCalledWith("**/*.bpmn");
+    });
+
+    it("returns kind=all-unreadable when every candidate read fails", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: { "/bad.bpmn": bpmnWithProcess("ProcessB") },
+        });
+        vsWorkspace.readFile.mockRejectedValue(new Error("EACCES"));
+
+        const result = await locator.findDeclaringFiles("ProcessB", "process");
+
+        expect(result.kind).toBe("all-unreadable");
+        if (result.kind === "all-unreadable") {
+            expect(result.attempted).toBe(1);
+            expect(result.failures[0]).toContain("EACCES");
+        }
+    });
+
+    it("includes partial read failures alongside successful matches", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: {
+                "/bad.bpmn": bpmnWithProcess("anything"),
+                "/good.bpmn": bpmnWithProcess("ProcessB"),
+            },
+        });
+        vsWorkspace.readFile.mockImplementationOnce(() =>
+            Promise.reject(new Error("EACCES")),
+        );
+
+        const result = await locator.findDeclaringFiles("ProcessB", "process");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/good.bpmn"]);
+            expect(result.readFailures).toHaveLength(1);
+        }
+    });
+
+    it("ignores commented-out and CDATA-wrapped declarations", async () => {
+        const xml = `<?xml version="1.0"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <!-- <bpmn:process id="ProcessB"/> -->
+  <docs><![CDATA[<bpmn:process id="ProcessB"/>]]></docs>
+  <bpmn:process id="Other"/>
+</bpmn:definitions>`;
+        const { locator } = createLocator({ fileContents: { "/a.bpmn": xml } });
+
+        const result = await locator.findDeclaringFiles("ProcessB", "process");
+
+        expect(result).toEqual({ kind: "matches", paths: [], readFailures: [] });
+    });
+
+    it("reads candidate files in parallel", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: { "/a.bpmn": "<doc/>", "/b.bpmn": "<doc/>", "/c.bpmn": "<doc/>" },
+        });
+        const pending: ((value: string) => void)[] = [];
+        vsWorkspace.readFile.mockImplementation(
+            () => new Promise<string>((resolve) => pending.push(resolve)),
+        );
+
+        const inFlight = locator.findDeclaringFiles("ProcessB", "process");
+        for (let i = 0; i < 20 && pending.length < 3; i++) {
+            await Promise.resolve();
+        }
+
+        expect(pending).toHaveLength(3);
+        pending.forEach((resolve) => resolve("<doc/>"));
+        await inFlight;
+    });
+});
+
+describe("findDeclaringFiles — walk-fallback (ripgrep silently failed)", () => {
+    it("falls back to fs walk when findFiles returns [] and a workspace folder is open", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: {
+                "/work/parent.bpmn": bpmnWithProcess("Parent"),
+                "/work/child.bpmn": bpmnWithProcess("ChildProcess"),
+            },
+            tree: { "/work": ["parent.bpmn", "child.bpmn"] },
+        });
+        vsWorkspace.findFiles.mockResolvedValue([]);
+        workspaceState.folderForUri = () => ({
+            uri: { scheme: "file", path: "/work", fsPath: "/work" },
+        });
+        const documentUri = {
+            scheme: "file",
+            path: "/work/parent.bpmn",
+            fsPath: "/work/parent.bpmn",
+        } as never;
+
+        const result = await locator.findDeclaringFiles(
+            "ChildProcess",
+            "process",
+            documentUri,
+        );
+
+        expect(vsWorkspace.findFiles).toHaveBeenCalledTimes(1);
+        expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");
+        expect(result).toEqual({
+            kind: "matches",
+            paths: ["/work/child.bpmn"],
+            readFailures: [],
+        });
+    });
+
+    it("recurses into subdirectories", async () => {
+        workspaceState.folders = [
+            { uri: { scheme: "file", path: "/work", fsPath: "/work" } },
+        ];
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: { "/work/sub/child.bpmn": bpmnWithProcess("Nested") },
+            tree: {
+                "/work": [{ name: "sub", type: "directory" }],
+                "/work/sub": ["child.bpmn"],
+            },
+        });
+        vsWorkspace.findFiles.mockResolvedValue([]);
+
+        const result = await locator.findDeclaringFiles("Nested", "process");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/work/sub/child.bpmn"]);
+        }
+    });
+
+    it("skips baseline-excluded directories (node_modules, dist, .git, …)", async () => {
+        workspaceState.folders = [
+            { uri: { scheme: "file", path: "/work", fsPath: "/work" } },
+        ];
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: {
+                "/work/wanted.bpmn": bpmnWithProcess("Wanted"),
+                "/work/node_modules/inner.bpmn": bpmnWithProcess("Wanted"),
+            },
+            tree: {
+                "/work": [
+                    "wanted.bpmn",
+                    { name: "node_modules", type: "directory" },
+                ],
+                "/work/node_modules": ["inner.bpmn"],
+            },
+        });
+        vsWorkspace.findFiles.mockResolvedValue([]);
+
+        const result = await locator.findDeclaringFiles("Wanted", "process");
+
+        expect(vsWorkspace.readDirectory).not.toHaveBeenCalledWith(
+            "/work/node_modules",
+        );
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/work/wanted.bpmn"]);
+        }
+    });
+
+    it("tolerates unreadable subdirectories", async () => {
+        workspaceState.folders = [
+            { uri: { scheme: "file", path: "/work", fsPath: "/work" } },
+        ];
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: { "/work/ok.bpmn": bpmnWithProcess("Wanted") },
+            tree: {
+                "/work": ["ok.bpmn", { name: "denied", type: "directory" }],
+                // "/work/denied" intentionally absent → readDirectory rejects
+            },
+        });
+        vsWorkspace.findFiles.mockResolvedValue([]);
+
+        const result = await locator.findDeclaringFiles("Wanted", "process");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/work/ok.bpmn"]);
+        }
+    });
+});
+
+describe("findDeclaringFiles — loose file (no workspace folder)", () => {
+    it("walks the source document's directory via readDirectory (not findFiles)", async () => {
+        workspaceState.folders = [];
+        workspaceState.folderForUri = () => undefined;
+
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: {
+                "/work/parent.bpmn": bpmnWithProcess("Parent"),
+                "/work/child.bpmn": bpmnWithProcess("ChildProcess"),
+            },
+            tree: { "/work": ["parent.bpmn", "child.bpmn"] },
+        });
+        const documentUri = {
+            scheme: "file",
+            path: "/work/parent.bpmn",
+            fsPath: "/work/parent.bpmn",
+        } as never;
+
+        const result = await locator.findDeclaringFiles(
+            "ChildProcess",
+            "process",
+            documentUri,
+        );
+
+        expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
+        expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");
+        expect(result).toEqual({
+            kind: "matches",
+            paths: ["/work/child.bpmn"],
+            readFailures: [],
+        });
+    });
+
+    it("returns no-search-scope when no source URI and no workspace folders", async () => {
+        workspaceState.folders = [];
+        workspaceState.folderForUri = () => undefined;
+
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: { "/a.bpmn": bpmnWithProcess("ProcessB") },
+        });
+
+        const result = await locator.findDeclaringFiles("ProcessB", "process");
+
+        expect(result).toEqual({ kind: "no-search-scope" });
+        expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
+        expect(vsWorkspace.readDirectory).not.toHaveBeenCalled();
+    });
+});
+
+describe("id regex semantics", () => {
+    const expectFinds = (id: string, xml: string, kind: "process" | "decision") => {
+        const { locator } = createLocator({ fileContents: { "/a.bpmn": xml, "/a.dmn": xml } });
+        return locator.findDeclaringFiles(id, kind);
+    };
+
+    it("matches namespaced and non-namespaced process tags", async () => {
+        await expect(
+            expectFinds("ProcessB", `<bpmn:process id="ProcessB"/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.bpmn"] });
+        await expect(
+            expectFinds("ProcessB", `<process id="ProcessB"/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.bpmn"] });
+        await expect(
+            expectFinds("ProcessB", `<bpmn2:process id='ProcessB'>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.bpmn"] });
+    });
+
+    it("does not match an id with the same prefix but a longer value", async () => {
+        await expect(
+            expectFinds("ProcessB", `<bpmn:process id="ProcessB_v2"/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: [] });
+    });
+
+    it("does not confuse <process> with <participant>", async () => {
+        await expect(
+            expectFinds(
+                "ProcessB",
+                `<bpmn:participant id="ProcessB" processRef="ProcessB"/>`,
+                "process",
+            ),
+        ).resolves.toMatchObject({ kind: "matches", paths: [] });
+    });
+
+    it("matches decision tags with optional dmn: prefix", async () => {
+        await expect(
+            expectFinds("Decision_1", `<decision id="Decision_1"/>`, "decision"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.dmn"] });
+        await expect(
+            expectFinds("Decision_1", `<dmn:decision id="Decision_1">`, "decision"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.dmn"] });
+    });
+
+    it("escapes regex metacharacters in the id", async () => {
+        await expect(
+            expectFinds("a.b+c", `<bpmn:process id="a.b+c"/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.bpmn"] });
+        await expect(
+            expectFinds("a.b+c", `<bpmn:process id="aXbZc"/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: [] });
+    });
+
+    it("tolerates whitespace around the = in id=", async () => {
+        await expect(
+            expectFinds("ProcessB", `<bpmn:process id = "ProcessB"/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.bpmn"] });
+        await expect(
+            expectFinds("ProcessB", `<bpmn:process id\t=\t'ProcessB'/>`, "process"),
+        ).resolves.toMatchObject({ kind: "matches", paths: ["/a.bpmn"] });
+    });
+});

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
@@ -1,0 +1,289 @@
+import { posix } from "path";
+
+import { Uri, workspace } from "vscode";
+
+import { VsCodeUI } from "../../infrastructure/VsCodeUI";
+import { VsCodeWorkspace } from "../../infrastructure/VsCodeWorkspace";
+
+/**
+ * Directory names skipped during the fs walk.  The `workspace.findFiles`
+ * path inherits the user's `files.exclude` from VS Code automatically and
+ * doesn't need a parallel list.
+ */
+const EXCLUDED_DIRS: ReadonlySet<string> = new Set([
+    "node_modules",
+    "dist",
+    "build",
+    "out",
+    "target",
+    "coverage",
+    ".git",
+    ".svn",
+    ".hg",
+]);
+
+/** Max length of a reference id echoed back into a user-facing log line. */
+const ID_DISPLAY_LIMIT = 100;
+
+/**
+ * Outcome of locating models that declare a process or decision id.
+ *
+ * - `no-search-scope` — nothing to search: no workspace folder open and no
+ *   source URI to fall back to.
+ * - `all-unreadable` — the search returned candidates but every read failed.
+ * - `matches` — candidates were searched.  `paths` may be empty (nothing
+ *   declared the id), or contain one or more absolute paths.
+ */
+export type LocateResult =
+    | { kind: "no-search-scope" }
+    | { kind: "all-unreadable"; attempted: number; failures: string[] }
+    | { kind: "matches"; paths: string[]; readFailures: string[] };
+
+/**
+ * Locates BPMN/DMN files that declare a given `<process id="…">` or
+ * `<decision id="…">`.
+ *
+ * Strategy, in order:
+ *   1. `workspace.findFiles("**\/*.bpmn"|.dmn)` — fast (ripgrep-backed in
+ *      Theia/VS Code) and respects the user's `files.exclude` setting.
+ *   2. fs-walk fallback — kicks in when (1) returns `[]` despite a workspace
+ *      folder being open, which happens in the unsigned electron-builder
+ *      package where the bundled ripgrep is missing or unexecutable.  No
+ *      ripgrep dependency.
+ *   3. fs-walk primary — for loose-file scenarios (no workspace folder).
+ */
+export class ReferencedModelLocator {
+    constructor(
+        private readonly vsWorkspace: VsCodeWorkspace,
+        private readonly vsUI: VsCodeUI,
+    ) {}
+
+    async findDeclaringFiles(
+        referenceId: string,
+        kind: "process" | "decision",
+        sourceDocumentUri?: Uri,
+    ): Promise<LocateResult> {
+        const extension = kind === "process" ? ".bpmn" : ".dmn";
+        const id = truncate(referenceId, ID_DISPLAY_LIMIT);
+        this.vsUI.logInfo(
+            `[nav] resolving ${kind} id="${id}" sourceUri=${sourceDocumentUri?.path ?? "<none>"}`,
+        );
+
+        const paths = await this.collectCandidateFiles(extension, sourceDocumentUri);
+        if (paths === undefined) {
+            this.vsUI.logInfo(`[nav] no search scope (no folder, no source uri)`);
+            return { kind: "no-search-scope" };
+        }
+        return this.filterByIdDeclaration(paths, referenceId, kind);
+    }
+
+    /**
+     * Phase 1.  Returns `undefined` when nothing can be searched (no source
+     * URI and no workspace folder).  Otherwise returns the candidate paths.
+     */
+    private async collectCandidateFiles(
+        extension: string,
+        sourceDocumentUri: Uri | undefined,
+    ): Promise<string[] | undefined> {
+        const looseFile =
+            sourceDocumentUri !== undefined &&
+            workspace.getWorkspaceFolder(sourceDocumentUri) === undefined;
+
+        if (looseFile) {
+            // No workspace folder covers the document → walk from its dir.
+            const rootDir = posix.dirname(sourceDocumentUri!.path);
+            return this.walkWorkspaceTree(rootDir, extension, "walk-primary");
+        }
+
+        const folders = workspace.workspaceFolders;
+        if (!folders || folders.length === 0) {
+            return undefined;
+        }
+
+        // Pass undefined for excludes — VS Code applies user's `files.exclude`.
+        const startedAt = Date.now();
+        const found = await this.vsWorkspace.findFiles(`**/*${extension}`);
+        this.vsUI.logInfo(
+            `[nav] findFiles returned ${found.length} path(s) in ${Date.now() - startedAt}ms`,
+        );
+        if (found.length > 0) {
+            return found;
+        }
+
+        // Fallback: findFiles failed silently (ripgrep missing in packaged .app).
+        const root = this.pickWalkRoot(sourceDocumentUri);
+        if (!root) return [];
+        return this.walkWorkspaceTree(root, extension, "walk-fallback");
+    }
+
+    /**
+     * Parallel BFS.  All directories at the same depth are read concurrently
+     * via `Promise.all` — sequential per-directory awaits cost several
+     * seconds on deep workspaces.  Unreadable subdirectories are swallowed.
+     */
+    private async walkWorkspaceTree(
+        rootDir: string,
+        extension: string,
+        reason: "walk-primary" | "walk-fallback",
+    ): Promise<string[]> {
+        this.vsUI.logInfo(`[nav] ${reason}: walking ${rootDir} for ${extension}`);
+        const startedAt = Date.now();
+
+        const out: string[] = [];
+        let level: string[] = [rootDir];
+        while (level.length > 0) {
+            const reads = await Promise.all(
+                level.map((dir) =>
+                    this.vsWorkspace
+                        .readDirectory(dir)
+                        .then(
+                            (entries) =>
+                                [dir, entries] as [
+                                    string,
+                                    Array<[string, "file" | "directory"]>,
+                                ],
+                        )
+                        .catch(() => [dir, []] as [
+                            string,
+                            Array<[string, "file" | "directory"]>,
+                        ]),
+                ),
+            );
+            const nextLevel: string[] = [];
+            for (const [dir, entries] of reads) {
+                for (const [name, type] of entries) {
+                    const full = posix.join(dir, name);
+                    if (type === "directory") {
+                        if (!EXCLUDED_DIRS.has(name)) nextLevel.push(full);
+                    } else if (name.endsWith(extension)) {
+                        out.push(full);
+                    }
+                }
+            }
+            level = nextLevel;
+        }
+
+        this.vsUI.logInfo(
+            `[nav] ${reason} returned ${out.length} path(s) in ${Date.now() - startedAt}ms`,
+        );
+        return out;
+    }
+
+    /** Where to root the walk fallback.  Best-effort. */
+    private pickWalkRoot(sourceDocumentUri: Uri | undefined): string | undefined {
+        if (sourceDocumentUri) {
+            const folder = workspace.getWorkspaceFolder(sourceDocumentUri);
+            if (folder) return folder.uri.path;
+        }
+        const folders = workspace.workspaceFolders;
+        if (folders && folders.length > 0) return folders[0].uri.path;
+        if (sourceDocumentUri) return posix.dirname(sourceDocumentUri.path);
+        return undefined;
+    }
+
+    /**
+     * Phase 2.  Reads each candidate file in parallel and tests the id regex
+     * against its content (ignoring XML comments and CDATA sections).
+     */
+    private async filterByIdDeclaration(
+        paths: string[],
+        referenceId: string,
+        kind: "process" | "decision",
+    ): Promise<LocateResult> {
+        const pattern = this.buildIdPattern(referenceId, kind);
+        const startedAt = Date.now();
+
+        const failures: string[] = [];
+        const results = await Promise.all(
+            paths.map(async (path) => {
+                try {
+                    const xml = await this.vsWorkspace.readFile(path);
+                    return this.matchesDeclaration(xml, pattern) ? path : undefined;
+                } catch (error) {
+                    failures.push(
+                        `Could not read ${path} while resolving reference "${referenceId}": ${
+                            (error as Error).message
+                        }`,
+                    );
+                    return undefined;
+                }
+            }),
+        );
+        const matches = results.filter(
+            (path): path is string => path !== undefined,
+        );
+
+        this.vsUI.logInfo(
+            `[nav] candidates=${paths.length} matches=${matches.length} readFailures=${failures.length} reads-took=${Date.now() - startedAt}ms`,
+        );
+
+        if (paths.length > 0 && failures.length === paths.length) {
+            return { kind: "all-unreadable", attempted: paths.length, failures };
+        }
+        return { kind: "matches", paths: matches, readFailures: failures };
+    }
+
+    /**
+     * Builds a regex matching `<…:process id="X">` or `<…:decision id="X">`.
+     * Tolerates optional namespace prefixes (`bpmn:`, `dmn:`, `camunda:`, …),
+     * whitespace around `=`, and either quote style.
+     *
+     * Edge-case alternative: `bpmn-moddle` / `dmn-moddle` parse the XML into
+     * a typed AST so we could read `process.id` directly.  Not used here
+     * because (1) it isn't a `modeler-plugin` dep yet, (2) per-file parse is
+     * 50-100× slower than this regex, which matters across a 100-file
+     * workspace.
+     */
+    private buildIdPattern(
+        referenceId: string,
+        kind: "process" | "decision",
+    ): RegExp {
+        const tag = kind === "process" ? "process" : "decision";
+        return new RegExp(
+            `<(?:[\\w-]+:)?${tag}\\b[^>]*\\bid\\s*=\\s*["']${escapeRegex(referenceId)}["']`,
+        );
+    }
+
+    /**
+     * Returns true if `pattern` matches at least one position in `xml` that
+     * is not inside an XML comment or CDATA section — a commented-out
+     * `<!-- <bpmn:process id="X"/> -->` is not a real declaration.
+     *
+     * We enumerate comment/CDATA ranges via regex rather than `.replace()`
+     * them away to avoid CodeQL's `js/incomplete-multi-character-sanitization`
+     * rule (this is filtering, not sanitisation, so the lint is a false
+     * positive but easier to dodge than appease).
+     */
+    private matchesDeclaration(xml: string, pattern: RegExp): boolean {
+        const excluded: Array<[number, number]> = [];
+        for (const re of [/<!--[\s\S]*?-->/g, /<!\[CDATA\[[\s\S]*?\]\]>/g]) {
+            let m;
+            while ((m = re.exec(xml)) !== null) {
+                excluded.push([m.index, m.index + m[0].length]);
+            }
+        }
+        const global = new RegExp(
+            pattern.source,
+            pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+        );
+        let match;
+        while ((match = global.exec(xml)) !== null) {
+            if (
+                !excluded.some(
+                    ([s, e]) => match!.index >= s && match!.index < e,
+                )
+            ) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function truncate(value: string, max: number): string {
+    return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}

--- a/apps/standalone/package.json
+++ b/apps/standalone/package.json
@@ -102,6 +102,8 @@
     "dev:fast": "npm-run-all -s build start",
     "start": "electron scripts/theia-electron-main.js",
     "start:debug": "yarn start --log-level=debug",
+    "start:isolated": "npm-run-all -s build:repo prepare-plugin package start:isolated:run",
+    "start:isolated:run": "bash scripts/launch-isolated.sh",
     "package": "yarn clean:dist && yarn download:plugins && yarn rebuild && yarn build:prod && electron-builder -c.mac.identity=null -c.mac.notarize=false -c.mac.hardenedRuntime=false --publish never --mac dmg",
     "package:signed": "yarn clean:dist && yarn download:plugins && yarn rebuild && yarn build:prod && electron-builder --publish never --mac dmg",
     "package:release": "yarn clean:dist && yarn download:plugins && yarn rebuild && yarn build:prod && electron-builder --publish never --mac dmg"

--- a/apps/standalone/scripts/launch-isolated.sh
+++ b/apps/standalone/scripts/launch-isolated.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Launch the standalone app with a throw-away $HOME.  The temp dir is wiped
+# via `trap … EXIT` the moment the app process exits — including on Ctrl-C,
+# crash, or normal close — so no state ever persists across runs.
+set -euo pipefail
+
+DIST="$(dirname "$0")/../dist"
+APP=$(ls -dt "$DIST"/mac-*/*.app 2>/dev/null | head -n1 || true)
+[ -d "${APP:-}" ] || {
+    echo "Unpacked .app not found under $DIST."
+    echo "Run 'corepack yarn workspace @miragon/bpmn-modeler-standalone package' first."
+    exit 1
+}
+
+ISO=$(mktemp -d -t miragon-iso)
+trap 'rm -rf "$ISO"' EXIT
+
+HOME="$ISO" "$APP/Contents/MacOS/$(basename "$APP" .app)"


### PR DESCRIPTION
Closes #1011.

## Summary

Three thematic commits:

- **`fix(modeler-plugin): "navigate to declaring process" works in standalone (#1011)`** — The Call-Activity / Business-Rule-Task navigate button returned "No model declaring … was found in the workspace" in the standalone shell, in two distinct failure modes:
  - "File → Open File…" doesn't register a workspace folder, so `workspace.findFiles("**/*.bpmn")` returned `[]` (folder-scoped API).
  - The electron-builder-packaged `.app` ships a ripgrep binary that isn't reliably executable, so even with a folder open `findFiles` returned `[]` silently.

  `ReferencedModelLocator` now layers `workspace.findFiles` → fs-walk fallback when it returns empty → fs-walk primary for loose files. The walk uses parallel BFS (each tree depth read concurrently) and skips the usual generated-output dir names. Status-bar progress spinner via `window.withProgress`, and diagnostic logs in the **bpmn.modeler** output channel show which strategy ran and how long each phase took.

- **`fix(modeler-plugin): retain webview context to prevent broken canvas on tab re-show`** — Without `retainContextWhenHidden: true`, hiding a BPMN/DMN tab discards the webview DOM and JS state. On re-show, a fresh `window.onload` racing with `importXML` intermittently leaves the canvas empty except for overlay markers (token-simulation pins on a blank SVG) while the properties panel still appears wired up. Flag now set for both `.bpmn` and `.dmn` editors; preserves zoom/pan/selection across tab switches as a bonus.

- **`chore(standalone): add 'start:isolated' script for ephemeral prod testing`** — `yarn workspace @miragon/bpmn-modeler-standalone start:isolated` builds + packages the standalone and launches the unpacked `.app` with `HOME=$(mktemp -d)`. A `trap … EXIT` in the shell launcher wipes the temp dir the moment the app exits, so the prod build can be exercised without touching the Theia config / Electron user-data of a separately installed copy (e.g. the Homebrew cask).

## Test plan

- [ ] Open the standalone via `corepack yarn workspace @miragon/bpmn-modeler-standalone start:isolated` (will package; ~5 min first run).
- [ ] **Navigation, folder workflow**: open a root folder containing multiple `.bpmn` files; click the navigate button on a Call Activity → target opens. Output → **bpmn.modeler** shows `findFiles` count or `walk-fallback` count.
- [ ] **Navigation, loose-file workflow**: File → Open File… → a single `.bpmn` with a Call Activity that references a sibling. Click navigate → sibling opens via the `walk-primary` path.
- [ ] **No-match path**: navigate to a non-existent id → "No model declaring 'X' was found in the workspace. (See Output → bpmn.modeler for what was searched.)"
- [ ] **Progress spinner**: visible bottom-left during the search, vanishes on completion.
- [ ] **Tab re-show**: open two `.bpmn` tabs, switch between them 5–10 times → canvas stays rendered, zoom/pan/selection preserved.
- [ ] **DMN parity**: repeat navigation + tab re-show with a `.dmn` file (Business Rule Task referencing a sibling `.dmn`).
- [ ] **Regression check in VS Code dev** (`yarn watch` + F5): navigation still works through the original `findFiles` path; no regression for workspace users.
- [ ] CI: `yarn test` (122 passing) and `yarn build` clean.