### PR TITLE
chore(format): bump Prettier printWidth from 89 to 100

### DIFF
--- a/.github/scripts/update-engine-versions.mjs
+++ b/.github/scripts/update-engine-versions.mjs
@@ -74,9 +74,7 @@ async function fetchStableC8Releases() {
  * @returns {string[]} The currently listed version strings.
  */
 function parseCurrentVersions(content) {
-    const match = content.match(
-        /C8_VERSIONS:\s*readonly\s*string\[\]\s*=\s*\[([\s\S]*?)\];/,
-    );
+    const match = content.match(/C8_VERSIONS:\s*readonly\s*string\[\]\s*=\s*\[([\s\S]*?)\];/);
     if (!match) {
         throw new Error("Could not find C8_VERSIONS array in engineVersions.ts");
     }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "printWidth": 89,
+    "printWidth": 100,
     "singleQuote": false,
     "trailingComma": "all",
     "arrowParens": "always",

--- a/apps/bpmn-webview/src/app/diff/DiffLegend.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffLegend.ts
@@ -119,8 +119,7 @@ export class DiffLegend {
         this.renderLabels();
 
         const { counts, origin } = context;
-        const total =
-            counts.added + counts.removed + counts.changed + counts.layoutChanged;
+        const total = counts.added + counts.removed + counts.changed + counts.layoutChanged;
         const hasChanges = total > 0;
         this.prevButton.disabled = !hasChanges;
         this.nextButton.disabled = !hasChanges;

--- a/apps/bpmn-webview/src/app/diff/DiffMode.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffMode.ts
@@ -128,11 +128,7 @@ export class DiffMode {
         // waypoints as a side-effect.  The flow carries no semantic change
         // on its own, and the user already sees it highlighted when the
         // attached shape comes up in the cycle.
-        const semanticIds = new Set<string>([
-            ...query.removed,
-            ...query.added,
-            ...query.changed,
-        ]);
+        const semanticIds = new Set<string>([...query.removed, ...query.added, ...query.changed]);
         const isLayoutOnlyConnection = (id: string): boolean =>
             !semanticIds.has(id) &&
             query.layoutChanged.includes(id) &&
@@ -169,8 +165,7 @@ export class DiffMode {
         if (this.changeIds.length === 0) {
             return;
         }
-        const next =
-            (this.cursor + direction + this.changeIds.length) % this.changeIds.length;
+        const next = (this.cursor + direction + this.changeIds.length) % this.changeIds.length;
         this.applyCursor(next, true, direction);
     }
 

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -130,10 +130,7 @@ export class BpmnModeler {
 
         // Apply default favourites immediately after creation.
         if (this.settings.favouriteBpmnElements) {
-            const appendMenuOverride = this.getModeler().get<any>(
-                "appendMenuOverride",
-                false,
-            );
+            const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
             if (appendMenuOverride) {
                 appendMenuOverride.setFavourites(this.settings.favouriteBpmnElements);
             }
@@ -187,10 +184,7 @@ export class BpmnModeler {
                 .importXML(bpmn)
                 .then((result: ImportXMLResult) => {
                     // Transaction boundaries are only available for the C7 modeler.
-                    if (
-                        this.engine === "c7" &&
-                        this.settings.showTransactionBoundaries
-                    ) {
+                    if (this.engine === "c7" && this.settings.showTransactionBoundaries) {
                         this.getModeler().get<any>("transactionBoundaries").show();
                     }
                     return result;
@@ -275,10 +269,7 @@ export class BpmnModeler {
 
         // Apply favourite BPMN elements to the append menu.
         if (settings.favouriteBpmnElements !== undefined) {
-            const appendMenuOverride = this.getModeler().get<any>(
-                "appendMenuOverride",
-                false,
-            );
+            const appendMenuOverride = this.getModeler().get<any>("appendMenuOverride", false);
             if (appendMenuOverride) {
                 appendMenuOverride.setFavourites(settings.favouriteBpmnElements);
             }

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.spec.ts
@@ -1,13 +1,4 @@
-import {
-    afterAll,
-    afterEach,
-    beforeAll,
-    beforeEach,
-    describe,
-    expect,
-    it,
-    vi,
-} from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { installContentEditableClipboardPolyfill } from "./propertiesPanelClipboard";
 

--- a/apps/bpmn-webview/src/app/resizer.ts
+++ b/apps/bpmn-webview/src/app/resizer.ts
@@ -102,9 +102,7 @@ export function initResizer(): PropertiesPanelHandle {
     const panelEl = document.getElementById("js-properties-panel");
 
     if (!resizerEl || !panelEl) {
-        console.warn(
-            "[resizer] Required DOM elements not found — skipping resizer init.",
-        );
+        console.warn("[resizer] Required DOM elements not found — skipping resizer init.");
         return NOOP_HANDLE;
     }
 

--- a/apps/bpmn-webview/src/app/vscode.ts
+++ b/apps/bpmn-webview/src/app/vscode.ts
@@ -306,9 +306,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
                 break;
             }
             default: {
-                throw new Error(
-                    `Unknown message type: ${(message as MessageType).type}`,
-                );
+                throw new Error(`Unknown message type: ${(message as MessageType).type}`);
             }
         }
 
@@ -353,17 +351,13 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
         try {
             cached = await this.ensureCachedDiff();
         } catch (error) {
-            console.error(
-                "[dev] Failed to compute mock diff; diff highlights unavailable.",
-                error,
-            );
+            console.error("[dev] Failed to compute mock diff; diff highlights unavailable.", error);
             return;
         }
 
         const slice = cached[side];
         const added = side === "after" ? (slice as { added: string[] }).added : [];
-        const removed =
-            side === "before" ? (slice as { removed: string[] }).removed : [];
+        const removed = side === "before" ? (slice as { removed: string[] }).removed : [];
 
         dispatch(
             new ApplyDiffHighlightsQuery(
@@ -426,11 +420,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
         const layoutChanged = Object.keys(result._layoutChanged);
 
         const afterOrder = buildFlowOrder(afterDefs as never);
-        const removedAnchors = buildRemovedAnchors(
-            removed,
-            beforeDefs as never,
-            afterOrder,
-        );
+        const removedAnchors = buildRemovedAnchors(removed, beforeDefs as never, afterOrder);
         const sortedAdded = sortIdsByOrder(added, afterOrder);
         const sortedRemoved = sortIdsByOrder(removed, removedAnchors);
         const sortedChanged = sortIdsByOrder(changed, afterOrder);

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -32,10 +32,7 @@ import {
     SyncDocumentCommand,
     TextClipboardQuery,
 } from "@miragon/bpmn-modeler-shared";
-import {
-    VsCodeClipboardModule,
-    LabelClipboardModule,
-} from "@miragon/bpmn-modeler-clipboard";
+import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-modeler-clipboard";
 import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import {
     BpmnModeler,
@@ -163,10 +160,7 @@ window.onload = async function () {
         // bridges them through the extension host clipboard, and guards Ctrl+A
         // in text-editing surfaces from being stolen by bpmn-js's Keyboard
         // service (canvas Ctrl+A is owned by bpmn-js's SelectionKeyBindings).
-        installContentEditableClipboardPolyfill(
-            requestTextClipboard,
-            writeTextClipboard,
-        );
+        installContentEditableClipboardPolyfill(requestTextClipboard, writeTextClipboard);
     }
 
     vscode.postMessage(new GetBpmnFileCommand());
@@ -190,16 +184,9 @@ window.onload = async function () {
 
     const propertiesPanelHandle = initResizer();
     const vsCodeBridgeModule = {
-        vsCodeBridge: [
-            "value",
-            { postMessage: (m: unknown) => vscode.postMessage(m as never) },
-        ],
+        vsCodeBridge: ["value", { postMessage: (m: unknown) => vscode.postMessage(m as never) }],
     };
-    const extraModules = [
-        TranslateModule,
-        vsCodeBridgeModule,
-        ...(clipboardModules ?? []),
-    ];
+    const extraModules = [TranslateModule, vsCodeBridgeModule, ...(clipboardModules ?? [])];
     await initializeModeler(bpmnFileQuery?.content, bpmnFileQuery?.engine, extraModules);
     modelerIsInitialized = true;
 
@@ -266,9 +253,7 @@ async function initializeModeler(
         } else if (error instanceof UnsupportedEngineError) {
             vscode.postMessage(new LogErrorCommand(error.message));
         } else {
-            vscode.postMessage(
-                new LogErrorCommand(`Unable to open XML\n${error.message}`),
-            );
+            vscode.postMessage(new LogErrorCommand(`Unable to open XML\n${error.message}`));
         }
     }
 }
@@ -330,8 +315,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
         }
         case queryOrCommand.type === "ElementTemplatesQuery": {
             try {
-                const elementTemplates = (message.data as ElementTemplatesQuery)
-                    .elementTemplates;
+                const elementTemplates = (message.data as ElementTemplatesQuery).elementTemplates;
                 console.log("Received element templates: ", elementTemplates);
                 bpmnModeler.setElementTemplates(elementTemplates);
                 elementTemplatesResolver.done(message.data as ElementTemplatesQuery);

--- a/apps/bpmn-webview/src/types/diagram-js.d.ts
+++ b/apps/bpmn-webview/src/types/diagram-js.d.ts
@@ -3,10 +3,7 @@ declare module "diagram-js/lib/core/EventBus" {
         on<T extends string>(event: T, callback: EventCallback, that?: any): void;
     }
 
-    export type EventCallback<T extends string = any> = (
-        event: EventType<T>,
-        data: any,
-    ) => any;
+    export type EventCallback<T extends string = any> = (event: EventType<T>, data: any) => any;
 
     export type EventType<T extends string> =
         EventMap extends Record<T, infer E> ? E : InternalEvent;

--- a/apps/deployment-webview/src/app/form.ts
+++ b/apps/deployment-webview/src/app/form.ts
@@ -71,8 +71,7 @@ export class DeploymentForm {
      * @throws {Error} If any expected DOM element is missing.
      */
     constructor(private readonly vscode: VsCodeApi<unknown, Command | Query>) {
-        this.deploymentNameInput =
-            this.requireElement<HTMLInputElement>("#deployment-name");
+        this.deploymentNameInput = this.requireElement<HTMLInputElement>("#deployment-name");
         this.tenantIdInput = this.requireElement<HTMLInputElement>("#tenant-id");
         this.endpointInput = this.requireElement<HTMLInputElement>("#endpoint");
         this.engineSelect = this.requireElement<HTMLSelectElement>("#engine");
@@ -80,19 +79,13 @@ export class DeploymentForm {
         this.basicAuthFields = this.requireElement<HTMLDivElement>("#basic-auth-fields");
         this.authUsernameInput = this.requireElement<HTMLInputElement>("#auth-username");
         this.authPasswordInput = this.requireElement<HTMLInputElement>("#auth-password");
-        this.oauth2AuthFields =
-            this.requireElement<HTMLDivElement>("#oauth2-auth-fields");
-        this.authClientIdInput =
-            this.requireElement<HTMLInputElement>("#auth-client-id");
-        this.authClientSecretInput =
-            this.requireElement<HTMLInputElement>("#auth-client-secret");
-        this.authTokenEndpointInput =
-            this.requireElement<HTMLInputElement>("#auth-token-endpoint");
+        this.oauth2AuthFields = this.requireElement<HTMLDivElement>("#oauth2-auth-fields");
+        this.authClientIdInput = this.requireElement<HTMLInputElement>("#auth-client-id");
+        this.authClientSecretInput = this.requireElement<HTMLInputElement>("#auth-client-secret");
+        this.authTokenEndpointInput = this.requireElement<HTMLInputElement>("#auth-token-endpoint");
         this.authAudienceInput = this.requireElement<HTMLInputElement>("#auth-audience");
-        this.mainFilePathInput =
-            this.requireElement<HTMLInputElement>("#main-file-path");
-        this.additionalFilesBtn =
-            this.requireElement<HTMLButtonElement>("#add-files-btn");
+        this.mainFilePathInput = this.requireElement<HTMLInputElement>("#main-file-path");
+        this.additionalFilesBtn = this.requireElement<HTMLButtonElement>("#add-files-btn");
         this.fileList = this.requireElement<HTMLUListElement>("#file-list");
         this.deployBtn = this.requireElement<HTMLButtonElement>("#deploy-btn");
         this.statusBanner = this.requireElement<HTMLDivElement>("#status-banner");
@@ -405,8 +398,7 @@ export class DeploymentForm {
                 this.vscode.postMessage(new DeployCommand(payload));
             } catch (err) {
                 this.statusBanner.className = "status-banner error";
-                this.statusBanner.textContent =
-                    err instanceof Error ? err.message : String(err);
+                this.statusBanner.textContent = err instanceof Error ? err.message : String(err);
                 this.statusBanner.style.display = "block";
             }
         });
@@ -463,9 +455,7 @@ export class DeploymentForm {
             removeBtn.textContent = "\u00d7";
             removeBtn.className = "remove-btn";
             removeBtn.addEventListener("click", () => {
-                this.additionalFilePaths = this.additionalFilePaths.filter(
-                    (p) => p !== filePath,
-                );
+                this.additionalFilePaths = this.additionalFilePaths.filter((p) => p !== filePath);
                 this.renderFileList();
             });
 

--- a/apps/deployment-webview/src/app/startInstanceForm.ts
+++ b/apps/deployment-webview/src/app/startInstanceForm.ts
@@ -45,14 +45,11 @@ export class StartInstanceForm {
             engine: "c7" | "c8";
         },
     ) {
-        this.processDefinitionKeyInput = this.requireElement<HTMLInputElement>(
-            "#process-definition-key",
-        );
+        this.processDefinitionKeyInput =
+            this.requireElement<HTMLInputElement>("#process-definition-key");
         this.payloadFileInput = this.requireElement<HTMLInputElement>("#payload-file");
-        this.selectPayloadBtn =
-            this.requireElement<HTMLButtonElement>("#select-payload-btn");
-        this.startInstanceBtn =
-            this.requireElement<HTMLButtonElement>("#start-instance-btn");
+        this.selectPayloadBtn = this.requireElement<HTMLButtonElement>("#select-payload-btn");
+        this.startInstanceBtn = this.requireElement<HTMLButtonElement>("#start-instance-btn");
         this.statusBanner = this.requireElement<HTMLDivElement>("#start-status-banner");
 
         this.bindEvents();
@@ -122,8 +119,7 @@ export class StartInstanceForm {
                 this.vscode.postMessage(new StartInstanceCommand(payload));
             } catch (err) {
                 this.statusBanner.className = "status-banner error";
-                this.statusBanner.textContent =
-                    err instanceof Error ? err.message : String(err);
+                this.statusBanner.textContent = err instanceof Error ? err.message : String(err);
                 this.statusBanner.style.display = "block";
             }
         });

--- a/apps/deployment-webview/src/app/vscode.ts
+++ b/apps/deployment-webview/src/app/vscode.ts
@@ -73,9 +73,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
             }
             case "DeployCommand": {
                 console.debug("[DEBUG] DeployCommand", message);
-                dispatchEvent(
-                    new DeploymentResultQuery(true, "Deployment succeeded (mock)."),
-                );
+                dispatchEvent(new DeploymentResultQuery(true, "Deployment succeeded (mock)."));
                 break;
             }
             case "RequestProcessDefinitionKeyCommand": {
@@ -89,11 +87,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
             case "StartInstanceCommand": {
                 console.debug("[DEBUG] StartInstanceCommand", message);
                 dispatchEvent(
-                    new StartInstanceResultQuery(
-                        true,
-                        "Process instance started (mock).",
-                        "12345",
-                    ),
+                    new StartInstanceResultQuery(true, "Process instance started (mock).", "12345"),
                 );
                 break;
             }

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -90,12 +90,9 @@ async function openXML(dmn: string | undefined) {
 
     if (result.warnings.length > 0) {
         const warnings = result.warnings.map(
-            (warning) =>
-                `${warning.message}\n${warning.error.message}\n${warning.error.stack}\n`,
+            (warning) => `${warning.message}\n${warning.error.message}\n${warning.error.stack}\n`,
         );
-        const message = `Diagram was opened with following warnings: ${formatErrors(
-            warnings,
-        )}
+        const message = `Diagram was opened with following warnings: ${formatErrors(warnings)}
             `;
         vscode.postMessage(new LogInfoCommand(message));
     }
@@ -118,8 +115,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>) {
                 if (error instanceof NoModelerError) {
                     dmnFileResolver.done(message.data as DmnFileQuery);
                 } else {
-                    const errorMessage =
-                        error instanceof Error ? error.message : `${error}`;
+                    const errorMessage = error instanceof Error ? error.message : `${error}`;
                     vscode.postMessage(
                         new LogErrorCommand(
                             `Something went wrong when receiving the message ${errorMessage}`,

--- a/apps/dmn-webview/src/types/diagram-js.d.ts
+++ b/apps/dmn-webview/src/types/diagram-js.d.ts
@@ -3,10 +3,7 @@ declare module "diagram-js/lib/core/EventBus" {
         on<T extends string>(event: T, callback: EventCallback, that?: any): void;
     }
 
-    export type EventCallback<T extends string = any> = (
-        event: EventType<T>,
-        data: any,
-    ) => any;
+    export type EventCallback<T extends string = any> = (event: EventType<T>, data: any) => any;
 
     export type EventType<T extends string> =
         EventMap extends Record<T, infer E> ? E : InternalEvent;

--- a/apps/modeler-plugin/src/controller/BpmnCompareController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnCompareController.ts
@@ -59,16 +59,8 @@ export class BpmnCompareController {
      */
     register(context: ExtensionContext): void {
         context.subscriptions.push(
-            commands.registerCommand(
-                SELECT_FOR_COMPARE_CMD,
-                this.selectForCompare,
-                this,
-            ),
-            commands.registerCommand(
-                COMPARE_WITH_SELECTED_CMD,
-                this.compareWithSelected,
-                this,
-            ),
+            commands.registerCommand(SELECT_FOR_COMPARE_CMD, this.selectForCompare, this),
+            commands.registerCommand(COMPARE_WITH_SELECTED_CMD, this.compareWithSelected, this),
             commands.registerCommand(COMPARE_SELECTED_CMD, this.compareSelected, this),
         );
     }
@@ -138,10 +130,7 @@ export class BpmnCompareController {
      * {@link CompareSelectionStore} — both URIs arrive in one call, so a
      * previously-stored "Select for Compare" pick is intentionally preserved.
      */
-    async compareSelected(
-        _uri: Uri | undefined,
-        uris: Uri[] | undefined,
-    ): Promise<void> {
+    async compareSelected(_uri: Uri | undefined, uris: Uri[] | undefined): Promise<void> {
         const bpmnUris = (uris ?? []).filter(isBpmnUri);
         if (bpmnUris.length !== 2) {
             this.vsUI.showInfo("Select exactly two .bpmn files to compare.");

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.navigate.spec.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.navigate.spec.ts
@@ -78,9 +78,7 @@ describe("BpmnEditorController — NavigateToReferencedModelCommand dispatch", (
         const cmd = new NavigateToReferencedModelCommand("ProcessB", "process");
         await callback(cmd, "file:///src/a.bpmn");
 
-        expect(editorStore.getDocumentForEditor).toHaveBeenCalledWith(
-            "file:///src/a.bpmn",
-        );
+        expect(editorStore.getDocumentForEditor).toHaveBeenCalledWith("file:///src/a.bpmn");
         expect(modelNavigationService.navigate).toHaveBeenCalledWith(
             "ProcessB",
             "process",

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -24,10 +24,7 @@ import { BpmnModelerService } from "../service/BpmnModelerService";
 import { BpmnDiffService } from "../service/BpmnDiffService";
 import { ArtifactService } from "../service/ArtifactService";
 import { ModelNavigationService } from "../service/ModelNavigationService";
-import {
-    detectExecutionPlatform,
-    detectExecutionPlatformVersion,
-} from "../service/bpmnUtils";
+import { detectExecutionPlatform, detectExecutionPlatformVersion } from "../service/bpmnUtils";
 import { VsCodeDocument } from "../infrastructure/VsCodeDocument";
 
 /** VS Code view-type identifier for the BPMN custom editor. */
@@ -161,81 +158,68 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      * @param editorId Document URI path of the editor whose webview to listen to.
      */
     private subscribeToMessageEvent(editorId: string): void {
-        this.editorStore.subscribeToMessageEvent(
-            editorId,
-            async (message: Command, id: string) => {
-                this.vsUI.logInfo(`Message received -> ${message.type}`);
-                switch (message.type) {
-                    case "GetBpmnFileCommand":
-                        if (await this.bpmnService.display(id)) {
-                            this.vsUI.logInfo("Bpmn modeler is ready");
-                        }
-                        break;
-                    case "GetElementTemplatesCommand":
-                        this.bpmnService.setElementTemplates(id);
-                        break;
-                    case "GetBpmnModelerSettingCommand":
-                        this.bpmnService.setSettings(id);
-                        this.bpmnService.setLanguage(id);
-                        break;
-                    case "GetPropertiesPanelStateCommand":
-                        this.bpmnService.sendPropertiesPanelState(id);
-                        break;
-                    case "SetPropertiesPanelStateCommand":
-                        this.bpmnService.setPropertiesPanelVisibility(
-                            (message as SetPropertiesPanelStateCommand).visible,
-                        );
-                        break;
-                    case "GetClipboardCommand":
-                        this.bpmnService.readClipboard(id);
-                        break;
-                    case "SetClipboardCommand":
-                        this.bpmnService.writeClipboard(
-                            (message as SetClipboardCommand).text,
-                        );
-                        break;
-                    case "GetTextClipboardCommand":
-                        this.bpmnService.readTextClipboard(id);
-                        break;
-                    case "SetTextClipboardCommand":
-                        this.bpmnService.writeClipboard(
-                            (message as SetTextClipboardCommand).text,
-                        );
-                        break;
-                    case "SyncDocumentCommand":
-                        await this.bpmnService.sync(
-                            id,
-                            (message as SyncDocumentCommand).content,
-                        );
-                        break;
-                    case "NavigateToReferencedModelCommand": {
-                        const cmd = message as NavigateToReferencedModelCommand;
-                        // Defence-in-depth: reject unknown discriminants
-                        // rather than letting them fall through to the
-                        // decision branch by default.
-                        if (
-                            cmd.referenceKind !== "process" &&
-                            cmd.referenceKind !== "decision"
-                        ) {
-                            this.vsUI.logWarning(
-                                `Ignoring NavigateToReferencedModelCommand with unknown kind: ${String(
-                                    cmd.referenceKind,
-                                )}`,
-                            );
-                            break;
-                        }
-                        const sourceDocument = this.editorStore.getDocumentForEditor(id);
-                        await this.modelNavigationService.navigate(
-                            cmd.referenceId,
-                            cmd.referenceKind,
-                            sourceDocument.uri,
+        this.editorStore.subscribeToMessageEvent(editorId, async (message: Command, id: string) => {
+            this.vsUI.logInfo(`Message received -> ${message.type}`);
+            switch (message.type) {
+                case "GetBpmnFileCommand":
+                    if (await this.bpmnService.display(id)) {
+                        this.vsUI.logInfo("Bpmn modeler is ready");
+                    }
+                    break;
+                case "GetElementTemplatesCommand":
+                    this.bpmnService.setElementTemplates(id);
+                    break;
+                case "GetBpmnModelerSettingCommand":
+                    this.bpmnService.setSettings(id);
+                    this.bpmnService.setLanguage(id);
+                    break;
+                case "GetPropertiesPanelStateCommand":
+                    this.bpmnService.sendPropertiesPanelState(id);
+                    break;
+                case "SetPropertiesPanelStateCommand":
+                    this.bpmnService.setPropertiesPanelVisibility(
+                        (message as SetPropertiesPanelStateCommand).visible,
+                    );
+                    break;
+                case "GetClipboardCommand":
+                    this.bpmnService.readClipboard(id);
+                    break;
+                case "SetClipboardCommand":
+                    this.bpmnService.writeClipboard((message as SetClipboardCommand).text);
+                    break;
+                case "GetTextClipboardCommand":
+                    this.bpmnService.readTextClipboard(id);
+                    break;
+                case "SetTextClipboardCommand":
+                    this.bpmnService.writeClipboard((message as SetTextClipboardCommand).text);
+                    break;
+                case "SyncDocumentCommand":
+                    await this.bpmnService.sync(id, (message as SyncDocumentCommand).content);
+                    break;
+                case "NavigateToReferencedModelCommand": {
+                    const cmd = message as NavigateToReferencedModelCommand;
+                    // Defence-in-depth: reject unknown discriminants
+                    // rather than letting them fall through to the
+                    // decision branch by default.
+                    if (cmd.referenceKind !== "process" && cmd.referenceKind !== "decision") {
+                        this.vsUI.logWarning(
+                            `Ignoring NavigateToReferencedModelCommand with unknown kind: ${String(
+                                cmd.referenceKind,
+                            )}`,
                         );
                         break;
                     }
+                    const sourceDocument = this.editorStore.getDocumentForEditor(id);
+                    await this.modelNavigationService.navigate(
+                        cmd.referenceId,
+                        cmd.referenceKind,
+                        sourceDocument.uri,
+                    );
+                    break;
                 }
-                this.vsUI.logInfo(`Message processed -> ${message.type}`);
-            },
-        );
+            }
+            this.vsUI.logInfo(`Message processed -> ${message.type}`);
+        });
     }
 
     /**
@@ -273,19 +257,13 @@ export class BpmnEditorController implements CustomTextEditorProvider {
             if (event.affectsConfiguration("miragon.bpmnModeler.alignToOrigin")) {
                 this.bpmnService.setSettings(id);
             }
-            if (
-                event.affectsConfiguration(
-                    "miragon.bpmnModeler.showTransactionBoundaries",
-                )
-            ) {
+            if (event.affectsConfiguration("miragon.bpmnModeler.showTransactionBoundaries")) {
                 this.bpmnService.setSettings(id);
             }
             if (event.affectsConfiguration("miragon.bpmnModeler.colorTheme")) {
                 this.bpmnService.setSettings(id);
             }
-            if (
-                event.affectsConfiguration("miragon.bpmnModeler.favouriteBpmnElements")
-            ) {
+            if (event.affectsConfiguration("miragon.bpmnModeler.favouriteBpmnElements")) {
                 this.bpmnService.setSettings(id);
             }
             if (event.affectsConfiguration("miragon.bpmnModeler.configFolder")) {
@@ -304,10 +282,7 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      * @param editorId Document URI path of the target editor.
      * @param webviewPanel The webview panel to observe.
      */
-    private subscribeToViewStateChangeEvent(
-        editorId: string,
-        webviewPanel: WebviewPanel,
-    ): void {
+    private subscribeToViewStateChangeEvent(editorId: string, webviewPanel: WebviewPanel): void {
         webviewPanel.onDidChangeViewState(() => {
             if (webviewPanel.active) {
                 this.updateEngineVersionStatusBar(editorId);

--- a/apps/modeler-plugin/src/controller/CommandController.ts
+++ b/apps/modeler-plugin/src/controller/CommandController.ts
@@ -68,11 +68,7 @@ export class CommandController {
             commands.registerCommand(LOGGING_CMD, this.showLogging, this),
             commands.registerCommand(COPY_SVG_CMD, this.writeToClipboard, this),
             commands.registerCommand(SAVE_SVG_CMD, this.writeToFile, this),
-            commands.registerCommand(
-                CHANGE_ENGINE_VERSION_CMD,
-                this.changeEngineVersion,
-                this,
-            ),
+            commands.registerCommand(CHANGE_ENGINE_VERSION_CMD, this.changeEngineVersion, this),
             commands.registerCommand(MIGRATE_ALL_CMD, this.migrateAllDiagrams, this),
             commands.registerCommand(CHANGE_LANGUAGE_CMD, this.changeLanguage, this),
         );
@@ -181,13 +177,9 @@ export class CommandController {
     private requestSvg(onSvg: (svg: string) => void): void {
         const activeId = this.editorStore.getActiveEditorId();
 
-        this.editorStore
-            .postMessage(activeId, new GetDiagramAsSVGCommand())
-            .catch((error) => {
-                this.vsUI.logError(
-                    error instanceof Error ? error : new Error(String(error)),
-                );
-            });
+        this.editorStore.postMessage(activeId, new GetDiagramAsSVGCommand()).catch((error) => {
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
+        });
 
         // Dispose previous subscription to avoid accumulating listeners.
         this.svgSubscription?.dispose();

--- a/apps/modeler-plugin/src/controller/DeploymentController.ts
+++ b/apps/modeler-plugin/src/controller/DeploymentController.ts
@@ -9,12 +9,7 @@ import {
     window,
 } from "vscode";
 
-import {
-    BasicAuth,
-    DeploymentConfigBuilder,
-    NoAuth,
-    OAuth2Auth,
-} from "../domain/deployment";
+import { BasicAuth, DeploymentConfigBuilder, NoAuth, OAuth2Auth } from "../domain/deployment";
 import { InvalidDeploymentConfigError } from "../domain/errors";
 import { deploymentWebviewHtml } from "../infrastructure/DeploymentWebviewHtml";
 import { EditorStore } from "../infrastructure/EditorStore";
@@ -104,9 +99,7 @@ export class DeploymentController implements WebviewViewProvider {
 
         webviewView.webview.options = {
             enableScripts: true,
-            localResourceRoots: [
-                Uri.joinPath(getContext().extensionUri, "deployment-webview"),
-            ],
+            localResourceRoots: [Uri.joinPath(getContext().extensionUri, "deployment-webview")],
         };
 
         webviewView.webview.html = deploymentWebviewHtml(
@@ -157,8 +150,7 @@ export class DeploymentController implements WebviewViewProvider {
 
             // Also send the process definition key for the Start Instance tab.
             try {
-                const key =
-                    this.startInstanceService.getProcessDefinitionKey(activeEditorId);
+                const key = this.startInstanceService.getProcessDefinitionKey(activeEditorId);
                 webviewView.webview.postMessage(new ProcessDefinitionKeyQuery(key));
             } catch {
                 // Process key extraction failed — send empty key.
@@ -199,10 +191,7 @@ export class DeploymentController implements WebviewViewProvider {
                     await this.handleAdditionalFilesRequest(webviewView);
                     break;
                 case "DeployCommand":
-                    await this.handleDeploy(
-                        webviewView,
-                        (message as DeployCommand).config,
-                    );
+                    await this.handleDeploy(webviewView, (message as DeployCommand).config);
                     break;
                 case "RequestProcessDefinitionKeyCommand":
                     this.handleProcessDefinitionKeyRequest(webviewView);
@@ -226,19 +215,13 @@ export class DeploymentController implements WebviewViewProvider {
      *
      * @param webviewView The target WebviewView.
      */
-    private async handleStoredCredentialsRequest(
-        webviewView: WebviewView,
-    ): Promise<void> {
+    private async handleStoredCredentialsRequest(webviewView: WebviewView): Promise<void> {
         try {
             const auth = await this.deploymentService.getStoredCredentials();
             webviewView.webview.postMessage(new StoredCredentialsQuery(auth));
         } catch (error) {
-            this.vsUI.logError(
-                error instanceof Error ? error : new Error(String(error)),
-            );
-            webviewView.webview.postMessage(
-                new StoredCredentialsQuery({ authType: "none" }),
-            );
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
+            webviewView.webview.postMessage(new StoredCredentialsQuery({ authType: "none" }));
         }
     }
 
@@ -253,9 +236,7 @@ export class DeploymentController implements WebviewViewProvider {
             const filePaths = await this.deploymentService.selectAdditionalFiles();
             webviewView.webview.postMessage(new AdditionalFilesQuery(filePaths));
         } catch (error) {
-            this.vsUI.logError(
-                error instanceof Error ? error : new Error(String(error)),
-            );
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
             webviewView.webview.postMessage(new AdditionalFilesQuery([]));
         }
     }
@@ -269,13 +250,10 @@ export class DeploymentController implements WebviewViewProvider {
     private handleProcessDefinitionKeyRequest(webviewView: WebviewView): void {
         try {
             const activeEditorId = this.editorStore.getActiveEditorId();
-            const key =
-                this.startInstanceService.getProcessDefinitionKey(activeEditorId);
+            const key = this.startInstanceService.getProcessDefinitionKey(activeEditorId);
             webviewView.webview.postMessage(new ProcessDefinitionKeyQuery(key));
         } catch (error) {
-            this.vsUI.logError(
-                error instanceof Error ? error : new Error(String(error)),
-            );
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
             webviewView.webview.postMessage(new ProcessDefinitionKeyQuery(""));
         }
     }
@@ -289,8 +267,7 @@ export class DeploymentController implements WebviewViewProvider {
     private async handlePayloadFilesRequest(webviewView: WebviewView): Promise<void> {
         try {
             const activeEditorId = this.editorStore.getActiveEditorId();
-            const result =
-                await this.startInstanceService.selectPayloadFile(activeEditorId);
+            const result = await this.startInstanceService.selectPayloadFile(activeEditorId);
             if (result) {
                 webviewView.webview.postMessage(
                     new SelectedPayloadFileQuery(result.filePath, result.label),
@@ -299,9 +276,7 @@ export class DeploymentController implements WebviewViewProvider {
                 webviewView.webview.postMessage(new SelectedPayloadFileQuery("", ""));
             }
         } catch (error) {
-            this.vsUI.logError(
-                error instanceof Error ? error : new Error(String(error)),
-            );
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
             webviewView.webview.postMessage(new SelectedPayloadFileQuery("", ""));
         }
     }
@@ -321,10 +296,7 @@ export class DeploymentController implements WebviewViewProvider {
             const authPayload = configPayload.auth;
             let auth;
             if (authPayload.authType === "basic") {
-                auth = new BasicAuth(
-                    authPayload.username ?? "",
-                    authPayload.password ?? "",
-                );
+                auth = new BasicAuth(authPayload.username ?? "", authPayload.password ?? "");
             } else if (authPayload.authType === "oauth2") {
                 auth = new OAuth2Auth(
                     authPayload.clientId ?? "",
@@ -358,15 +330,10 @@ export class DeploymentController implements WebviewViewProvider {
                 ),
             );
         } catch (error) {
-            const message =
-                "An unexpected error occurred while starting the process instance.";
-            this.vsUI.logError(
-                error instanceof Error ? error : new Error(String(error)),
-            );
+            const message = "An unexpected error occurred while starting the process instance.";
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
             this.vsUI.showError(message);
-            webviewView.webview.postMessage(
-                new StartInstanceResultQuery(false, message),
-            );
+            webviewView.webview.postMessage(new StartInstanceResultQuery(false, message));
         }
     }
 
@@ -385,10 +352,7 @@ export class DeploymentController implements WebviewViewProvider {
             const authPayload = configPayload.auth;
             let auth;
             if (authPayload.authType === "basic") {
-                auth = new BasicAuth(
-                    authPayload.username ?? "",
-                    authPayload.password ?? "",
-                );
+                auth = new BasicAuth(authPayload.username ?? "", authPayload.password ?? "");
             } else if (authPayload.authType === "oauth2") {
                 auth = new OAuth2Auth(
                     authPayload.clientId ?? "",
@@ -422,11 +386,7 @@ export class DeploymentController implements WebviewViewProvider {
             }
 
             webviewView.webview.postMessage(
-                new DeploymentResultQuery(
-                    result.success,
-                    result.message,
-                    result.deploymentId,
-                ),
+                new DeploymentResultQuery(result.success, result.message, result.deploymentId),
             );
         } catch (error) {
             const message =
@@ -434,9 +394,7 @@ export class DeploymentController implements WebviewViewProvider {
                     ? error.message
                     : "An unexpected error occurred during deployment.";
 
-            this.vsUI.logError(
-                error instanceof Error ? error : new Error(String(error)),
-            );
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
             this.vsUI.showError(message);
             webviewView.webview.postMessage(new DeploymentResultQuery(false, message));
         }

--- a/apps/modeler-plugin/src/controller/DmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/DmnEditorController.ts
@@ -68,12 +68,7 @@ export class DmnEditorController implements CustomTextEditorProvider {
     ): void | Thenable<void> {
         try {
             const editorId = document.uri.toString();
-            this.editorStore.createEditor(
-                DMN_VIEW_TYPE,
-                editorId,
-                webviewPanel,
-                document,
-            );
+            this.editorStore.createEditor(DMN_VIEW_TYPE, editorId, webviewPanel, document);
             this.dmnService.registerSession(editorId);
 
             this.subscribeToMessageEvent(editorId);
@@ -95,26 +90,20 @@ export class DmnEditorController implements CustomTextEditorProvider {
      * @param editorId Document URI path of the editor whose webview to listen to.
      */
     private subscribeToMessageEvent(editorId: string): void {
-        this.editorStore.subscribeToMessageEvent(
-            editorId,
-            async (message: Command, id: string) => {
-                this.vsUI.logInfo(`Message received -> ${message.type}`);
-                switch (message.type) {
-                    case "GetDmnFileCommand":
-                        if (await this.dmnService.display(id)) {
-                            this.vsUI.logInfo("Dmn modeler is ready");
-                        }
-                        break;
-                    case "SyncDocumentCommand":
-                        await this.dmnService.sync(
-                            id,
-                            (message as SyncDocumentCommand).content,
-                        );
-                        break;
-                }
-                this.vsUI.logInfo(`Message processed -> ${message.type}`);
-            },
-        );
+        this.editorStore.subscribeToMessageEvent(editorId, async (message: Command, id: string) => {
+            this.vsUI.logInfo(`Message received -> ${message.type}`);
+            switch (message.type) {
+                case "GetDmnFileCommand":
+                    if (await this.dmnService.display(id)) {
+                        this.vsUI.logInfo("Dmn modeler is ready");
+                    }
+                    break;
+                case "SyncDocumentCommand":
+                    await this.dmnService.sync(id, (message as SyncDocumentCommand).content);
+                    break;
+            }
+            this.vsUI.logInfo(`Message processed -> ${message.type}`);
+        });
     }
 
     /**

--- a/apps/modeler-plugin/src/domain/ports.ts
+++ b/apps/modeler-plugin/src/domain/ports.ts
@@ -31,10 +31,7 @@ export interface CamundaEnginePort {
      * @returns A {@link DeploymentResult} describing the outcome.
      * @throws {DeploymentFailedError} If the server returns a non-2xx status.
      */
-    deploy(
-        config: DeploymentConfig,
-        fileContents: Map<string, string>,
-    ): Promise<DeploymentResult>;
+    deploy(config: DeploymentConfig, fileContents: Map<string, string>): Promise<DeploymentResult>;
 
     /**
      * Starts a process instance on the Camunda engine.
@@ -75,11 +72,7 @@ export interface HttpClient {
      * @param headers Optional extra headers to merge into the request.
      * @returns The HTTP status code and raw response body text.
      */
-    postForm(
-        url: string,
-        body: string,
-        headers?: Record<string, string>,
-    ): Promise<HttpResponse>;
+    postForm(url: string, body: string, headers?: Record<string, string>): Promise<HttpResponse>;
 
     /**
      * Sends a POST request with a multipart/form-data body.

--- a/apps/modeler-plugin/src/infrastructure/EditorStore.ts
+++ b/apps/modeler-plugin/src/infrastructure/EditorStore.ts
@@ -55,8 +55,7 @@ export class EditorStore implements Disposable {
     private readonly _onDidChangeActiveEditor = new EventEmitter<string>();
 
     /** Event that fires when the active editor changes. */
-    readonly onDidChangeActiveEditor: Event<string> =
-        this._onDidChangeActiveEditor.event;
+    readonly onDidChangeActiveEditor: Event<string> = this._onDidChangeActiveEditor.event;
 
     // ─── Editor lifecycle ────────────────────────────────────────────────────
 
@@ -142,10 +141,7 @@ export class EditorStore implements Disposable {
      */
     findEditorIdByPath(filePath: string): string | undefined {
         for (const [, entry] of this.editors) {
-            if (
-                entry.document.uri.scheme === "file" &&
-                entry.document.uri.path === filePath
-            ) {
+            if (entry.document.uri.scheme === "file" && entry.document.uri.path === filePath) {
                 return entry.id;
             }
         }
@@ -347,8 +343,7 @@ export class EditorStore implements Disposable {
 
         if (this.activeEditorId === editorId) {
             const remaining = [...this.editors.keys()];
-            const next =
-                remaining.length > 0 ? remaining[remaining.length - 1] : undefined;
+            const next = remaining.length > 0 ? remaining[remaining.length - 1] : undefined;
             this.activeEditorId = next;
             if (next) {
                 this._onDidChangeActiveEditor.fire(next);

--- a/apps/modeler-plugin/src/infrastructure/VsCodeDeploymentState.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeDeploymentState.ts
@@ -26,10 +26,7 @@ export class VsCodeDeploymentState {
      * @returns The persisted endpoint, or an empty string if none has been saved.
      */
     getEndpoint(): string {
-        return getContext().workspaceState.get<string>(
-            VsCodeDeploymentState.ENDPOINT_KEY,
-            "",
-        );
+        return getContext().workspaceState.get<string>(VsCodeDeploymentState.ENDPOINT_KEY, "");
     }
 
     /**
@@ -38,10 +35,7 @@ export class VsCodeDeploymentState {
      * @returns The persisted tenant ID, or an empty string if none has been saved.
      */
     getTenantId(): string {
-        return getContext().workspaceState.get<string>(
-            VsCodeDeploymentState.TENANT_ID_KEY,
-            "",
-        );
+        return getContext().workspaceState.get<string>(VsCodeDeploymentState.TENANT_ID_KEY, "");
     }
 
     /**
@@ -62,10 +56,7 @@ export class VsCodeDeploymentState {
      * @param authType The authentication type to persist.
      */
     async saveAuthType(authType: AuthTypePayload): Promise<void> {
-        await getContext().workspaceState.update(
-            VsCodeDeploymentState.AUTH_TYPE_KEY,
-            authType,
-        );
+        await getContext().workspaceState.update(VsCodeDeploymentState.AUTH_TYPE_KEY, authType);
     }
 
     /**
@@ -93,10 +84,7 @@ export class VsCodeDeploymentState {
      * @returns The persisted audience, or an empty string if none has been saved.
      */
     getAudience(): string {
-        return getContext().workspaceState.get<string>(
-            VsCodeDeploymentState.AUDIENCE_KEY,
-            "",
-        );
+        return getContext().workspaceState.get<string>(VsCodeDeploymentState.AUDIENCE_KEY, "");
     }
 
     /**
@@ -110,20 +98,11 @@ export class VsCodeDeploymentState {
             VsCodeDeploymentState.TOKEN_ENDPOINT_KEY,
             tokenEndpoint,
         );
-        await getContext().workspaceState.update(
-            VsCodeDeploymentState.AUDIENCE_KEY,
-            audience,
-        );
+        await getContext().workspaceState.update(VsCodeDeploymentState.AUDIENCE_KEY, audience);
     }
 
     async save(endpoint: string, tenantId: string): Promise<void> {
-        await getContext().workspaceState.update(
-            VsCodeDeploymentState.ENDPOINT_KEY,
-            endpoint,
-        );
-        await getContext().workspaceState.update(
-            VsCodeDeploymentState.TENANT_ID_KEY,
-            tenantId,
-        );
+        await getContext().workspaceState.update(VsCodeDeploymentState.ENDPOINT_KEY, endpoint);
+        await getContext().workspaceState.update(VsCodeDeploymentState.TENANT_ID_KEY, tenantId);
     }
 }

--- a/apps/modeler-plugin/src/infrastructure/VsCodeSettings.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeSettings.ts
@@ -8,9 +8,7 @@ export class VsCodeSettings {
      */
     getAlignToOrigin(): boolean {
         return (
-            workspace
-                .getConfiguration("miragon.bpmnModeler")
-                .get<boolean>("alignToOrigin") ?? false
+            workspace.getConfiguration("miragon.bpmnModeler").get<boolean>("alignToOrigin") ?? false
         );
     }
 
@@ -47,9 +45,7 @@ export class VsCodeSettings {
      * @returns The API version string (e.g. `"v2"`).
      */
     getC8ApiVersion(): string {
-        return workspace
-            .getConfiguration("miragon.bpmnModeler")
-            .get<string>("c8ApiVersion", "v2");
+        return workspace.getConfiguration("miragon.bpmnModeler").get<string>("c8ApiVersion", "v2");
     }
 
     /**
@@ -87,8 +83,6 @@ export class VsCodeSettings {
      * @returns The locale code (e.g. `"de"`, `"fr"`).
      */
     getLanguage(): string {
-        return workspace
-            .getConfiguration("miragon.bpmnModeler")
-            .get<string>("language", "en");
+        return workspace.getConfiguration("miragon.bpmnModeler").get<string>("language", "en");
     }
 }

--- a/apps/modeler-plugin/src/infrastructure/VsCodeStatusBar.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeStatusBar.ts
@@ -95,10 +95,7 @@ export class VsCodeStatusBar {
      */
     private getOrCreateTemplateStatusItem(): StatusBarItem {
         if (!this.templateStatusItem) {
-            this.templateStatusItem = window.createStatusBarItem(
-                StatusBarAlignment.Left,
-                100,
-            );
+            this.templateStatusItem = window.createStatusBarItem(StatusBarAlignment.Left, 100);
         }
         return this.templateStatusItem;
     }

--- a/apps/modeler-plugin/src/infrastructure/VsCodeUI.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeUI.spec.ts
@@ -40,9 +40,7 @@ import { VsCodeUI } from "./VsCodeUI";
 beforeEach(() => {
     showQuickPickMock.mockReset();
     asRelativePathMock.mockReset();
-    asRelativePathMock.mockImplementation((uri: { path: string }) =>
-        uri.path.replace(/^\//, ""),
-    );
+    asRelativePathMock.mockImplementation((uri: { path: string }) => uri.path.replace(/^\//, ""));
 });
 
 describe("VsCodeUI.pickReferencedModel", () => {
@@ -90,11 +88,7 @@ describe("VsCodeUI.pickReferencedModel", () => {
         // Inputs in non-alphabetical order; expect the picker to receive
         // them sorted by `description` so nearby files surface first.
         const sut = new VsCodeUI();
-        await sut.pickReferencedModel([
-            "/repo/src/z.bpmn",
-            "/repo/lib/a.bpmn",
-            "/repo/src/m.bpmn",
-        ]);
+        await sut.pickReferencedModel(["/repo/src/z.bpmn", "/repo/lib/a.bpmn", "/repo/src/m.bpmn"]);
 
         const items = showQuickPickMock.mock.calls[0][0] as { path: string }[];
         expect(items.map((i) => i.path)).toEqual([

--- a/apps/modeler-plugin/src/infrastructure/VsCodeUI.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeUI.ts
@@ -109,10 +109,7 @@ export class VsCodeUI {
      * @throws {UserCancelledError} If the user dismisses the quick pick.
      * @throws {Error} If the user selects an unknown item.
      */
-    async pickExecutionPlatform(
-        placeHolder: string,
-        items: string[],
-    ): Promise<"c7" | "c8"> {
+    async pickExecutionPlatform(placeHolder: string, items: string[]): Promise<"c7" | "c8"> {
         const result = await window.showQuickPick(items, {
             placeHolder,
             onDidSelectItem: (item) => item,
@@ -168,10 +165,7 @@ export class VsCodeUI {
      * @returns The selected version string.
      * @throws {UserCancelledError} If the user dismisses the quick pick.
      */
-    async pickEngineVersion(
-        platform: "c7" | "c8",
-        versions: readonly string[],
-    ): Promise<string> {
+    async pickEngineVersion(platform: "c7" | "c8", versions: readonly string[]): Promise<string> {
         const label = platform === "c7" ? "Camunda 7" : "Camunda 8";
         const result = await window.showQuickPick([...versions], {
             placeHolder: `Select ${label} engine version`,

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.spec.ts
@@ -53,10 +53,7 @@ describe("VsCodeWorkspace.findFiles", () => {
     });
 
     it("returns the .path of every matching Uri", async () => {
-        findFilesMock.mockResolvedValueOnce([
-            { path: "/x.bpmn" },
-            { path: "/nested/y.bpmn" },
-        ]);
+        findFilesMock.mockResolvedValueOnce([{ path: "/x.bpmn" }, { path: "/nested/y.bpmn" }]);
         const sut = new VsCodeWorkspace();
 
         const result = await sut.findFiles("**/*.bpmn");

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
@@ -2,11 +2,7 @@ import { posix } from "path";
 
 import { FileType, GlobPattern, Uri, workspace } from "vscode";
 
-import {
-    DirectoryNotFound,
-    FileNotFound,
-    NoWorkspaceFolderFoundError,
-} from "../domain/errors";
+import { DirectoryNotFound, FileNotFound, NoWorkspaceFolderFoundError } from "../domain/errors";
 
 const fs = workspace.fs;
 
@@ -125,10 +121,7 @@ export class VsCodeWorkspace {
      *   `null` opts out of every default exclude.
      * @returns An array of absolute file paths.
      */
-    async findFiles(
-        pattern: GlobPattern,
-        exclude?: GlobPattern | null,
-    ): Promise<string[]> {
+    async findFiles(pattern: GlobPattern, exclude?: GlobPattern | null): Promise<string[]> {
         const uris = await workspace.findFiles(pattern, exclude);
         return uris.map((uri) => uri.path);
     }

--- a/apps/modeler-plugin/src/infrastructure/WebviewHtml.ts
+++ b/apps/modeler-plugin/src/infrastructure/WebviewHtml.ts
@@ -46,9 +46,7 @@ export function bpmnEditorUi(
     const panelClass = initialPanelVisible
         ? "properties-panel-parent"
         : "properties-panel-parent collapsed";
-    const resizerClass = initialPanelVisible
-        ? "panel-resizer"
-        : "panel-resizer collapsed";
+    const resizerClass = initialPanelVisible ? "panel-resizer" : "panel-resizer collapsed";
     const panelStyle = initialPanelVisible ? "" : ` style="width: 0"`;
 
     return `
@@ -85,9 +83,7 @@ export function dmnModelerHtml(webview: Webview, extensionUri: Uri): string {
     const baseUri = Uri.joinPath(extensionUri, DMN_WEBVIEW_PATH);
 
     const scriptUri = webview.asWebviewUri(Uri.joinPath(baseUri, "index.js"));
-    const styleResetUri = webview.asWebviewUri(
-        Uri.joinPath(extensionUri, "assets", "reset.css"),
-    );
+    const styleResetUri = webview.asWebviewUri(Uri.joinPath(extensionUri, "assets", "reset.css"));
     const styleUri = webview.asWebviewUri(Uri.joinPath(baseUri, "index.css"));
     const frontUri = webview.asWebviewUri(Uri.joinPath(baseUri, "css", "dmn.css"));
 

--- a/apps/modeler-plugin/src/infrastructure/bootstrapWebview.ts
+++ b/apps/modeler-plugin/src/infrastructure/bootstrapWebview.ts
@@ -33,11 +33,7 @@ export function bootstrapWebview(
     webview.options = { enableScripts: true };
 
     if (viewType === BPMN_VIEW_TYPE) {
-        webview.html = bpmnEditorUi(
-            webview,
-            getContext().extensionUri,
-            initialPanelVisible,
-        );
+        webview.html = bpmnEditorUi(webview, getContext().extensionUri, initialPanelVisible);
     } else if (viewType === DMN_VIEW_TYPE) {
         webview.html = dmnModelerHtml(webview, getContext().extensionUri);
     } else {

--- a/apps/modeler-plugin/src/infrastructure/camunda/AuthHeaderResolver.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/AuthHeaderResolver.spec.ts
@@ -56,12 +56,7 @@ describe("AuthHeaderResolver", () => {
         };
         httpClient.postForm.mockResolvedValue(tokenResponse);
 
-        const auth = new OAuth2Auth(
-            "my-client",
-            "my-secret",
-            "http://idp.local/token",
-            "",
-        );
+        const auth = new OAuth2Auth("my-client", "my-secret", "http://idp.local/token", "");
 
         const result = await resolver.resolve(auth);
 
@@ -142,8 +137,6 @@ describe("AuthHeaderResolver", () => {
         const auth = new OAuth2Auth("cid", "csec", "http://idp.local/token", "");
 
         await expect(resolver.resolve(auth)).rejects.toThrow(TokenFetchError);
-        await expect(resolver.resolve(auth)).rejects.toThrow(
-            /does not contain an access_token/,
-        );
+        await expect(resolver.resolve(auth)).rejects.toThrow(/does not contain an access_token/);
     });
 });

--- a/apps/modeler-plugin/src/infrastructure/camunda/AuthHeaderResolver.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/AuthHeaderResolver.ts
@@ -31,9 +31,9 @@ export class AuthHeaderResolver {
                 return {};
 
             case "basic": {
-                const credentials = Buffer.from(
-                    `${auth.username}:${auth.password}`,
-                ).toString("base64");
+                const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString(
+                    "base64",
+                );
                 return { Authorization: `Basic ${credentials}` };
             }
 
@@ -65,10 +65,7 @@ export class AuthHeaderResolver {
 
         let response;
         try {
-            response = await this.httpClient.postForm(
-                auth.tokenEndpoint,
-                params.toString(),
-            );
+            response = await this.httpClient.postForm(auth.tokenEndpoint, params.toString());
         } catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             throw new TokenFetchError(message);

--- a/apps/modeler-plugin/src/infrastructure/camunda/Camunda7RestClient.integration.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/Camunda7RestClient.integration.spec.ts
@@ -6,12 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { FetchHttpClient } from "../FetchHttpClient";
 import { AuthHeaderResolver } from "./AuthHeaderResolver";
 import { Camunda7RestClient } from "./Camunda7RestClient";
-import {
-    BasicAuth,
-    DeploymentConfig,
-    NoAuth,
-    OAuth2Auth,
-} from "../../domain/deployment";
+import { BasicAuth, DeploymentConfig, NoAuth, OAuth2Auth } from "../../domain/deployment";
 import { StartInstanceConfig } from "../../domain/startInstance";
 import { DeploymentFailedError, StartInstanceFailedError } from "../../domain/errors";
 
@@ -26,11 +21,7 @@ describe("Camunda7RestClient (integration)", () => {
     let baseUrl: string;
 
     /** Handler installed per-test; receives the raw request and body buffer. */
-    let handler: (
-        req: http.IncomingMessage,
-        body: Buffer,
-        res: http.ServerResponse,
-    ) => void;
+    let handler: (req: http.IncomingMessage, body: Buffer, res: http.ServerResponse) => void;
 
     beforeAll(async () => {
         server = http.createServer((req, res) => {
@@ -104,9 +95,9 @@ describe("Camunda7RestClient (integration)", () => {
             new NoAuth(),
         );
 
-        await expect(
-            client.deploy(config, new Map([["proc.bpmn", "<bpmn/>"]])),
-        ).rejects.toThrow(DeploymentFailedError);
+        await expect(client.deploy(config, new Map([["proc.bpmn", "<bpmn/>"]]))).rejects.toThrow(
+            DeploymentFailedError,
+        );
     });
 
     // ── Start instance ──────────────────────────────────────────────────
@@ -136,9 +127,7 @@ describe("Camunda7RestClient (integration)", () => {
         const client = createClient();
         const config = new StartInstanceConfig("missing", baseUrl, "c7", new NoAuth());
 
-        await expect(client.startInstance(config)).rejects.toThrow(
-            StartInstanceFailedError,
-        );
+        await expect(client.startInstance(config)).rejects.toThrow(StartInstanceFailedError);
     });
 
     // ── Auth headers ────────────────────────────────────────────────────

--- a/apps/modeler-plugin/src/infrastructure/camunda/Camunda8RestClient.integration.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/Camunda8RestClient.integration.spec.ts
@@ -21,11 +21,7 @@ describe("Camunda8RestClient (integration)", () => {
     let baseUrl: string;
 
     /** Handler installed per-test; receives the raw request and body buffer. */
-    let handler: (
-        req: http.IncomingMessage,
-        body: Buffer,
-        res: http.ServerResponse,
-    ) => void;
+    let handler: (req: http.IncomingMessage, body: Buffer, res: http.ServerResponse) => void;
 
     beforeAll(async () => {
         server = http.createServer((req, res) => {
@@ -101,9 +97,9 @@ describe("Camunda8RestClient (integration)", () => {
             new NoAuth(),
         );
 
-        await expect(
-            client.deploy(config, new Map([["proc.bpmn", "<bpmn/>"]])),
-        ).rejects.toThrow(DeploymentFailedError);
+        await expect(client.deploy(config, new Map([["proc.bpmn", "<bpmn/>"]]))).rejects.toThrow(
+            DeploymentFailedError,
+        );
     });
 
     // ── Start instance ──────────────────────────────────────────────────
@@ -142,9 +138,7 @@ describe("Camunda8RestClient (integration)", () => {
         const client = createClient();
         const config = new StartInstanceConfig("missing", baseUrl, "c8", new NoAuth());
 
-        await expect(client.startInstance(config)).rejects.toThrow(
-            StartInstanceFailedError,
-        );
+        await expect(client.startInstance(config)).rejects.toThrow(StartInstanceFailedError);
     });
 
     // ── Custom C8 API version ─────────────────────────────────────────

--- a/apps/modeler-plugin/src/infrastructure/camunda/Camunda8RestClient.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/Camunda8RestClient.ts
@@ -70,9 +70,7 @@ export class Camunda8RestClient implements CamundaEnginePort {
         try {
             const json = JSON.parse(responseBody);
             deploymentId =
-                json.deploymentKey !== undefined
-                    ? String(json.deploymentKey)
-                    : undefined;
+                json.deploymentKey !== undefined ? String(json.deploymentKey) : undefined;
         } catch {
             // Response was not valid JSON — deploymentId remains undefined.
         }
@@ -119,9 +117,7 @@ export class Camunda8RestClient implements CamundaEnginePort {
         try {
             const json = JSON.parse(responseBody);
             processInstanceId =
-                json.processInstanceKey !== undefined
-                    ? String(json.processInstanceKey)
-                    : undefined;
+                json.processInstanceKey !== undefined ? String(json.processInstanceKey) : undefined;
         } catch {
             // Response was not valid JSON — processInstanceId remains undefined.
         }

--- a/apps/modeler-plugin/src/infrastructure/camunda/CamundaEngineRouter.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/CamundaEngineRouter.spec.ts
@@ -81,12 +81,7 @@ describe("CamundaEngineRouter", () => {
         const expectedResult = new StartInstanceResult(true, "ok", "i1");
         c7.startInstance.mockResolvedValue(expectedResult);
 
-        const config = new StartInstanceConfig(
-            "myProc",
-            "http://localhost",
-            "c7",
-            new NoAuth(),
-        );
+        const config = new StartInstanceConfig("myProc", "http://localhost", "c7", new NoAuth());
 
         const result = await router.startInstance(config);
 
@@ -99,12 +94,7 @@ describe("CamundaEngineRouter", () => {
         const expectedResult = new StartInstanceResult(true, "ok", "i2");
         c8.startInstance.mockResolvedValue(expectedResult);
 
-        const config = new StartInstanceConfig(
-            "myProc",
-            "http://localhost",
-            "c8",
-            new NoAuth(),
-        );
+        const config = new StartInstanceConfig("myProc", "http://localhost", "c8", new NoAuth());
 
         const result = await router.startInstance(config);
 

--- a/apps/modeler-plugin/src/infrastructure/camunda/CamundaEngineRouter.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/CamundaEngineRouter.ts
@@ -26,10 +26,7 @@ export class CamundaEngineRouter implements CamundaEnginePort {
      * @param fileContents Map of filename → UTF-8 file content.
      * @returns The deployment result from the selected engine client.
      */
-    deploy(
-        config: DeploymentConfig,
-        fileContents: Map<string, string>,
-    ): Promise<DeploymentResult> {
+    deploy(config: DeploymentConfig, fileContents: Map<string, string>): Promise<DeploymentResult> {
         return (config.engine === "c7" ? this.c7 : this.c8).deploy(config, fileContents);
     }
 

--- a/apps/modeler-plugin/src/infrastructure/window.ts
+++ b/apps/modeler-plugin/src/infrastructure/window.ts
@@ -1,11 +1,4 @@
-import {
-    LogOutputChannel,
-    Tab,
-    TabInputText,
-    ViewColumn,
-    window,
-    workspace,
-} from "vscode";
+import { LogOutputChannel, Tab, TabInputText, ViewColumn, window, workspace } from "vscode";
 
 import { getContext } from "./extensionContext";
 
@@ -69,10 +62,7 @@ export class VsCodeTextEditor {
     private getTab(documentPath: string): Tab | undefined {
         for (const tabGroup of window.tabGroups.all) {
             for (const tab of tabGroup.tabs) {
-                if (
-                    tab.input instanceof TabInputText &&
-                    tab.input.uri.path === documentPath
-                ) {
+                if (tab.input instanceof TabInputText && tab.input.uri.path === documentPath) {
                     return tab;
                 }
             }

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -64,11 +64,7 @@ export function activate(context: ExtensionContext): void {
     const httpClient = new FetchHttpClient();
     const authResolver = new AuthHeaderResolver(httpClient);
     const c7Client = new Camunda7RestClient(httpClient, authResolver);
-    const c8Client = new Camunda8RestClient(
-        httpClient,
-        authResolver,
-        vsSettings.getC8ApiVersion(),
-    );
+    const c8Client = new Camunda8RestClient(httpClient, authResolver, vsSettings.getC8ApiVersion());
     const restClient = new CamundaEngineRouter(c7Client, c8Client);
     const panelStateRepo = new PropertiesPanelStateRepository(context);
 
@@ -104,18 +100,10 @@ export function activate(context: ExtensionContext): void {
         artifactSvc,
     );
     const referencedModelLocator = new ReferencedModelLocator(vsWorkspace, vsUI);
-    const modelNavigationService = new ModelNavigationService(
-        referencedModelLocator,
-        vsUI,
-    );
+    const modelNavigationService = new ModelNavigationService(referencedModelLocator, vsUI);
 
     // 4. Controllers
-    const commandController = new CommandController(
-        editorStore,
-        vsDocument,
-        vsUI,
-        bpmnService,
-    );
+    const commandController = new CommandController(editorStore, vsDocument, vsUI, bpmnService);
     new BpmnEditorController(
         editorStore,
         bpmnService,

--- a/apps/modeler-plugin/src/service/ArtifactService.ts
+++ b/apps/modeler-plugin/src/service/ArtifactService.ts
@@ -92,12 +92,7 @@ export class ArtifactService {
         workspaceRoot: string,
         configFolder: string,
     ): Promise<string[]> {
-        return this.collectSubDirs(
-            documentDir,
-            workspaceRoot,
-            configFolder,
-            "element-templates",
-        );
+        return this.collectSubDirs(documentDir, workspaceRoot, configFolder, "element-templates");
     }
 
     /**
@@ -232,10 +227,7 @@ export class ArtifactService {
      * @param target Service that exposes `setElementTemplates`.
      * @returns Disposables for created watchers and any errors that occurred.
      */
-    async createWatcher(
-        editorId: string,
-        target: ArtifactChangeTarget,
-    ): Promise<WatcherResult> {
+    async createWatcher(editorId: string, target: ArtifactChangeTarget): Promise<WatcherResult> {
         const documentDir = posix.dirname(editorId);
         const configFolder = this.vsSettings.getConfigFolder();
         const workspaceRoot = await this.getWorkspaceRoot(documentDir);
@@ -275,9 +267,7 @@ export class ArtifactService {
         const files: string[] = [];
         for (const [name, type] of entries) {
             if (type === "directory") {
-                files.push(
-                    ...(await this.readDirectory(`${folder}/${name}`, extension)),
-                );
+                files.push(...(await this.readDirectory(`${folder}/${name}`, extension)));
             } else if (type === "file" && name.endsWith(extension)) {
                 files.push(`${folder}/${name}`);
             }

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -194,9 +194,7 @@ export class BpmnDiffService {
             });
         } catch (error) {
             this.vsUI.logError(error as Error);
-            this.vsUI.showError(
-                `Failed to open compare view: ${(error as Error).message}`,
-            );
+            this.vsUI.showError(`Failed to open compare view: ${(error as Error).message}`);
         }
     }
 
@@ -312,9 +310,7 @@ export class BpmnDiffService {
             ready: false,
         };
 
-        panel.webview.onDidReceiveMessage((message: Command) =>
-            this.onMessage(entry, message),
-        );
+        panel.webview.onDidReceiveMessage((message: Command) => this.onMessage(entry, message));
         panel.onDidDispose(() => this.disposePane(entry));
 
         const session = this.findSessionFor(document.uri);
@@ -436,10 +432,7 @@ export class BpmnDiffService {
                 await this.markReady(entry);
                 break;
             case "ViewportChangedCommand":
-                await this.forwardViewport(
-                    entry,
-                    (message as ViewportChangedCommand).viewport,
-                );
+                await this.forwardViewport(entry, (message as ViewportChangedCommand).viewport);
                 break;
             case "CursorChangedCommand":
                 await this.forwardCursor(entry, (message as CursorChangedCommand).index);
@@ -491,9 +484,7 @@ export class BpmnDiffService {
             } catch {
                 engine = "c7";
             }
-            await entry.panel.webview.postMessage(
-                new BpmnFileQuery(content, engine, "viewer"),
-            );
+            await entry.panel.webview.postMessage(new BpmnFileQuery(content, engine, "viewer"));
         } catch (error) {
             this.vsUI.logError(error as Error);
         }
@@ -522,9 +513,7 @@ export class BpmnDiffService {
      */
     private async sendLanguage(entry: DiffPaneEntry): Promise<void> {
         try {
-            await entry.panel.webview.postMessage(
-                new LanguageQuery(this.vsSettings.getLanguage()),
-            );
+            await entry.panel.webview.postMessage(new LanguageQuery(this.vsSettings.getLanguage()));
         } catch (error) {
             this.vsUI.logInfo(`setLanguage dropped: ${(error as Error).message}`);
         }
@@ -656,11 +645,7 @@ export class BpmnDiffService {
         // before canvas; anchor each one next to a surviving neighbour in the
         // after order so it appears near where it used to be in the flow.
         const afterOrder = buildFlowOrder(afterDefs as never);
-        const removedAnchors = buildRemovedAnchors(
-            removed,
-            beforeDefs as never,
-            afterOrder,
-        );
+        const removedAnchors = buildRemovedAnchors(removed, beforeDefs as never, afterOrder);
         const sortedAdded = sortIdsByOrder(added, afterOrder);
         const sortedRemoved = sortIdsByOrder(removed, removedAnchors);
         const sortedChanged = sortIdsByOrder(changed, afterOrder);
@@ -721,9 +706,7 @@ export class BpmnDiffService {
         try {
             await panel.webview.postMessage(query);
         } catch (error) {
-            this.vsUI.logInfo(
-                `ApplyDiffHighlights dropped: ${(error as Error).message}`,
-            );
+            this.vsUI.logInfo(`ApplyDiffHighlights dropped: ${(error as Error).message}`);
         }
     }
 }

--- a/apps/modeler-plugin/src/service/BpmnModelerService.ts
+++ b/apps/modeler-plugin/src/service/BpmnModelerService.ts
@@ -141,10 +141,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
 
                 return sent;
             } catch (error) {
-                if (
-                    error instanceof Error &&
-                    error.message === "The active editor is hidden."
-                ) {
+                if (error instanceof Error && error.message === "The active editor is hidden.") {
                     return false;
                 } else if (error instanceof ExecutionPlatformNotDetectedError) {
                     const ep = await this.vsUI.pickExecutionPlatform(
@@ -248,12 +245,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
                     String(a.name ?? "").localeCompare(String(b.name ?? "")),
                 );
 
-            if (
-                await this.editorStore.postMessage(
-                    editorId,
-                    new ElementTemplatesQuery(sorted),
-                )
-            ) {
+            if (await this.editorStore.postMessage(editorId, new ElementTemplatesQuery(sorted))) {
                 this.statusBar.showElementTemplatesReady(sorted.length);
                 if (artifacts.length > 0) {
                     this.vsUI.logInfo(`${artifacts.length} element templates are set.`);
@@ -261,9 +253,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
                 return true;
             } else {
                 this.statusBar.hideElementTemplatesStatus();
-                return this.handleError(
-                    new Error("Setting the `elementTemplates` failed."),
-                );
+                return this.handleError(new Error("Setting the `elementTemplates` failed."));
             }
         } catch (error) {
             this.statusBar.hideElementTemplatesStatus();
@@ -283,9 +273,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
         try {
             const settings = new SettingBuilder()
                 .alignToOrigin(this.vsSettings.getAlignToOrigin())
-                .showTransactionBoundaries(
-                    this.vsSettings.getShowTransactionBoundaries(),
-                )
+                .showTransactionBoundaries(this.vsSettings.getShowTransactionBoundaries())
                 .colorTheme(this.vsSettings.getColorTheme())
                 .favouriteBpmnElements(this.vsSettings.getFavouriteBpmnElements())
                 .buildBpmnModeler();
@@ -376,10 +364,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
     async readClipboard(editorId: string): Promise<boolean> {
         try {
             const text = await this.vsUI.readClipboard();
-            return await this.editorStore.postMessage(
-                editorId,
-                new ClipboardQuery(text),
-            );
+            return await this.editorStore.postMessage(editorId, new ClipboardQuery(text));
         } catch (error) {
             this.vsUI.logError(error as Error);
             return false;
@@ -396,10 +381,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
     async readTextClipboard(editorId: string): Promise<boolean> {
         try {
             const text = await this.vsUI.readClipboard();
-            return await this.editorStore.postMessage(
-                editorId,
-                new TextClipboardQuery(text),
-            );
+            return await this.editorStore.postMessage(editorId, new TextClipboardQuery(text));
         } catch (error) {
             this.vsUI.logError(error as Error);
             return false;
@@ -433,13 +415,9 @@ export class BpmnModelerService implements ArtifactChangeTarget {
      */
     setLanguage(editorId: string): void {
         const locale = this.vsSettings.getLanguage();
-        this.editorStore
-            .postMessage(editorId, new LanguageQuery(locale))
-            .catch((error) => {
-                this.vsUI.logError(
-                    error instanceof Error ? error : new Error(String(error)),
-                );
-            });
+        this.editorStore.postMessage(editorId, new LanguageQuery(locale)).catch((error) => {
+            this.vsUI.logError(error instanceof Error ? error : new Error(String(error)));
+        });
     }
 
     // ─── Change engine version ─────────────────────────────────────────────
@@ -533,28 +511,16 @@ export class BpmnModelerService implements ArtifactChangeTarget {
             const summaryParts: string[] = [];
 
             if (c7Version) {
-                const c7Updated = await this.applyVersionUpdate(
-                    plan.c7Files,
-                    c7Version,
-                    "c7",
-                );
+                const c7Updated = await this.applyVersionUpdate(plan.c7Files, c7Version, "c7");
                 if (c7Updated > 0) {
-                    summaryParts.push(
-                        `${c7Updated} diagram(s) to Camunda 7 (${c7Version})`,
-                    );
+                    summaryParts.push(`${c7Updated} diagram(s) to Camunda 7 (${c7Version})`);
                 }
             }
 
             if (c8Version) {
-                const c8Updated = await this.applyVersionUpdate(
-                    plan.c8Files,
-                    c8Version,
-                    "c8",
-                );
+                const c8Updated = await this.applyVersionUpdate(plan.c8Files, c8Version, "c8");
                 if (c8Updated > 0) {
-                    summaryParts.push(
-                        `${c8Updated} diagram(s) to Camunda 8 (${c8Version})`,
-                    );
+                    summaryParts.push(`${c8Updated} diagram(s) to Camunda 8 (${c8Version})`);
                 }
             }
 
@@ -633,8 +599,7 @@ export class BpmnModelerService implements ArtifactChangeTarget {
             let updatedContent: string;
             if (file.version === undefined) {
                 // File has namespace but no version attribute — inject it.
-                const platformName =
-                    platform === "c7" ? "Camunda Platform" : "Camunda Cloud";
+                const platformName = platform === "c7" ? "Camunda Platform" : "Camunda Cloud";
                 const schema =
                     platform === "c7"
                         ? `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`
@@ -645,14 +610,9 @@ export class BpmnModelerService implements ArtifactChangeTarget {
                     targetVersion,
                     schema,
                 );
-                this.vsUI.logWarning(
-                    `Added missing executionPlatform attribute to: ${file.path}`,
-                );
+                this.vsUI.logWarning(`Added missing executionPlatform attribute to: ${file.path}`);
             } else {
-                updatedContent = updateExecutionPlatformVersion(
-                    file.content,
-                    targetVersion,
-                );
+                updatedContent = updateExecutionPlatformVersion(file.content, targetVersion);
             }
 
             const editorId = this.editorStore.findEditorIdByPath(file.path);

--- a/apps/modeler-plugin/src/service/DeploymentService.ts
+++ b/apps/modeler-plugin/src/service/DeploymentService.ts
@@ -70,9 +70,7 @@ export class DeploymentService {
         return {
             deploymentName,
             tenantId: this.deploymentState.getTenantId(),
-            endpoint:
-                this.deploymentState.getEndpoint() ||
-                "http://localhost:8080/engine-rest",
+            endpoint: this.deploymentState.getEndpoint() || "http://localhost:8080/engine-rest",
             engine,
             authType: this.deploymentState.getAuthType(),
             tokenEndpoint: this.deploymentState.getTokenEndpoint(),
@@ -220,9 +218,7 @@ export class DeploymentService {
      * @returns Map of filename (basename) to UTF-8 string content.
      * @throws {FileNotFound} If any referenced file cannot be read.
      */
-    private async readFileContents(
-        config: DeploymentConfig,
-    ): Promise<Map<string, string>> {
+    private async readFileContents(config: DeploymentConfig): Promise<Map<string, string>> {
         const contents = new Map<string, string>();
 
         // Read the main BPMN file.

--- a/apps/modeler-plugin/src/service/DmnModelerService.ts
+++ b/apps/modeler-plugin/src/service/DmnModelerService.ts
@@ -76,18 +76,12 @@ export class DmnModelerService {
                 await this.vsDocument.save(editorId);
             }
 
-            return await this.editorStore.postMessage(
-                editorId,
-                new DmnFileQuery(dmnFile),
-            );
+            return await this.editorStore.postMessage(editorId, new DmnFileQuery(dmnFile));
         } catch (error) {
             if (error instanceof UserCancelledError) {
                 return false;
             }
-            if (
-                error instanceof Error &&
-                error.message === "The active editor is hidden."
-            ) {
+            if (error instanceof Error && error.message === "The active editor is hidden.") {
                 return false;
             }
             return this.handleError(error as Error);

--- a/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
@@ -62,11 +62,7 @@ describe("ModelNavigationService.navigate", () => {
 
         await service.navigate("Id", "process", documentUri);
 
-        expect(locator.findDeclaringFiles).toHaveBeenCalledWith(
-            "Id",
-            "process",
-            documentUri,
-        );
+        expect(locator.findDeclaringFiles).toHaveBeenCalledWith("Id", "process", documentUri);
     });
 
     it("opens the file directly via vscode.open when the locator returns a single match", async () => {
@@ -133,9 +129,7 @@ describe("ModelNavigationService.navigate", () => {
 
         await service.navigate("ProcessB", "process");
 
-        expect(vsUI.showInfo).toHaveBeenCalledWith(
-            expect.stringContaining("Open a folder"),
-        );
+        expect(vsUI.showInfo).toHaveBeenCalledWith(expect.stringContaining("Open a folder"));
         expect(commands.executeCommand).not.toHaveBeenCalled();
     });
 
@@ -177,15 +171,11 @@ describe("ModelNavigationService.navigate", () => {
             paths: ["/a.bpmn"],
             readFailures: [],
         });
-        vi.mocked(commands.executeCommand).mockRejectedValueOnce(
-            new Error("File not found"),
-        );
+        vi.mocked(commands.executeCommand).mockRejectedValueOnce(new Error("File not found"));
 
         await service.navigate("ProcessB", "process");
 
-        expect(vsUI.showError).toHaveBeenCalledWith(
-            expect.stringContaining("File not found"),
-        );
+        expect(vsUI.showError).toHaveBeenCalledWith(expect.stringContaining("File not found"));
         expect(vsUI.logError).toHaveBeenCalled();
     });
 

--- a/apps/modeler-plugin/src/service/ModelNavigationService.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.ts
@@ -36,10 +36,7 @@ export class ModelNavigationService {
         const result = await window.withProgress(
             {
                 location: ProgressLocation.Window,
-                title: `Searching for ${kind} "${truncate(
-                    referenceId,
-                    PROGRESS_LABEL_LIMIT,
-                )}"…`,
+                title: `Searching for ${kind} "${truncate(referenceId, PROGRESS_LABEL_LIMIT)}"…`,
             },
             () => this.locator.findDeclaringFiles(referenceId, kind, sourceDocumentUri),
         );

--- a/apps/modeler-plugin/src/service/StartInstanceService.ts
+++ b/apps/modeler-plugin/src/service/StartInstanceService.ts
@@ -55,9 +55,7 @@ export class StartInstanceService {
      * @returns An object with `filePath` and `label`, or `null` if the user cancels
      *   or no payload files are found.
      */
-    async selectPayloadFile(
-        editorId: string,
-    ): Promise<{ filePath: string; label: string } | null> {
+    async selectPayloadFile(editorId: string): Promise<{ filePath: string; label: string } | null> {
         const filePath = this.vsDocument.getFilePath(editorId);
         const documentDir = posix.dirname(filePath);
 

--- a/apps/modeler-plugin/src/service/bpmnUtils.ts
+++ b/apps/modeler-plugin/src/service/bpmnUtils.ts
@@ -39,9 +39,7 @@ export function addExecutionPlatform(
         // before appending the new attributes.
         const definition = match[0].split(" ");
         if (definition[definition.length - 1].endsWith(">")) {
-            definition[definition.length - 1] = definition[
-                definition.length - 1
-            ].replace(">", "");
+            definition[definition.length - 1] = definition[definition.length - 1].replace(">", "");
             definition.push(insert);
         }
         return bpmnFile.replace(regex, `${definition.join(" ")}`);
@@ -73,9 +71,7 @@ export function detectExecutionPlatform(bpmnFile: string): "c7" | "c8" {
             case "8":
                 return "c8";
             default:
-                throw new Error(
-                    `The execution platform version ${match[1]} is not supported.`,
-                );
+                throw new Error(`The execution platform version ${match[1]} is not supported.`);
         }
     }
 
@@ -103,9 +99,7 @@ export function extractProcessId(bpmnFile: string): string {
         return match[1];
     }
 
-    throw new Error(
-        "No <bpmn:process> element with an id attribute found in the BPMN file.",
-    );
+    throw new Error("No <bpmn:process> element with an id attribute found in the BPMN file.");
 }
 
 /**
@@ -175,10 +169,7 @@ export function detectExecutionPlatformVersion(bpmnFile: string): string | undef
  * @param newVersion The new version string to set (e.g. `"8.7.0"`).
  * @returns A new BPMN XML string with the updated version.
  */
-export function updateExecutionPlatformVersion(
-    bpmnFile: string,
-    newVersion: string,
-): string {
+export function updateExecutionPlatformVersion(bpmnFile: string, newVersion: string): string {
     return bpmnFile.replace(
         /modeler:executionPlatformVersion="\d+\.\d+\.\d+"/,
         `modeler:executionPlatformVersion="${newVersion}"`,

--- a/apps/modeler-plugin/src/service/bpmnUtils.ts
+++ b/apps/modeler-plugin/src/service/bpmnUtils.ts
@@ -39,7 +39,7 @@ export function addExecutionPlatform(
         // before appending the new attributes.
         const definition = match[0].split(" ");
         if (definition[definition.length - 1].endsWith(">")) {
-            definition[definition.length - 1] = definition[definition.length - 1].replace(">", "");
+            definition[definition.length - 1] = definition[definition.length - 1].slice(0, -1);
             definition.push(insert);
         }
         return bpmnFile.replace(regex, `${definition.join(" ")}`);

--- a/apps/modeler-plugin/src/service/migrateAllDiagrams.spec.ts
+++ b/apps/modeler-plugin/src/service/migrateAllDiagrams.spec.ts
@@ -124,9 +124,7 @@ describe("migrateAllDiagrams", () => {
         const result = await service.migrateAllDiagrams();
 
         expect(result).toBe(false);
-        expect(vsUI.showInfo).toHaveBeenCalledWith(
-            "No BPMN files found in the workspace.",
-        );
+        expect(vsUI.showInfo).toHaveBeenCalledWith("No BPMN files found in the workspace.");
     });
 
     it("should show info and return false when no engine is detectable", async () => {
@@ -200,9 +198,7 @@ describe("migrateAllDiagrams", () => {
             .mockResolvedValueOnce(c7Bpmn("7.20.0"))
             .mockResolvedValueOnce(c8Bpmn("8.5.0"));
         vsUI.pickMigrationScope.mockResolvedValue("both");
-        vsUI.pickEngineVersion
-            .mockResolvedValueOnce("7.24.0")
-            .mockResolvedValueOnce("8.8.0");
+        vsUI.pickEngineVersion.mockResolvedValueOnce("7.24.0").mockResolvedValueOnce("8.8.0");
 
         const result = await service.migrateAllDiagrams();
 
@@ -230,9 +226,7 @@ describe("migrateAllDiagrams", () => {
         await service.migrateAllDiagrams();
 
         expect(vsWorkspace.writeFile).toHaveBeenCalledTimes(1);
-        expect(vsUI.showInfo).toHaveBeenCalledWith(
-            expect.stringContaining("1 diagram(s)"),
-        );
+        expect(vsUI.showInfo).toHaveBeenCalledWith(expect.stringContaining("1 diagram(s)"));
     });
 
     it("should show 'already at version' when all files match target", async () => {
@@ -258,10 +252,7 @@ describe("migrateAllDiagrams", () => {
 
         await service.migrateAllDiagrams();
 
-        expect(vsDocument.write).toHaveBeenCalledWith(
-            "editor-1",
-            expect.stringContaining("8.8.0"),
-        );
+        expect(vsDocument.write).toHaveBeenCalledWith("editor-1", expect.stringContaining("8.8.0"));
         expect(vsWorkspace.writeFile).not.toHaveBeenCalled();
     });
 
@@ -303,8 +294,6 @@ describe("migrateAllDiagrams", () => {
 
         await service.migrateAllDiagrams();
 
-        expect(vsUI.logWarning).toHaveBeenCalledWith(
-            expect.stringContaining("Skipped 1 file(s)"),
-        );
+        expect(vsUI.logWarning).toHaveBeenCalledWith(expect.stringContaining("Skipped 1 file(s)"));
     });
 });

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
@@ -59,9 +59,7 @@ function createLocator(opts: { fileContents: Record<string, string>; tree?: DirT
             const entries = tree[dir];
             if (!entries) return Promise.reject(new Error("ENOENT"));
             return Promise.resolve(
-                entries.map((e) =>
-                    typeof e === "string" ? [e, "file"] : [e.name, e.type],
-                ),
+                entries.map((e) => (typeof e === "string" ? [e, "file"] : [e.name, e.type])),
             );
         }),
         readFile: vi.fn().mockImplementation((path: string) => {
@@ -178,9 +176,7 @@ describe("findDeclaringFiles — workspace folder open (findFiles path)", () => 
                 "/good.bpmn": bpmnWithProcess("ProcessB"),
             },
         });
-        vsWorkspace.readFile.mockImplementationOnce(() =>
-            Promise.reject(new Error("EACCES")),
-        );
+        vsWorkspace.readFile.mockImplementationOnce(() => Promise.reject(new Error("EACCES")));
 
         const result = await locator.findDeclaringFiles("ProcessB", "process");
 
@@ -248,11 +244,7 @@ describe("findDeclaringFiles — walk-fallback (ripgrep silently failed)", () =>
             fsPath: "/work/parent.bpmn",
         } as never;
 
-        const result = await locator.findDeclaringFiles(
-            "ChildProcess",
-            "process",
-            documentUri,
-        );
+        const result = await locator.findDeclaringFiles("ChildProcess", "process", documentUri);
 
         expect(vsWorkspace.findFiles).toHaveBeenCalledTimes(1);
         expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");
@@ -264,9 +256,7 @@ describe("findDeclaringFiles — walk-fallback (ripgrep silently failed)", () =>
     });
 
     it("recurses into subdirectories", async () => {
-        workspaceState.folders = [
-            { uri: { scheme: "file", path: "/work", fsPath: "/work" } },
-        ];
+        workspaceState.folders = [{ uri: { scheme: "file", path: "/work", fsPath: "/work" } }];
         const { locator, vsWorkspace } = createLocator({
             fileContents: { "/work/sub/child.bpmn": bpmnWithProcess("Nested") },
             tree: {
@@ -285,9 +275,7 @@ describe("findDeclaringFiles — walk-fallback (ripgrep silently failed)", () =>
     });
 
     it("skips baseline-excluded directories (node_modules, dist, .git, …)", async () => {
-        workspaceState.folders = [
-            { uri: { scheme: "file", path: "/work", fsPath: "/work" } },
-        ];
+        workspaceState.folders = [{ uri: { scheme: "file", path: "/work", fsPath: "/work" } }];
         const { locator, vsWorkspace } = createLocator({
             fileContents: {
                 "/work/wanted.bpmn": bpmnWithProcess("Wanted"),
@@ -310,9 +298,7 @@ describe("findDeclaringFiles — walk-fallback (ripgrep silently failed)", () =>
     });
 
     it("tolerates unreadable subdirectories", async () => {
-        workspaceState.folders = [
-            { uri: { scheme: "file", path: "/work", fsPath: "/work" } },
-        ];
+        workspaceState.folders = [{ uri: { scheme: "file", path: "/work", fsPath: "/work" } }];
         const { locator, vsWorkspace } = createLocator({
             fileContents: { "/work/ok.bpmn": bpmnWithProcess("Wanted") },
             tree: {
@@ -349,11 +335,7 @@ describe("findDeclaringFiles — loose file (no workspace folder)", () => {
             fsPath: "/work/parent.bpmn",
         } as never;
 
-        const result = await locator.findDeclaringFiles(
-            "ChildProcess",
-            "process",
-            documentUri,
-        );
+        const result = await locator.findDeclaringFiles("ChildProcess", "process", documentUri);
 
         expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
         expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
@@ -138,18 +138,9 @@ export class ReferencedModelLocator {
                         .readDirectory(dir)
                         .then(
                             (entries) =>
-                                [dir, entries] as [
-                                    string,
-                                    Array<[string, "file" | "directory"]>,
-                                ],
+                                [dir, entries] as [string, Array<[string, "file" | "directory"]>],
                         )
-                        .catch(
-                            () =>
-                                [dir, []] as [
-                                    string,
-                                    Array<[string, "file" | "directory"]>,
-                                ],
-                        ),
+                        .catch(() => [dir, []] as [string, Array<[string, "file" | "directory"]>]),
                 ),
             );
             const nextLevel: string[] = [];

--- a/apps/modeler-plugin/vitest.config.ts
+++ b/apps/modeler-plugin/vitest.config.ts
@@ -7,10 +7,7 @@ export default defineConfig({
         environment: "node",
         include: ["src/**/*.{spec,test}.ts"],
         alias: {
-            "@miragon/bpmn-modeler-shared": resolve(
-                __dirname,
-                "../../libs/shared/src/index.ts",
-            ),
+            "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
         },
         coverage: {
             provider: "v8",

--- a/apps/modeler-plugin/webpack.config.js
+++ b/apps/modeler-plugin/webpack.config.js
@@ -86,10 +86,7 @@ module.exports = (env, argv) => {
                         // Single source of truth: themes live in the standalone
                         // extension. `vsce package --no-dependencies` strips
                         // node_modules, so the JSON must be present in dist.
-                        from: path.resolve(
-                            __dirname,
-                            "../../libs/standalone-extension/src/themes",
-                        ),
+                        from: path.resolve(__dirname, "../../libs/standalone-extension/src/themes"),
                         to: "themes",
                     },
                     {
@@ -110,20 +107,14 @@ module.exports = (env, argv) => {
                         // info.minimized prevents TerserPlugin from re-minimizing the
                         // already-minified Vite output, which would mangle variable names
                         // and break preact/htm tagged templates at runtime.
-                        from: path.resolve(
-                            __dirname,
-                            "../../dist/webview-staging/bpmn-webview",
-                        ),
+                        from: path.resolve(__dirname, "../../dist/webview-staging/bpmn-webview"),
                         to: "bpmn-webview",
                         noErrorOnMissing: true,
                         info: { minimized: true },
                     },
                     {
                         // Copy the DMN webview build artefacts into the extension output.
-                        from: path.resolve(
-                            __dirname,
-                            "../../dist/webview-staging/dmn-webview",
-                        ),
+                        from: path.resolve(__dirname, "../../dist/webview-staging/dmn-webview"),
                         to: "dmn-webview",
                         noErrorOnMissing: true,
                         info: { minimized: true },

--- a/apps/standalone/scripts/bundle-extension.mjs
+++ b/apps/standalone/scripts/bundle-extension.mjs
@@ -21,13 +21,7 @@ const yauzl = require("yauzl");
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const standaloneDir = resolve(__dirname, "..");
 const repoRoot = resolve(standaloneDir, "..", "..");
-const vsixSrc = resolve(
-    repoRoot,
-    "dist",
-    "apps",
-    "modeler-plugin",
-    "bpmn-modeler-plugin.vsix",
-);
+const vsixSrc = resolve(repoRoot, "dist", "apps", "modeler-plugin", "bpmn-modeler-plugin.vsix");
 const pluginsDir = resolve(standaloneDir, "plugins");
 const pluginName = "bpmn-modeler-plugin";
 const unpackedDir = resolve(pluginsDir, pluginName);

--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -63,12 +63,7 @@ class AppendMenuOverride {
         };
 
         // --- Override popupMenu.open ---
-        popupMenu.open = (
-            target: any,
-            providerId: string,
-            position: any,
-            options?: any,
-        ) => {
+        popupMenu.open = (target: any, providerId: string, position: any, options?: any) => {
             if (!INTERCEPTED_PROVIDERS.has(providerId)) {
                 return originalOpen(target, providerId, position, options);
             }
@@ -161,14 +156,11 @@ class AppendMenuOverride {
         };
 
         // --- Auto-close on diagram events ---
-        eventBus.on(
-            ["contextPad.close", "canvas.viewbox.changing", "commandStack.changed"],
-            () => {
-                if (customMenuOpen) {
-                    destroyCustomMenu();
-                }
-            },
-        );
+        eventBus.on(["contextPad.close", "canvas.viewbox.changing", "commandStack.changed"], () => {
+            if (customMenuOpen) {
+                destroyCustomMenu();
+            }
+        });
     }
 }
 

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -6,11 +6,7 @@
  * a collapsible BPMN element palette on the right.
  */
 import { useState, useEffect, useCallback, useMemo, useRef } from "preact/hooks";
-import type {
-    EnrichedTemplateEntry,
-    BpmnElementGroup,
-    PopupMenuEntryAction,
-} from "../types";
+import type { EnrichedTemplateEntry, BpmnElementGroup, PopupMenuEntryAction } from "../types";
 import { TemplatePanel } from "./TemplatePanel";
 import { BpmnElementPalette } from "./BpmnElementPalette";
 
@@ -83,17 +79,14 @@ export function AppendMenuOverlay({
 
     const [search, setSearch] = useState("");
     const [activeCategory, setActiveCategory] = useState<string | null>(null);
-    const [selectedTemplate, setSelectedTemplate] =
-        useState<EnrichedTemplateEntry | null>(null);
+    const [selectedTemplate, setSelectedTemplate] = useState<EnrichedTemplateEntry | null>(null);
     // When the workspace has no element templates, default to the expanded
     // palette so users see the full BPMN element list instead of an awkward
     // icon-only column next to an empty template panel.
     const [paletteExpanded, setPaletteExpanded] = useState(!hasTemplates);
     const searchRef = useRef<HTMLInputElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
-    const [panelStyle, setPanelStyle] = useState<{ left: number; top: number } | null>(
-        null,
-    );
+    const [panelStyle, setPanelStyle] = useState<{ left: number; top: number } | null>(null);
 
     // The set of BPMN types the selected multi-type template applies to.
     const appliesToFilter = useMemo<Set<string> | null>(() => {

--- a/libs/append-menu/src/components/BpmnElementPalette.tsx
+++ b/libs/append-menu/src/components/BpmnElementPalette.tsx
@@ -61,9 +61,7 @@ function entryMatchesFilter(entry: BpmnElementEntry, filter: Set<string>): boole
  * @returns `true` if the entry label or description matches.
  */
 function entryMatchesSearch(entry: BpmnElementEntry, query: string): boolean {
-    const haystack = [entry.entry.label, entry.entry.description ?? ""]
-        .join(" ")
-        .toLowerCase();
+    const haystack = [entry.entry.label, entry.entry.description ?? ""].join(" ").toLowerCase();
     return haystack.includes(query);
 }
 
@@ -98,9 +96,7 @@ export function BpmnElementPalette({
             ...group,
             entries: group.entries.map((entry) => ({
                 ...entry,
-                disabled: appliesToFilter
-                    ? !entryMatchesFilter(entry, appliesToFilter)
-                    : false,
+                disabled: appliesToFilter ? !entryMatchesFilter(entry, appliesToFilter) : false,
                 hidden: query ? !entryMatchesSearch(entry, query) : false,
             })),
         }));
@@ -117,9 +113,7 @@ export function BpmnElementPalette({
             .map((type) => {
                 const shortName = type.split(":")[1]?.toLowerCase() ?? "";
                 return allEntries.find((e) => {
-                    const normalizedLabel = e.entry.label
-                        .toLowerCase()
-                        .replace(/[\s-]/g, "");
+                    const normalizedLabel = e.entry.label.toLowerCase().replace(/[\s-]/g, "");
                     if (normalizedLabel === shortName) return true;
                     const normalizedId = e.id.toLowerCase().replace(/[\s-]/g, "");
                     return normalizedId.includes(shortName);
@@ -152,9 +146,7 @@ export function BpmnElementPalette({
                 {favouriteEntries.length > 0 && (
                     <div class="am-bpmn-group am-bpmn-group--favourites">
                         {expanded && <h4 class="am-bpmn-group-title">Favourites</h4>}
-                        <div
-                            class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}
-                        >
+                        <div class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}>
                             {favouriteEntries.map(({ id, entry, disabled, hidden }) => {
                                 if (hidden) return null;
                                 const isDisabled = disabled || !!entry.disabled;
@@ -170,14 +162,10 @@ export function BpmnElementPalette({
                                         type="button"
                                     >
                                         {entry.className && (
-                                            <span
-                                                class={`am-bpmn-icon ${entry.className}`}
-                                            />
+                                            <span class={`am-bpmn-icon ${entry.className}`} />
                                         )}
                                         {expanded && (
-                                            <span class="am-bpmn-label">
-                                                {entry.label}
-                                            </span>
+                                            <span class="am-bpmn-label">{entry.label}</span>
                                         )}
                                     </button>
                                 );
@@ -194,12 +182,8 @@ export function BpmnElementPalette({
                     }
                     return (
                         <div key={group.id} class="am-bpmn-group">
-                            {expanded && (
-                                <h4 class="am-bpmn-group-title">{group.name}</h4>
-                            )}
-                            <div
-                                class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}
-                            >
+                            {expanded && <h4 class="am-bpmn-group-title">{group.name}</h4>}
+                            <div class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}>
                                 {visibleEntries.map(({ id, entry, disabled }) => {
                                     const isDisabled = disabled || !!entry.disabled;
                                     return (
@@ -208,23 +192,16 @@ export function BpmnElementPalette({
                                             class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
                                             disabled={isDisabled}
                                             onClick={(e) =>
-                                                onSelect(
-                                                    entry.action,
-                                                    e as unknown as Event,
-                                                )
+                                                onSelect(entry.action, e as unknown as Event)
                                             }
                                             title={entry.label}
                                             type="button"
                                         >
                                             {entry.className && (
-                                                <span
-                                                    class={`am-bpmn-icon ${entry.className}`}
-                                                />
+                                                <span class={`am-bpmn-icon ${entry.className}`} />
                                             )}
                                             {expanded && (
-                                                <span class="am-bpmn-label">
-                                                    {entry.label}
-                                                </span>
+                                                <span class="am-bpmn-label">{entry.label}</span>
                                             )}
                                         </button>
                                     );

--- a/libs/append-menu/src/components/ExpandableTemplateCard.tsx
+++ b/libs/append-menu/src/components/ExpandableTemplateCard.tsx
@@ -53,18 +53,14 @@ export function ExpandableTemplateCard({
         >
             <div class="am-card-header">
                 {appliesTo.length === 1 ? (
-                    <span
-                        class={`am-card-bpmn-icon ${bpmnTypeToIconClass(appliesTo[0])}`}
-                    />
+                    <span class={`am-card-bpmn-icon ${bpmnTypeToIconClass(appliesTo[0])}`} />
                 ) : (
                     <span class="am-card-bpmn-icon bpmn-icon-task" />
                 )}
                 <div class="am-card-text">
                     <span class="am-card-name">{entry.label}</span>
                     {template?.category && (
-                        <span class="am-badge am-badge--category">
-                            {template.category.name}
-                        </span>
+                        <span class="am-badge am-badge--category">{template.category.name}</span>
                     )}
                 </div>
                 {entry.imageUrl && (

--- a/libs/append-menu/src/components/TemplateHoverCard.tsx
+++ b/libs/append-menu/src/components/TemplateHoverCard.tsx
@@ -35,9 +35,7 @@ export function TemplateHoverCard({
 }: TemplateHoverCardProps) {
     const { entry, template } = enrichedEntry;
 
-    const implDetail = template
-        ? extractImplementationDetail(template.properties)
-        : undefined;
+    const implDetail = template ? extractImplementationDetail(template.properties) : undefined;
 
     const inputs =
         template?.properties.filter(
@@ -78,9 +76,7 @@ export function TemplateHoverCard({
 
                 {/* Description + metadata */}
                 <div class="am-hover-card-details">
-                    {entry.description && (
-                        <p class="am-hover-card-desc">{entry.description}</p>
-                    )}
+                    {entry.description && <p class="am-hover-card-desc">{entry.description}</p>}
                     {entry.documentationRef && (
                         <a
                             class="am-card-docs-link"
@@ -89,12 +85,7 @@ export function TemplateHoverCard({
                             rel="noopener noreferrer"
                             onClick={(e) => e.stopPropagation()}
                         >
-                            <svg
-                                width="12"
-                                height="12"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
+                            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                                 <path d="M4.715 6.542L3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.001 1.001 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z" />
                                 <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 0 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 0 0-4.243-4.243L6.586 4.672z" />
                             </svg>
@@ -113,20 +104,16 @@ export function TemplateHoverCard({
 
                 {/* Parameter sections */}
                 <div class="am-hover-card-params">
-                    {props.length > 0 && (
-                        <ParameterSection title="Properties" items={props} />
-                    )}
+                    {props.length > 0 && <ParameterSection title="Properties" items={props} />}
                     {inputs.length > 0 && (
                         <ParameterSection title="Input Parameters" items={inputs} />
                     )}
                     {outputs.length > 0 && (
                         <ParameterSection title="Output Parameters" items={outputs} />
                     )}
-                    {props.length === 0 &&
-                        inputs.length === 0 &&
-                        outputs.length === 0 && (
-                            <p class="am-hover-card-no-params">No visible parameters</p>
-                        )}
+                    {props.length === 0 && inputs.length === 0 && outputs.length === 0 && (
+                        <p class="am-hover-card-no-params">No visible parameters</p>
+                    )}
                 </div>
             </div>
         </div>
@@ -139,13 +126,7 @@ export function TemplateHoverCard({
  * @param props.title Section heading text.
  * @param props.items Property items to display.
  */
-function ParameterSection({
-    title,
-    items,
-}: {
-    title: string;
-    items: TemplateProperty[];
-}) {
+function ParameterSection({ title, items }: { title: string; items: TemplateProperty[] }) {
     return (
         <div class="am-hover-param-section">
             <h5 class="am-hover-param-title">{title}</h5>
@@ -158,25 +139,17 @@ function ParameterSection({
                             </span>
                             <div class="am-hover-param-badges">
                                 {p.constraints?.notEmpty && (
-                                    <span class="am-badge am-badge--required">
-                                        required
-                                    </span>
+                                    <span class="am-badge am-badge--required">required</span>
                                 )}
                                 {p.editable === false && (
-                                    <span class="am-badge am-badge--readonly">
-                                        read-only
-                                    </span>
+                                    <span class="am-badge am-badge--readonly">read-only</span>
                                 )}
                                 {p.optional && (
-                                    <span class="am-badge am-badge--optional">
-                                        optional
-                                    </span>
+                                    <span class="am-badge am-badge--optional">optional</span>
                                 )}
                             </div>
                         </div>
-                        {p.description && (
-                            <p class="am-hover-param-desc">{p.description}</p>
-                        )}
+                        {p.description && <p class="am-hover-param-desc">{p.description}</p>}
                         {p.value && <code class="am-hover-param-value">{p.value}</code>}
                     </li>
                 ))}

--- a/libs/append-menu/src/components/TemplatePanel.tsx
+++ b/libs/append-menu/src/components/TemplatePanel.tsx
@@ -127,11 +127,7 @@ export function TemplatePanel({
             } else if (e.key === "ArrowUp") {
                 e.preventDefault();
                 setFocusIndex((prev) => Math.max(prev - 1, 0));
-            } else if (
-                e.key === "Enter" &&
-                focusIndex >= 0 &&
-                focusIndex < filtered.length
-            ) {
+            } else if (e.key === "Enter" && focusIndex >= 0 && focusIndex < filtered.length) {
                 e.preventDefault();
                 const focused = filtered[focusIndex];
                 onTemplateClick(focused, e as unknown as Event);
@@ -158,10 +154,7 @@ export function TemplatePanel({
         if (hovered) {
             setHoveredIndex(index);
         } else {
-            hideTimeoutRef.current = window.setTimeout(
-                () => setHoveredIndex(-1),
-                HOVER_HIDE_DELAY,
-            );
+            hideTimeoutRef.current = window.setTimeout(() => setHoveredIndex(-1), HOVER_HIDE_DELAY);
         }
     }, []);
 
@@ -172,10 +165,7 @@ export function TemplatePanel({
 
     /** Starts the hide delay when the mouse leaves the hover card. */
     const handleHoverCardLeave = useCallback(() => {
-        hideTimeoutRef.current = window.setTimeout(
-            () => setHoveredIndex(-1),
-            HOVER_HIDE_DELAY,
-        );
+        hideTimeoutRef.current = window.setTimeout(() => setHoveredIndex(-1), HOVER_HIDE_DELAY);
     }, []);
 
     /**
@@ -224,9 +214,7 @@ export function TemplatePanel({
                             key={cat.id}
                             class={`am-chip ${activeCategory === cat.id ? "am-chip--active" : ""}`}
                             onClick={() =>
-                                onCategoryChange(
-                                    activeCategory === cat.id ? null : cat.id,
-                                )
+                                onCategoryChange(activeCategory === cat.id ? null : cat.id)
                             }
                             type="button"
                         >
@@ -241,9 +229,7 @@ export function TemplatePanel({
                 {filtered.length === 0 ? (
                     <div class="am-empty">
                         <p class="am-empty-text">No templates found</p>
-                        {search && (
-                            <p class="am-empty-hint">Try a different search term</p>
-                        )}
+                        {search && <p class="am-empty-hint">Try a different search term</p>}
                     </div>
                 ) : (
                     filtered.map((enriched, idx) => (

--- a/libs/append-menu/src/types.ts
+++ b/libs/append-menu/src/types.ts
@@ -295,11 +295,7 @@ export type BindingDirection = "input" | "output" | "property" | "hidden";
 export function classifyBinding(binding: TemplateProperty["binding"]): BindingDirection {
     const type = binding.type;
 
-    if (
-        type === "camunda:out" ||
-        type === "camunda:outputParameter" ||
-        type === "zeebe:output"
-    ) {
+    if (type === "camunda:out" || type === "camunda:outputParameter" || type === "zeebe:output") {
         return "output";
     }
 

--- a/libs/bpmn-clipboard/src/LabelClipboardModule.ts
+++ b/libs/bpmn-clipboard/src/LabelClipboardModule.ts
@@ -105,11 +105,7 @@ class LabelClipboard {
 
         eventBus.on("directEditing.deactivate", () => {
             if (this.activeElement && this.keydownHandler) {
-                this.activeElement.removeEventListener(
-                    "keydown",
-                    this.keydownHandler,
-                    true,
-                );
+                this.activeElement.removeEventListener("keydown", this.keydownHandler, true);
             }
             this.keydownHandler = null;
             this.activeElement = null;

--- a/libs/bpmn-i18n/src/TranslateModule.spec.ts
+++ b/libs/bpmn-i18n/src/TranslateModule.spec.ts
@@ -61,9 +61,7 @@ describe("CustomTranslator", () => {
 
         it("should fall back to the original template for untranslated keys", () => {
             translator.setLanguage("de");
-            const result = translator.translate(
-                "This key does not exist in any dictionary",
-            );
+            const result = translator.translate("This key does not exist in any dictionary");
             expect(result).toBe("This key does not exist in any dictionary");
         });
 

--- a/libs/bpmn-i18n/src/TranslateModule.ts
+++ b/libs/bpmn-i18n/src/TranslateModule.ts
@@ -43,11 +43,7 @@ export class CustomTranslator {
      * @returns The translated (or original) string with placeholders resolved.
      */
     translate(template: string, replacements?: Record<string, string>): string {
-        if (
-            this.locale !== "en" &&
-            !this.dictionary[template] &&
-            !missingKeys.has(template)
-        ) {
+        if (this.locale !== "en" && !this.dictionary[template] && !missingKeys.has(template)) {
             missingKeys.add(template);
             console.log(`Missing translation [${this.locale}]: ${template}`);
         }

--- a/libs/bpmn-i18n/src/languages/de/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/de/bpmn-js.ts
@@ -19,13 +19,11 @@
  */
 const translations: Record<string, string> = {
     "{semantic}#{side} Ref not specified": "{semantic}#{side} Ref nicht angegeben",
-    "Activate create/remove space tool":
-        "Werkzeug zum Erstellen/Entfernen von Platz aktivieren",
+    "Activate create/remove space tool": "Werkzeug zum Erstellen/Entfernen von Platz aktivieren",
     "Activate global connect tool": "Globales Verbindungswerkzeug aktivieren",
     "Activate hand tool": "Handwerkzeug aktivieren",
     "Activate lasso tool": "Lassowerkzeug aktivieren",
-    "Activate the create/remove space tool":
-        "Space-hinzufügen/entfernen-Tool aktivieren",
+    "Activate the create/remove space tool": "Space-hinzufügen/entfernen-Tool aktivieren",
     "Activate the global connect tool": "Globales Verbindungstool aktivieren",
     "Activate the hand tool": "Hand-Tool aktivieren",
     "Activate the lasso tool": "Lasso-Tool aktivieren",
@@ -41,16 +39,14 @@ const translations: Record<string, string> = {
     "Append compensation activity": "Kompensationsaktivität anfügen",
     "Append conditional intermediate catch event":
         "Bedingungs-Zwischenereignis (eintretend) anfügen",
-    "Append ConditionIntermediateCatchEvent":
-        "Bedingungs-Zwischenereignis (eintretend) anfügen",
+    "Append ConditionIntermediateCatchEvent": "Bedingungs-Zwischenereignis (eintretend) anfügen",
     "Append end event": "Endereignis anfügen",
     "Append EndEvent": "Endereignis anfügen",
     "Append gateway": "Gateway anfügen",
     "Append Gateway": "Gateway anfügen",
     "Append Intermediate/Boundary Event": "Zwischen-/Grenzereignis anfügen",
     "Append intermediate/boundary event": "Zwischen-/Grenzereignis anfügen",
-    "Append message intermediate catch event":
-        "Nachrichtenerignis (eingetreten) anfügen",
+    "Append message intermediate catch event": "Nachrichtenerignis (eingetreten) anfügen",
     "Append MessageIntermediateCatchEvent": "Nachrichtenerignis (eingetreten) anfügen",
     "Append receive task": "Empfangsaufgabe anfügen",
     "Append ReceiveTask": "Empfangsaufgabe anfügen",
@@ -69,8 +65,7 @@ const translations: Record<string, string> = {
     "Collection": "Sammlung",
     "Compensation boundary event": "Kompensations-Grenzereignis",
     "Compensation end event": "Kompensations-Endereignis",
-    "Compensation intermediate throw event":
-        "Kompensations-Zwischenereignis (auslösend)",
+    "Compensation intermediate throw event": "Kompensations-Zwischenereignis (auslösend)",
     "Compensation start event": "Kompensations-Startereignis",
     "Complex gateway": "Komplexes Gateway",
     "Conditional boundary event (non-interrupting)":
@@ -78,8 +73,7 @@ const translations: Record<string, string> = {
     "Conditional boundary event": "Bedingungserignis-Grenzereignis",
     "Conditional flow": "Bedingter Fluss",
     "Conditional intermediate catch event": "Bedingungs-Zwischenereignis (fangend)",
-    "Conditional start event (non-interrupting)":
-        "Bedingungs-Startereignis (nicht unterbrechend)",
+    "Conditional start event (non-interrupting)": "Bedingungs-Startereignis (nicht unterbrechend)",
     "Conditional start event": "Bedingungs-Startereignis",
     "Connect to other element": "Mit anderem Element verbinden",
     "Connect using association": "Mit Assoziation verbinden",
@@ -115,8 +109,7 @@ const translations: Record<string, string> = {
     "Data store reference": "Datenspeicher",
     "Default flow": "Standardfluss",
     "Delete": "Löschen",
-    "diagram not part of bpmn:Definitions":
-        "Das Diagramm ist nicht Teil von bpmn:Definitions",
+    "diagram not part of bpmn:Definitions": "Das Diagramm ist nicht Teil von bpmn:Definitions",
     "Distribute elements horizontally": "Elemente horizontal verteilen",
     "Distribute elements vertically": "Elemente vertikal verteilen",
     "Divide into three Lanes": "In drei Lanes aufteilen",
@@ -135,8 +128,7 @@ const translations: Record<string, string> = {
     "Escalation boundary event": "Eskalations-Grenzereignis",
     "Escalation end event": "Eskalations-Endereignis",
     "Escalation intermediate throw event": "Eskalations-Zwischenereignis (auslösend)",
-    "Escalation start event (non-interrupting)":
-        "Eskalations-Startereignis (nicht unterbrechend)",
+    "Escalation start event (non-interrupting)": "Eskalations-Startereignis (nicht unterbrechend)",
     "Escalation start event": "Eskalations-Startereignis",
     "Event based instantiating Gateway": "Ereignisbasiertes instanziierendes Gateway",
     "Event sub-process": "Ereignis-Teilprozess",
@@ -151,26 +143,20 @@ const translations: Record<string, string> = {
     "Link intermediate throw event": "Linkereignis (auslösend)",
     "Loop": "Schleife",
     "Manual task": "Manuelle Aufgabe",
-    "Message boundary event (non-interrupting)":
-        "Nachrichten-Grenzereignis (nicht-unterbrechend)",
+    "Message boundary event (non-interrupting)": "Nachrichten-Grenzereignis (nicht-unterbrechend)",
     "Message boundary event": "Nachrichten-Grenzereignis",
     "Message end event": "Nachrichten-Endereignis",
     "Message intermediate catch event": "Nachrichten-Zwischenereignis (empfangend)",
     "Message intermediate throw event": "Nachrichten-Zwischenereignis (auslösend)",
-    "Message start event (non-interrupting)":
-        "Nachrichtenstartereignis (nicht unterbrechend)",
+    "Message start event (non-interrupting)": "Nachrichtenstartereignis (nicht unterbrechend)",
     "Message start event": "Nachrichtenstartereignis",
     "missing {semantic}#attachedToRef": "{semantic}#attachedToRef fehlt",
     "more than {count} child lanes": "mehr als {count} Kind-Lanes",
-    "multiple DI elements defined for {element}":
-        "Mehrere DI-Elemente für {element} definiert",
-    "no bpmnElement referenced in {element}":
-        "Kein bpmnElement in {element} referenziert",
+    "multiple DI elements defined for {element}": "Mehrere DI-Elemente für {element} definiert",
+    "no bpmnElement referenced in {element}": "Kein bpmnElement in {element} referenziert",
     "no diagram to display": "Kein Diagramm zum Anzeigen",
-    "no parent for {element} in {parent}":
-        "Kein Elternelement für {element} in {parent}",
-    "no process or collaboration to display":
-        "Kein Prozess oder Kollaboration zum Anzeigen",
+    "no parent for {element} in {parent}": "Kein Elternelement für {element} in {parent}",
+    "no process or collaboration to display": "Kein Prozess oder Kollaboration zum Anzeigen",
     "no shape type specified": "Kein Formtyp angegeben",
     "out of bounds release": "Außerhalb der Grenzen losgelassen",
     "Parallel Event based instantiating Gateway":
@@ -187,14 +173,12 @@ const translations: Record<string, string> = {
     "Sequential Multi Instance": "Sequenzielle Mehrfachinstanz",
     "Sequential multi-instance": "Sequenzielle Mehrfachinstanz",
     "Service task": "Serviceaufgabe",
-    "Signal boundary event (non-interrupting)":
-        "Signal-Grenzereignis (nicht unterbrechend)",
+    "Signal boundary event (non-interrupting)": "Signal-Grenzereignis (nicht unterbrechend)",
     "Signal boundary event": "Signal-Grenzereignis",
     "Signal end event": "Signal-Endereignis",
     "Signal intermediate catch event": "Signal-Zwischenereignis (empfangend)",
     "Signal intermediate throw event": "Signal-Zwischenereignis (auslösend)",
-    "Signal start event (non-interrupting)":
-        "Signal-Startereignis (nicht unterbrechend)",
+    "Signal start event (non-interrupting)": "Signal-Startereignis (nicht unterbrechend)",
     "Signal start event": "Signal-Startereignis",
     "Start event": "Startereignis",
     "Sub-process (collapsed)": "Zugeklappter Teilprozess",
@@ -209,8 +193,7 @@ const translations: Record<string, string> = {
     "Timer start event": "Zeitstartereignis",
     "Toggle non-interrupting": "Auf nicht-unterbrechend umschalten",
     "Transaction": "Transaktion",
-    "unknown di {di} for element {semantic}":
-        "Unbekannter DI {di} für Element {semantic}",
+    "unknown di {di} for element {semantic}": "Unbekannter DI {di} für Element {semantic}",
     "unrecognized flowElement {element} in context {context}":
         "FlowElement {element} im Context {context} nicht erkannt",
     "unsupported bpmnElement for {plane}: {rootElement}":

--- a/libs/bpmn-i18n/src/languages/de/other.ts
+++ b/libs/bpmn-i18n/src/languages/de/other.ts
@@ -93,8 +93,7 @@ const translations: Record<string, string> = {
     "Deprecated": "Veraltet",
     "Description": "Beschreibung",
     "Edit String": "Zeichenkette bearbeiten",
-    "Empty pool/participant (removes content)":
-        "Leerer Pool/Teilnehmer (Inhalt wird entfernt)",
+    "Empty pool/participant (removes content)": "Leerer Pool/Teilnehmer (Inhalt wird entfernt)",
     "Empty pool/participant": "Leerer Pool/Teilnehmer (Inhalt wird entfernt)",
     "Empty": "Leer",
     "End Event": "Endereignis",
@@ -151,8 +150,7 @@ const translations: Record<string, string> = {
     "Literal Expression": "Literaler Ausdruck",
     "Local variable assignment": "Lokale Variablenzuweisung",
     "Manual Task": "Manuelle Aufgabe",
-    "Message Boundary Event (non-interrupting)":
-        "Nachrichtengrenzereignis (nicht unterbrechend)",
+    "Message Boundary Event (non-interrupting)": "Nachrichtengrenzereignis (nicht unterbrechend)",
     "Message Boundary Event": "Nachrichtengrenzereignis",
     "Message End Event": "Nachrichtenendereignis",
     "Message Intermediate Catch Event": "Nachrichten-Zwischenfangerereignis",
@@ -204,8 +202,7 @@ const translations: Record<string, string> = {
     "Repetition Rule": "Wiederholungsregel",
     "Required Rule": "Erforderliche Regel",
     "resultList": "Ergebnisliste",
-    "Rule is overwritten by item control":
-        "Regel wird durch Elementsteuerung überschrieben",
+    "Rule is overwritten by item control": "Regel wird durch Elementsteuerung überschrieben",
     "Rule order": "Regelreihenfolge",
     "Rule": "Regel",
     "Rules": "Regeln",
@@ -218,8 +215,7 @@ const translations: Record<string, string> = {
     "Service Task": "Serviceaufgabe",
     "Set Value": "Wert setzen",
     "Show Standard Event": "Standardereignis anzeigen",
-    "Signal Boundary Event (non-interrupting)":
-        "Signalgrenzereignis (nicht unterbrechend)",
+    "Signal Boundary Event (non-interrupting)": "Signalgrenzereignis (nicht unterbrechend)",
     "Signal Boundary Event": "Signalgrenzereignis",
     "Signal End Event": "Signalendereignis",
     "Signal Intermediate Catch Event": "Signalzwischenereignis (Empfangend)",

--- a/libs/bpmn-i18n/src/languages/de/properties-panel.ts
+++ b/libs/bpmn-i18n/src/languages/de/properties-panel.ts
@@ -128,8 +128,7 @@ const translations: Record<string, string> = {
         "Definieren Sie die zu bewertende Entscheidung und wie das Bewertungsergebnis zurückgeführt wird. ",
     "Define the ID of the process to call (e.g. ":
         "Definieren Sie die ID des aufzurufenden Prozesses (z. B.",
-    "Define the name of the message (e.g. ":
-        "Definieren Sie den Namen der Nachricht (z. B.",
+    "Define the name of the message (e.g. ": "Definieren Sie den Namen der Nachricht (z. B.",
     "Define the name of the variable that will contain the error code.":
         "Definieren Sie den Namen der Variablen, die den Fehlercode enthält.",
     "Define the name of the variable that will contain the error message.":
@@ -305,8 +304,7 @@ const translations: Record<string, string> = {
     "Mapping must have a value": "Zuordnung muss einen Wert haben",
     "Message event documentation": "Dokumentation zu Nachrichtenereignissen",
     "Message Name": "Nachrichtenname",
-    "Message throw event documentation":
-        "Dokumentation zu auslösenden Nachrichtenereignissen",
+    "Message throw event documentation": "Dokumentation zu auslösenden Nachrichtenereignissen",
     "Message variable": "Nachrichtenvariable",
     "Message": "Nachricht",
     "Multi Instance ": "Mehrfachinstanz ",
@@ -366,8 +364,7 @@ const translations: Record<string, string> = {
     "Propagate all variables": "Alle Variablen propagieren",
     "Properties": "Eigenschaften",
     "Receive task documentation": "Dokumentation zur Empfangsaufgabe",
-    "Refers to the process variable name":
-        "Bezieht sich auf den Namen der Prozessvariablen",
+    "Refers to the process variable name": "Bezieht sich auf den Namen der Prozessvariablen",
     "Resource": "Ressource",
     "Result variable": "Ergebnisvariable",
     "Result Variable": "Ergebnisvariable",
@@ -438,8 +435,7 @@ const translations: Record<string, string> = {
         "Das Fälligkeitsdatum als EL-Ausdruck (z. B. ${someDate}) oder als ISO-Datum (z. B. 2015-06-26T09:54:00).",
     "The number of times the engine tries executing this activity if a worker signals a failure. The default is three.":
         "Die Anzahl der Versuche, die die Engine unternimmt, um diese Aktivität auszuführen, wenn ein Worker einen Fehler signalisiert. Standard ist drei.",
-    "This maps to the process definition key.":
-        "Dies entspricht dem Prozessdefinitionsschlüssel.",
+    "This maps to the process definition key.": "Dies entspricht dem Prozessdefinitionsschlüssel.",
     "Throw expression": "Ausnahmeausdruck",
     "Time to live": "Lebensdauer",
     "timeout": "Zeitlimit",

--- a/libs/bpmn-i18n/src/languages/en/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/en/bpmn-js.ts
@@ -70,8 +70,7 @@ const translations: Record<string, string> = {
     "{semantic}#{side} Ref not specified": "{semantic}#{side} Ref not specified",
     "already rendered {element}": "already rendered {element}",
     "failed to import {element}": "failed to import {element}",
-    "multiple DI elements defined for {element}":
-        "multiple DI elements defined for {element}",
+    "multiple DI elements defined for {element}": "multiple DI elements defined for {element}",
     "no bpmnElement referenced in {element}": "no bpmnElement referenced in {element}",
     "diagram not part of bpmn:Definitions": "diagram not part of bpmn:Definitions",
     "no diagram to display": "no diagram to display",

--- a/libs/bpmn-i18n/src/languages/en/other.ts
+++ b/libs/bpmn-i18n/src/languages/en/other.ts
@@ -20,8 +20,7 @@
 const translations: Record<string, string> = {
     "Open minimap": "Open minimap",
     "Open properties panel": "Open properties panel",
-    "This maps to the process definition key.":
-        "This maps to the process definition key.",
+    "This maps to the process definition key.": "This maps to the process definition key.",
     "Key": "Key",
     "Intermediate Throw Event": "Intermediate Throw Event",
     "End Event": "End Event",
@@ -83,21 +82,17 @@ const translations: Record<string, string> = {
     "Cancel Boundary Event": "Cancel Boundary Event",
     "Signal Boundary Event": "Signal Boundary Event",
     "Compensation Boundary Event": "Compensation Boundary Event",
-    "Message Boundary Event (non-interrupting)":
-        "Message Boundary Event (non-interrupting)",
+    "Message Boundary Event (non-interrupting)": "Message Boundary Event (non-interrupting)",
     "Timer Boundary Event (non-interrupting)": "Timer Boundary Event (non-interrupting)",
-    "Escalation Boundary Event (non-interrupting)":
-        "Escalation Boundary Event (non-interrupting)",
+    "Escalation Boundary Event (non-interrupting)": "Escalation Boundary Event (non-interrupting)",
     "Conditional Boundary Event (non-interrupting)":
         "Conditional Boundary Event (non-interrupting)",
-    "Signal Boundary Event (non-interrupting)":
-        "Signal Boundary Event (non-interrupting)",
+    "Signal Boundary Event (non-interrupting)": "Signal Boundary Event (non-interrupting)",
     "Connect using Information/Knowledge/Authority Requirement or Association":
         "Connect using Information/Knowledge/Authority Requirement or Association",
     "Empty": "Empty",
     "Literal Expression": "Literal Expression",
-    "This maps to the decision definition key.":
-        "This maps to the decision definition key.",
+    "This maps to the decision definition key.": "This maps to the decision definition key.",
     "Decision Table": "Decision Table",
     "Output": "Output",
     "Annotation": "Annotation",

--- a/libs/bpmn-i18n/src/languages/es/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/es/bpmn-js.ts
@@ -23,8 +23,7 @@ const translations: Record<string, string> = {
     "Activate global connect tool": "Activar herramienta de conexión global",
     "Activate hand tool": "Activar herramienta de mano",
     "Activate lasso tool": "Activar herramienta de lazo",
-    "Activate the create/remove space tool":
-        "Activar herramienta de crear/eliminar espacio",
+    "Activate the create/remove space tool": "Activar herramienta de crear/eliminar espacio",
     "Activate the global connect tool": "Activar herramienta de conexión global",
     "Activate the hand tool": "Activar herramienta de mano",
     "Activate the lasso tool": "Activar herramienta de lazo",
@@ -40,30 +39,23 @@ const translations: Record<string, string> = {
     "Append compensation activity": "Añadir actividad de compensación",
     "Append conditional intermediate catch event":
         "Añadir evento intermedio de captura condicional",
-    "Append ConditionIntermediateCatchEvent":
-        "Añadir evento intermedio de captura condicional",
+    "Append ConditionIntermediateCatchEvent": "Añadir evento intermedio de captura condicional",
     "Append end event": "Añadir evento de fin",
     "Append EndEvent": "Añadir evento de fin",
     "Append gateway": "Añadir Gateway",
     "Append Gateway": "Añadir Gateway",
     "Append Intermediate/Boundary Event": "Añadir evento intermedio/de límite",
     "Append intermediate/boundary event": "Añadir evento intermedio/de límite",
-    "Append message intermediate catch event":
-        "Añadir evento intermedio de captura de mensaje",
-    "Append MessageIntermediateCatchEvent":
-        "Añadir evento intermedio de captura de mensaje",
+    "Append message intermediate catch event": "Añadir evento intermedio de captura de mensaje",
+    "Append MessageIntermediateCatchEvent": "Añadir evento intermedio de captura de mensaje",
     "Append receive task": "Añadir tarea de recepción",
     "Append ReceiveTask": "Añadir tarea de recepción",
-    "Append signal intermediate catch event":
-        "Añadir evento intermedio de captura de señal",
-    "Append SignalIntermediateCatchEvent":
-        "Añadir evento intermedio de captura de señal",
+    "Append signal intermediate catch event": "Añadir evento intermedio de captura de señal",
+    "Append SignalIntermediateCatchEvent": "Añadir evento intermedio de captura de señal",
     "Append task": "Añadir tarea",
     "Append Task": "Añadir tarea",
-    "Append timer intermediate catch event":
-        "Añadir evento intermedio de captura de temporizador",
-    "Append TimerIntermediateCatchEvent":
-        "Añadir evento intermedio de captura de temporizador",
+    "Append timer intermediate catch event": "Añadir evento intermedio de captura de temporizador",
+    "Append TimerIntermediateCatchEvent": "Añadir evento intermedio de captura de temporizador",
     "Business rule task": "Tarea de regla de negocio",
     "Call activity": "Actividad de llamada",
     "Cancel boundary event": "Evento de límite de cancelación",
@@ -73,8 +65,7 @@ const translations: Record<string, string> = {
     "Collection": "Colección",
     "Compensation boundary event": "Evento de límite de compensación",
     "Compensation end event": "Evento de fin de compensación",
-    "Compensation intermediate throw event":
-        "Evento intermedio de lanzamiento de compensación",
+    "Compensation intermediate throw event": "Evento intermedio de lanzamiento de compensación",
     "Compensation start event": "Evento de inicio de compensación",
     "Complex gateway": "Gateway complejo",
     "Conditional boundary event (non-interrupting)":
@@ -82,16 +73,13 @@ const translations: Record<string, string> = {
     "Conditional boundary event": "Evento de límite condicional",
     "Conditional flow": "Flujo condicional",
     "Conditional intermediate catch event": "Evento intermedio de captura condicional",
-    "Conditional start event (non-interrupting)":
-        "Evento de inicio condicional (no interrumpible)",
+    "Conditional start event (non-interrupting)": "Evento de inicio condicional (no interrumpible)",
     "Conditional start event": "Evento de inicio condicional",
     "Connect to other element": "Conectar con otro elemento",
     "Connect using association": "Conectar usando asociación",
     "Connect using Association": "Conectar usando asociación",
-    "Connect using data input association":
-        "Conectar usando asociación de entrada de datos",
-    "Connect using DataInputAssociation":
-        "Conectar usando asociación de entrada de datos",
+    "Connect using data input association": "Conectar usando asociación de entrada de datos",
+    "Connect using DataInputAssociation": "Conectar usando asociación de entrada de datos",
     "Connect using Sequence/MessageFlow or Association":
         "Conectar usando flujo de secuencia/mensaje o asociación",
     "correcting missing bpmnElement on {plane} to {rootElement}":
@@ -121,8 +109,7 @@ const translations: Record<string, string> = {
     "Data store reference": "Almacén de datos",
     "Default flow": "Flujo predeterminado",
     "Delete": "Eliminar",
-    "diagram not part of bpmn:Definitions":
-        "El diagrama no es parte de bpmn:Definitions",
+    "diagram not part of bpmn:Definitions": "El diagrama no es parte de bpmn:Definitions",
     "Distribute elements horizontally": "Distribuir elementos horizontalmente",
     "Distribute elements vertically": "Distribuir elementos verticalmente",
     "Divide into three Lanes": "Dividir en tres carriles",
@@ -140,8 +127,7 @@ const translations: Record<string, string> = {
         "Evento de límite de escalación (no interrumpible)",
     "Escalation boundary event": "Evento de límite de escalación",
     "Escalation end event": "Evento de fin de escalación",
-    "Escalation intermediate throw event":
-        "Evento intermedio de lanzamiento de escalación",
+    "Escalation intermediate throw event": "Evento intermedio de lanzamiento de escalación",
     "Escalation start event (non-interrupting)":
         "Evento de inicio de escalación (no interrumpible)",
     "Escalation start event": "Evento de inicio de escalación",
@@ -158,30 +144,23 @@ const translations: Record<string, string> = {
     "Link intermediate throw event": "Evento intermedio de lanzamiento de enlace",
     "Loop": "Bucle",
     "Manual task": "Tarea manual",
-    "Message boundary event (non-interrupting)":
-        "Evento de límite de mensaje (no interrumpible)",
+    "Message boundary event (non-interrupting)": "Evento de límite de mensaje (no interrumpible)",
     "Message boundary event": "Evento de límite de mensaje",
     "Message end event": "Evento de fin de mensaje",
     "Message intermediate catch event": "Evento intermedio de captura de mensaje",
     "Message intermediate throw event": "Evento intermedio de lanzamiento de mensaje",
-    "Message start event (non-interrupting)":
-        "Evento de inicio de mensaje (no interrumpible)",
+    "Message start event (non-interrupting)": "Evento de inicio de mensaje (no interrumpible)",
     "Message start event": "Evento de inicio de mensaje",
     "missing {semantic}#attachedToRef": "Falta {semantic}#attachedToRef",
     "more than {count} child lanes": "Más de {count} carriles hijos",
-    "multiple DI elements defined for {element}":
-        "Múltiples elementos DI definidos para {element}",
-    "no bpmnElement referenced in {element}":
-        "Ningún bpmnElement referenciado en {element}",
+    "multiple DI elements defined for {element}": "Múltiples elementos DI definidos para {element}",
+    "no bpmnElement referenced in {element}": "Ningún bpmnElement referenciado en {element}",
     "no diagram to display": "No hay diagrama para mostrar",
-    "no parent for {element} in {parent}":
-        "No hay elemento padre para {element} en {parent}",
-    "no process or collaboration to display":
-        "No hay proceso o colaboración para mostrar",
+    "no parent for {element} in {parent}": "No hay elemento padre para {element} en {parent}",
+    "no process or collaboration to display": "No hay proceso o colaboración para mostrar",
     "no shape type specified": "No se especificó tipo de forma",
     "out of bounds release": "Liberación fuera de los límites",
-    "Parallel Event based instantiating Gateway":
-        "Gateway instanciador paralelo basado en eventos",
+    "Parallel Event based instantiating Gateway": "Gateway instanciador paralelo basado en eventos",
     "Parallel gateway": "Gateway paralelo (AND)",
     "Parallel Multi Instance": "Instancia múltiple paralela",
     "Parallel multi-instance": "Instancia múltiple paralela",
@@ -194,14 +173,12 @@ const translations: Record<string, string> = {
     "Sequential Multi Instance": "Instancia múltiple secuencial",
     "Sequential multi-instance": "Instancia múltiple secuencial",
     "Service task": "Tarea de servicio",
-    "Signal boundary event (non-interrupting)":
-        "Evento de límite de señal (no interrumpible)",
+    "Signal boundary event (non-interrupting)": "Evento de límite de señal (no interrumpible)",
     "Signal boundary event": "Evento de límite de señal",
     "Signal end event": "Evento de fin de señal",
     "Signal intermediate catch event": "Evento intermedio de captura de señal",
     "Signal intermediate throw event": "Evento intermedio de lanzamiento de señal",
-    "Signal start event (non-interrupting)":
-        "Evento de inicio de señal (no interrumpible)",
+    "Signal start event (non-interrupting)": "Evento de inicio de señal (no interrumpible)",
     "Signal start event": "Evento de inicio de señal",
     "Start event": "Evento de inicio",
     "Sub-process (collapsed)": "Subproceso (contraído)",
@@ -213,13 +190,11 @@ const translations: Record<string, string> = {
         "Evento de límite de temporizador (no interrumpible)",
     "Timer boundary event": "Evento de límite de temporizador",
     "Timer intermediate catch event": "Evento intermedio de captura de temporizador",
-    "Timer start event (non-interrupting)":
-        "Evento de inicio de temporizador (no interrumpible)",
+    "Timer start event (non-interrupting)": "Evento de inicio de temporizador (no interrumpible)",
     "Timer start event": "Evento de inicio de temporizador",
     "Toggle non-interrupting": "Alternar no interrumpible",
     "Transaction": "Transacción",
-    "unknown di {di} for element {semantic}":
-        "DI desconocido {di} para el elemento {semantic}",
+    "unknown di {di} for element {semantic}": "DI desconocido {di} para el elemento {semantic}",
     "unrecognized flowElement {element} in context {context}":
         "flowElement {element} no reconocido en el contexto {context}",
     "unsupported bpmnElement for {plane}: {rootElement}":

--- a/libs/bpmn-i18n/src/languages/es/dmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/es/dmn-js.ts
@@ -217,10 +217,8 @@ const translations: Record<string, string> = {
     "Start time": "Hora de inicio",
     "Start value": "Valor inicial",
     "String value": "Valor de cadena de texto",
-    "Strings must be in double quotes":
-        "Las cadenas de texto deben ir entre comillas dobles",
-    "Strings must be in double quotes.":
-        "Las cadenas de texto deben ir entre comillas dobles.",
+    "Strings must be in double quotes": "Las cadenas de texto deben ir entre comillas dobles",
+    "Strings must be in double quotes.": "Las cadenas de texto deben ir entre comillas dobles.",
     "Test type": "Tipo de prueba",
     "Then": "Entonces",
     "Time value": "Valor de hora",

--- a/libs/bpmn-i18n/src/languages/es/other.ts
+++ b/libs/bpmn-i18n/src/languages/es/other.ts
@@ -51,8 +51,7 @@ const translations: Record<string, string> = {
     "Compensation Boundary Event": "Evento de límite de compensación",
     "Compensation End Event": "Evento de fin de compensación",
     "Compensation Event": "Evento de compensación",
-    "Compensation Intermediate Throw Event":
-        "Evento intermedio de lanzamiento de compensación",
+    "Compensation Intermediate Throw Event": "Evento intermedio de lanzamiento de compensación",
     "Complex Gateway": "Gateway complejo",
     "Conditional Boundary Event (non-interrupting)":
         "Evento de límite condicional (no interrumpible)",
@@ -90,8 +89,7 @@ const translations: Record<string, string> = {
     "Deprecated": "Obsoleto",
     "Description": "Descripción",
     "Edit String": "Editar cadena de texto",
-    "Empty pool/participant (removes content)":
-        "Pool/Participante vacío (elimina contenido)",
+    "Empty pool/participant (removes content)": "Pool/Participante vacío (elimina contenido)",
     "Empty pool/participant": "Pool/Participante vacío (elimina contenido)",
     "Empty": "Vacío",
     "End Event": "Evento de fin",
@@ -102,10 +100,8 @@ const translations: Record<string, string> = {
         "Evento de límite de escalación (no interrumpible)",
     "Escalation Boundary Event": "Evento de límite de escalación",
     "Escalation End Event": "Evento de fin de escalación",
-    "Escalation Intermediate Throw Event":
-        "Evento intermedio de lanzamiento de escalación",
-    "Event is ignored due to entry criteria":
-        "El evento se ignora debido a criterios de entrada",
+    "Escalation Intermediate Throw Event": "Evento intermedio de lanzamiento de escalación",
+    "Event is ignored due to entry criteria": "El evento se ignora debido a criterios de entrada",
     "Event-based Exclusive Gateway": "Gateway exclusivo basado en eventos (XOR)",
     "Event": "Evento",
     "Example Data documentation": "Documentación de datos de ejemplo",
@@ -147,8 +143,7 @@ const translations: Record<string, string> = {
     "Literal Expression": "Expresión literal",
     "Local variable assignment": "Asignación de variable local",
     "Manual Task": "Tarea manual",
-    "Message Boundary Event (non-interrupting)":
-        "Evento de límite de mensaje (no interrumpible)",
+    "Message Boundary Event (non-interrupting)": "Evento de límite de mensaje (no interrumpible)",
     "Message Boundary Event": "Evento de límite de mensaje",
     "Message End Event": "Evento de fin de mensaje",
     "Message Intermediate Catch Event": "Evento intermedio de captura de mensaje",
@@ -196,8 +191,7 @@ const translations: Record<string, string> = {
     "Repetition Rule": "Regla de repetición",
     "Required Rule": "Regla requerida",
     "resultList": "Lista de resultados",
-    "Rule is overwritten by item control":
-        "La regla es sobrescrita por el control de elemento",
+    "Rule is overwritten by item control": "La regla es sobrescrita por el control de elemento",
     "Rule order": "Orden de reglas",
     "Rule": "Regla",
     "Rules": "Reglas",
@@ -210,8 +204,7 @@ const translations: Record<string, string> = {
     "Service Task": "Tarea de servicio",
     "Set Value": "Establecer valor",
     "Show Standard Event": "Mostrar evento estándar",
-    "Signal Boundary Event (non-interrupting)":
-        "Evento de límite de señal (no interrumpible)",
+    "Signal Boundary Event (non-interrupting)": "Evento de límite de señal (no interrumpible)",
     "Signal Boundary Event": "Evento de límite de señal",
     "Signal End Event": "Evento de fin de señal",
     "Signal Intermediate Catch Event": "Evento intermedio de captura de señal",
@@ -221,8 +214,7 @@ const translations: Record<string, string> = {
     "singleResult": "Resultado único",
     "Standard Event": "Evento estándar",
     "Start Event": "Evento de inicio",
-    "Strings must be in double quotes.":
-        "Las cadenas de texto deben ir entre comillas dobles.",
+    "Strings must be in double quotes.": "Las cadenas de texto deben ir entre comillas dobles.",
     "Sub Process (collapsed)": "Subproceso (contraído)",
     "Sub Process (expanded)": "Subproceso (expandido)",
     "Sub Process": "Subproceso",
@@ -240,8 +232,7 @@ const translations: Record<string, string> = {
         "Esto corresponde a la clave de definición de decisión.",
     "This maps to the process definition key.":
         "Esto corresponde a la clave de definición de proceso.",
-    "This maps to the task definition key.":
-        "Esto corresponde a la clave de definición de tarea.",
+    "This maps to the task definition key.": "Esto corresponde a la clave de definición de tarea.",
     "This template is deprecated.": "Esta plantilla está obsoleta.",
     "Timer Boundary Event (non-interrupting)":
         "Evento de límite de temporizador (no interrumpible)",

--- a/libs/bpmn-i18n/src/languages/es/properties-panel.ts
+++ b/libs/bpmn-i18n/src/languages/es/properties-panel.ts
@@ -126,8 +126,7 @@ const translations: Record<string, string> = {
         "Defina una expresión de colección de entrada que determine la colección a recorrer (p. ej. ",
     "Define the decision to evaluate and how to map back the evaluation result. ":
         "Defina la decisión a evaluar y cómo mapear el resultado de la evaluación.",
-    "Define the ID of the process to call (e.g. ":
-        "Defina el ID del proceso a llamar (p. ej. ",
+    "Define the ID of the process to call (e.g. ": "Defina el ID del proceso a llamar (p. ej. ",
     "Define the name of the message (e.g. ": "Defina el nombre del mensaje (p. ej. ",
     "Define the name of the variable that will contain the error code.":
         "Defina el nombre de la variable que contendrá el código de error.",
@@ -304,8 +303,7 @@ const translations: Record<string, string> = {
     "Mapping must have a value": "El mapeo debe tener un valor",
     "Message event documentation": "Documentación de evento de mensaje",
     "Message Name": "Nombre del mensaje",
-    "Message throw event documentation":
-        "Documentación de evento de lanzamiento de mensaje",
+    "Message throw event documentation": "Documentación de evento de lanzamiento de mensaje",
     "Message variable": "Variable de mensaje",
     "Message": "Mensaje",
     "Multi Instance ": "Instancia múltiple ",
@@ -360,15 +358,12 @@ const translations: Record<string, string> = {
     "Process Name": "Nombre de proceso",
     "Process variable name": "Nombre de variable de proceso",
     "Process variables": "Variables de proceso",
-    "Propagate all child process variables":
-        "Propagar todas las variables del proceso hijo",
-    "Propagate all parent process variables":
-        "Propagar todas las variables del proceso padre",
+    "Propagate all child process variables": "Propagar todas las variables del proceso hijo",
+    "Propagate all parent process variables": "Propagar todas las variables del proceso padre",
     "Propagate all variables": "Propagar todas las variables",
     "Properties": "Propiedades",
     "Receive task documentation": "Documentación de tarea de recepción",
-    "Refers to the process variable name":
-        "Se refiere al nombre de la variable de proceso",
+    "Refers to the process variable name": "Se refiere al nombre de la variable de proceso",
     "Resource": "Recurso",
     "Result variable": "Variable de resultado",
     "Result Variable": "Variable de resultado",
@@ -421,8 +416,7 @@ const translations: Record<string, string> = {
     "String": "Cadena de texto",
     "Subscription correlation key": "Clave de correlación de suscripción",
     "take": "tomar",
-    "Target must not contain whitespace":
-        "El destino no debe contener espacios en blanco",
+    "Target must not contain whitespace": "El destino no debe contener espacios en blanco",
     "Target": "Destino",
     "Task definition": "Definición de tarea",
     "Task listener": "Listener de tarea",

--- a/libs/bpmn-i18n/src/languages/fr/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/fr/bpmn-js.ts
@@ -70,21 +70,16 @@ const translations: Record<string, string> = {
     "Ad-hoc": "Ad-hoc",
     "element {element} referenced by {referenced}#{property} not yet drawn":
         "élément {element} référencé par {referenced}#{property} pas encore dessiné",
-    "unknown di {di} for element {semantic}":
-        "di {di} inconnu pour l'élément {semantic}",
+    "unknown di {di} for element {semantic}": "di {di} inconnu pour l'élément {semantic}",
     "missing {semantic}#attachedToRef": "{semantic}#attachedToRef manquant",
     "{semantic}#{side} Ref not specified": "{semantic}#{side} Ref non spécifié",
     "already rendered {element}": "{element} déjà rendu",
     "failed to import {element}": "échec de l'importation de {element}",
-    "multiple DI elements defined for {element}":
-        "plusieurs éléments DI définis pour {element}",
-    "no bpmnElement referenced in {element}":
-        "aucun bpmnElement référencé dans {element}",
-    "diagram not part of bpmn:Definitions":
-        "diagramme ne fait pas partie de bpmn:Definitions",
+    "multiple DI elements defined for {element}": "plusieurs éléments DI définis pour {element}",
+    "no bpmnElement referenced in {element}": "aucun bpmnElement référencé dans {element}",
+    "diagram not part of bpmn:Definitions": "diagramme ne fait pas partie de bpmn:Definitions",
     "no diagram to display": "aucun diagramme à afficher",
-    "no process or collaboration to display":
-        "aucun processus ou collaboration à afficher",
+    "no process or collaboration to display": "aucun processus ou collaboration à afficher",
     "correcting missing bpmnElement on {plane} to {rootElement}":
         "correction du bpmnElement manquant sur {plane} vers {rootElement}",
     "unsupported bpmnElement for {plane}: {rootElement}":

--- a/libs/bpmn-i18n/src/languages/fr/dmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/fr/dmn-js.ts
@@ -76,8 +76,7 @@ const translations: Record<string, string> = {
     "Remove Output Column": "Supprimer la colonne de sortie",
     "Remove Rule": "Supprimer la règle",
     "Set Value": "Définir la valeur",
-    "Strings must be in double quotes.":
-        "Les chaînes doivent être entre guillemets doubles.",
+    "Strings must be in double quotes.": "Les chaînes doivent être entre guillemets doubles.",
     "Type": "Type",
 };
 

--- a/libs/bpmn-i18n/src/languages/fr/other.ts
+++ b/libs/bpmn-i18n/src/languages/fr/other.ts
@@ -43,17 +43,13 @@ const translations: Record<string, string> = {
     "Sub Process (collapsed)": "Sous-processus (réduit)",
     "Close minimap": "Fermer la mini-carte",
     "Message Intermediate Catch Event": "Événement intermédiaire de capture de message",
-    "Message Intermediate Throw Event":
-        "Événement intermédiaire de lancement de message",
+    "Message Intermediate Throw Event": "Événement intermédiaire de lancement de message",
     "Timer Intermediate Catch Event": "Événement intermédiaire de capture de minuterie",
-    "Escalation Intermediate Throw Event":
-        "Événement intermédiaire de lancement d'escalade",
-    "Conditional Intermediate Catch Event":
-        "Événement intermédiaire de capture conditionnel",
+    "Escalation Intermediate Throw Event": "Événement intermédiaire de lancement d'escalade",
+    "Conditional Intermediate Catch Event": "Événement intermédiaire de capture conditionnel",
     "Link Intermediate Catch Event": "Événement intermédiaire de capture de lien",
     "Link Intermediate Throw Event": "Événement intermédiaire de lancement de lien",
-    "Compensation Intermediate Throw Event":
-        "Événement intermédiaire de lancement de compensation",
+    "Compensation Intermediate Throw Event": "Événement intermédiaire de lancement de compensation",
     "Signal Intermediate Catch Event": "Événement intermédiaire de capture de signal",
     "Signal Intermediate Throw Event": "Événement intermédiaire de lancement de signal",
     "Parallel Gateway": "Passerelle parallèle",
@@ -73,8 +69,7 @@ const translations: Record<string, string> = {
     "Sub Process": "Sous-processus",
     "Swap sides": "Inverser les côtés",
     "Task": "Tâche",
-    "This maps to the task definition key.":
-        "Cela correspond à la clé de définition de la tâche.",
+    "This maps to the task definition key.": "Cela correspond à la clé de définition de la tâche.",
     "Collapsed Pool": "Pool réduit",
     "Expanded Pool": "Pool étendu",
     "flow elements must be children of pools/participants":
@@ -89,16 +84,12 @@ const translations: Record<string, string> = {
     "Cancel Boundary Event": "Événement limite d'annulation",
     "Signal Boundary Event": "Événement limite de signal",
     "Compensation Boundary Event": "Événement limite de compensation",
-    "Message Boundary Event (non-interrupting)":
-        "Événement limite de message (non interruptif)",
-    "Timer Boundary Event (non-interrupting)":
-        "Événement limite de minuterie (non interruptif)",
-    "Escalation Boundary Event (non-interrupting)":
-        "Événement limite d'escalade (non interruptif)",
+    "Message Boundary Event (non-interrupting)": "Événement limite de message (non interruptif)",
+    "Timer Boundary Event (non-interrupting)": "Événement limite de minuterie (non interruptif)",
+    "Escalation Boundary Event (non-interrupting)": "Événement limite d'escalade (non interruptif)",
     "Conditional Boundary Event (non-interrupting)":
         "Événement limite conditionnel (non interruptif)",
-    "Signal Boundary Event (non-interrupting)":
-        "Événement limite de signal (non interruptif)",
+    "Signal Boundary Event (non-interrupting)": "Événement limite de signal (non interruptif)",
     "Connect using Information/Knowledge/Authority Requirement or Association":
         "Connecter en utilisant une exigence d'information/connaissance/autorité ou une association",
     "Empty": "Vide",

--- a/libs/bpmn-i18n/src/languages/nl-nl/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/nl-nl/bpmn-js.ts
@@ -26,8 +26,7 @@ const translations: Record<string, string> = {
     "Append ReceiveTask": "Voeg Receive-Task toe",
     "Append MessageIntermediateCatchEvent": "Voeg Message-Intermediate-Catch-Event toe",
     "Append TimerIntermediateCatchEvent": "Voeg Timer-Intermediate-Catch-Event toe",
-    "Append ConditionIntermediateCatchEvent":
-        "Voeg Condition-Intermediate-Catch-Event toe",
+    "Append ConditionIntermediateCatchEvent": "Voeg Condition-Intermediate-Catch-Event toe",
     "Append SignalIntermediateCatchEvent": "Voeg Signal-Intermediate-Catch-Event toe",
     "Append compensation activity": "Voeg compensation activity toe",
     "Append EndEvent": "Voeg End-Event toe",
@@ -44,13 +43,11 @@ const translations: Record<string, string> = {
     "out of bounds release": "release buiten bereik",
     "more than {count} child lanes": "meer dan {count} child lanes",
     "element required": "element vereist",
-    "no parent for {element} in {parent}":
-        "geen ouderelement voor {element} in {parent}",
+    "no parent for {element} in {parent}": "geen ouderelement voor {element} in {parent}",
     "Create {type}": "Maak {type}",
     "Activate the hand tool": "Activeer het hand gereedschap",
     "Activate the lasso tool": "Activeer het lasso gereedschap",
-    "Activate the create/remove space tool":
-        "Activeer het maak/verwijder ruimte gereedschap",
+    "Activate the create/remove space tool": "Activeer het maak/verwijder ruimte gereedschap",
     "Activate the global connect tool": "Activeer het globale verbinding gereedschap",
     "Create StartEvent": "Maak Start-Event",
     "Create Intermediate/Boundary Event": "Maak Intermediate/Boundary Event",
@@ -68,21 +65,17 @@ const translations: Record<string, string> = {
     "Ad-hoc": "Ad-hoc",
     "element {element} referenced by {referenced}#{property} not yet drawn":
         "element {element} gerefereerd door {referenced}#{property} nog niet getekend",
-    "unknown di {di} for element {semantic}":
-        "onbekende di {di} voor element {semantic}",
+    "unknown di {di} for element {semantic}": "onbekende di {di} voor element {semantic}",
     "missing {semantic}#attachedToRef": "{semantic}#attachedToRef ontbreekt",
     "{semantic}#{side} Ref not specified": "{semantic}#{side} Ref niet gespecificeerd",
     "already rendered {element}": "{element} reeds getekend",
     "failed to import {element}": "importeren van {element} gefaald",
     "multiple DI elements defined for {element}":
         "meerdere DI elementen gedefinieerd voor {element}",
-    "no bpmnElement referenced in {element}":
-        "geen bpmnElement gerefereerd in {element}",
-    "diagram not part of bpmn:Definitions":
-        "diagram geen onderdeel van bpmn:Definitions",
+    "no bpmnElement referenced in {element}": "geen bpmnElement gerefereerd in {element}",
+    "diagram not part of bpmn:Definitions": "diagram geen onderdeel van bpmn:Definitions",
     "no diagram to display": "geen diagram om weer te geven",
-    "no process or collaboration to display":
-        "geen process of collaboration om weer te geven",
+    "no process or collaboration to display": "geen process of collaboration om weer te geven",
     "correcting missing bpmnElement on {plane} to {rootElement}":
         "corrigeer ontbrekend bpmnElement op {plane} naar {rootElement}",
     "unsupported bpmnElement for {plane}: {rootElement}":

--- a/libs/bpmn-i18n/src/languages/nl-nl/dmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/nl-nl/dmn-js.ts
@@ -76,8 +76,7 @@ const translations: Record<string, string> = {
     "Remove Output Column": "Verwijder Output Kolom",
     "Remove Rule": "Verwijder Regel",
     "Set Value": "Geef Waarde",
-    "Strings must be in double quotes.":
-        "Teksten moeten tussen dubbele aanhalingstekens staan.",
+    "Strings must be in double quotes.": "Teksten moeten tussen dubbele aanhalingstekens staan.",
     "Type": "Type",
 };
 

--- a/libs/bpmn-i18n/src/languages/nl-nl/other.ts
+++ b/libs/bpmn-i18n/src/languages/nl-nl/other.ts
@@ -69,8 +69,7 @@ const translations: Record<string, string> = {
     "Sub Process": "Sub-Process",
     "Swap sides": "Zijden omwisselen",
     "Task": "Task",
-    "This maps to the task definition key.":
-        "Dit wordt vertaald naar de task definition key.",
+    "This maps to the task definition key.": "Dit wordt vertaald naar de task definition key.",
     "Collapsed Pool": "Ingeklapte Pool",
     "Expanded Pool": "Uitgeklapte Pool",
     "flow elements must be children of pools/participants":
@@ -85,15 +84,12 @@ const translations: Record<string, string> = {
     "Cancel Boundary Event": "Cancel-Boundary-Event",
     "Signal Boundary Event": "Signal-Boundary-Event",
     "Compensation Boundary Event": "Compensation-Boundary-Event",
-    "Message Boundary Event (non-interrupting)":
-        "Message-Boundary-Event (non-interrupting)",
+    "Message Boundary Event (non-interrupting)": "Message-Boundary-Event (non-interrupting)",
     "Timer Boundary Event (non-interrupting)": "Timer-Boundary-Event (non-interrupting)",
-    "Escalation Boundary Event (non-interrupting)":
-        "Escalation-Boundary-Event (non-interrupting)",
+    "Escalation Boundary Event (non-interrupting)": "Escalation-Boundary-Event (non-interrupting)",
     "Conditional Boundary Event (non-interrupting)":
         "Conditional-Boundary-Event (non-interrupting)",
-    "Signal Boundary Event (non-interrupting)":
-        "Signal-Boundary-Event (non-interrupting)",
+    "Signal Boundary Event (non-interrupting)": "Signal-Boundary-Event (non-interrupting)",
     "Connect using Information/Knowledge/Authority Requirement or Association":
         "Verbind met Information/Knowledge/Authority Requirement of Association",
     "Empty": "Leeg",

--- a/libs/bpmn-i18n/src/languages/pt-br/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/pt-br/bpmn-js.ts
@@ -24,14 +24,11 @@ const translations: Record<string, string> = {
     "Divide into three Lanes": "Dividir em três Raias",
     "Add Lane below": "Adicionar Raia abaixo",
     "Append ReceiveTask": "Adicionar Atividade de Recebimento",
-    "Append MessageIntermediateCatchEvent":
-        "Adicionar Evento Intermediário de Captura de Mensagem",
-    "Append TimerIntermediateCatchEvent":
-        "Adicionar Evento Intermediário de Captura de Tempo",
+    "Append MessageIntermediateCatchEvent": "Adicionar Evento Intermediário de Captura de Mensagem",
+    "Append TimerIntermediateCatchEvent": "Adicionar Evento Intermediário de Captura de Tempo",
     "Append ConditionIntermediateCatchEvent":
         "Adicionar Evento Intermediário de Captura de Condição",
-    "Append SignalIntermediateCatchEvent":
-        "Adicionar Evento Intermediário de Captura de Sinal",
+    "Append SignalIntermediateCatchEvent": "Adicionar Evento Intermediário de Captura de Sinal",
     "Append compensation activity": "Adicionar atividade de compensação",
     "Append EndEvent": "Adicionar Evento Final",
     "Append Gateway": "Adicionar Gateway",
@@ -41,8 +38,7 @@ const translations: Record<string, string> = {
     "Connect using Association": "Conectar usando Associação",
     "Connect using Sequence/MessageFlow or Association":
         "Conectar usando Sequência/Fluxo de Mensagem, ou Associação",
-    "Connect using DataInputAssociation":
-        "Conectar usando Associacao de Entrada de Dados",
+    "Connect using DataInputAssociation": "Conectar usando Associacao de Entrada de Dados",
     "Remove": "Remover",
     "no shape type specified": "nenhum tipo de forma especificado",
     "out of bounds release": "solto fora da região delimitada",
@@ -52,8 +48,7 @@ const translations: Record<string, string> = {
     "Create {type}": "Criar {type}",
     "Activate the hand tool": "Ativar ferramenta mão",
     "Activate the lasso tool": "Ativar ferramenta laço",
-    "Activate the create/remove space tool":
-        "Ativar ferramenta para criar/remover espaço",
+    "Activate the create/remove space tool": "Ativar ferramenta para criar/remover espaço",
     "Activate the global connect tool": "Ativar ferramenta de conexão global",
     "Create StartEvent": "Criar Evento de Início",
     "Create Intermediate/Boundary Event": "Criar Evento Intermediário ou de Borda",
@@ -71,20 +66,16 @@ const translations: Record<string, string> = {
     "Ad-hoc": "Ad-hoc",
     "element {element} referenced by {referenced}#{property} not yet drawn":
         "elemento {element} referenciado por {referenced}#{property} ainda não renderizado",
-    "unknown di {di} for element {semantic}":
-        "di desconhecido {di} para elemento {semantic}",
+    "unknown di {di} for element {semantic}": "di desconhecido {di} para elemento {semantic}",
     "missing {semantic}#attachedToRef": "faltando {semantic}#attachedToRef",
     "{semantic}#{side} Ref not specified": "{semantic}#{side} Ref não especificada",
     "already rendered {element}": "já renderizado {element}",
     "failed to import {element}": "falha ao importar {element}",
-    "multiple DI elements defined for {element}":
-        "múltiplos elementos DI definidos para {element}",
-    "no bpmnElement referenced in {element}":
-        "nenhum bpmnElement referenciado em {element}",
+    "multiple DI elements defined for {element}": "múltiplos elementos DI definidos para {element}",
+    "no bpmnElement referenced in {element}": "nenhum bpmnElement referenciado em {element}",
     "diagram not part of bpmn:Definitions": "diagrama não faz parte de bpmn:Definitions",
     "no diagram to display": "nenhum diagrama para exibir",
-    "no process or collaboration to display":
-        "nenhum processo ou colaboração para exibir",
+    "no process or collaboration to display": "nenhum processo ou colaboração para exibir",
     "correcting missing bpmnElement on {plane} to {rootElement}":
         "corrigindo bpmnElement faltando no {plane} para {rootElement}",
     "unsupported bpmnElement for {plane}: {rootElement}":

--- a/libs/bpmn-i18n/src/languages/pt-br/other.ts
+++ b/libs/bpmn-i18n/src/languages/pt-br/other.ts
@@ -20,8 +20,7 @@
 const translations: Record<string, string> = {
     "Open minimap": "Abrir mini-mapa",
     "Open properties panel": "Abrir painel de propriedades",
-    "This maps to the process definition key.":
-        "Aponta para a chave de definição do processo.",
+    "This maps to the process definition key.": "Aponta para a chave de definição do processo.",
     "Key": "Chave",
     "Intermediate Throw Event": "Evento Intermediário de Lançamento",
     "End Event": "Evento Final",
@@ -45,14 +44,11 @@ const translations: Record<string, string> = {
     "Message Intermediate Catch Event": "Evento Intermediário de Captura de Mensagem",
     "Message Intermediate Throw Event": "Evento Intermediário de Lançamento de Mensagem",
     "Timer Intermediate Catch Event": "Evento Intermediário de Captura de Tempo",
-    "Escalation Intermediate Throw Event":
-        "Evento Intermediário de Lançamento de Escalação",
-    "Conditional Intermediate Catch Event":
-        "Evento Intermediário de Captura de Condição",
+    "Escalation Intermediate Throw Event": "Evento Intermediário de Lançamento de Escalação",
+    "Conditional Intermediate Catch Event": "Evento Intermediário de Captura de Condição",
     "Link Intermediate Catch Event": "Evento Intermediário de Captura de Link",
     "Link Intermediate Throw Event": "Evento Intermediário de Lançamento de Línk",
-    "Compensation Intermediate Throw Event":
-        "Evento Intermediário de Lançamento de Compensação",
+    "Compensation Intermediate Throw Event": "Evento Intermediário de Lançamento de Compensação",
     "Signal Intermediate Catch Event": "Evento Intermediário de Captura de Sinal",
     "Signal Intermediate Throw Event": "Evento Intermediário de Lançamento de Sinal",
     "Parallel Gateway": "Gateway Paralelo",
@@ -72,8 +68,7 @@ const translations: Record<string, string> = {
     "Sub Process": "Sub Processo",
     "Swap sides": "Inverter lados",
     "Task": "Atividade",
-    "This maps to the task definition key.":
-        "Aponta para a chave de definição da atividade.",
+    "This maps to the task definition key.": "Aponta para a chave de definição da atividade.",
     "Collapsed Pool": "Piscina Colapsada",
     "Expanded Pool": "Piscina Expandida",
     "flow elements must be children of pools/participants":
@@ -88,22 +83,18 @@ const translations: Record<string, string> = {
     "Cancel Boundary Event": "Evento de Borda de Cancelamento",
     "Signal Boundary Event": "Evento de Borda de Sinal",
     "Compensation Boundary Event": "Evento de Borda de Compensação",
-    "Message Boundary Event (non-interrupting)":
-        "Evento de Borda de Mensagem (sem interrupção)",
-    "Timer Boundary Event (non-interrupting)":
-        "Evento de Borda de Tempo (sem interrupção)",
+    "Message Boundary Event (non-interrupting)": "Evento de Borda de Mensagem (sem interrupção)",
+    "Timer Boundary Event (non-interrupting)": "Evento de Borda de Tempo (sem interrupção)",
     "Escalation Boundary Event (non-interrupting)":
         "Evento de Borda de Escalação (sem interrupção)",
     "Conditional Boundary Event (non-interrupting)":
         "Evento de Borda Condicional (sem interrupção)",
-    "Signal Boundary Event (non-interrupting)":
-        "Evento de Borda de Sinal (sem interrupção)",
+    "Signal Boundary Event (non-interrupting)": "Evento de Borda de Sinal (sem interrupção)",
     "Connect using Information/Knowledge/Authority Requirement or Association":
         "Conecte usando Requerimento de Informação/Conhecimento/Autoridade ou Associação",
     "Empty": "Vazio",
     "Literal Expression": "Expressão Literal",
-    "This maps to the decision definition key.":
-        "Aponta para a chave de definicão da decisão.",
+    "This maps to the decision definition key.": "Aponta para a chave de definicão da decisão.",
     "Decision Table": "Tabela de Decisão",
     "Output": "Saída",
     "Annotation": "Anotação",

--- a/libs/bpmn-i18n/src/languages/ru/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/ru/bpmn-js.ts
@@ -24,12 +24,10 @@ const translations: Record<string, string> = {
     "Divide into three Lanes": "Разделить на три дорожки",
     "Add Lane below": "Добавить дорожку ниже",
     "Append ReceiveTask": "Добавить задачу приема сообщения",
-    "Append MessageIntermediateCatchEvent":
-        "Добавить промежуточное событие приема сообщения",
+    "Append MessageIntermediateCatchEvent": "Добавить промежуточное событие приема сообщения",
     "Append TimerIntermediateCatchEvent": "Добавить промежуточное событие таймер",
     "Append ConditionIntermediateCatchEvent": "Добавить промежуточное событие условие",
-    "Append SignalIntermediateCatchEvent":
-        "Добавить промежуточное событие приема сигнала",
+    "Append SignalIntermediateCatchEvent": "Добавить промежуточное событие приема сигнала",
     "Append compensation activity": "Добавить событийный подпроцесс",
     "Append EndEvent": "Добавить конечное событие",
     "Append Gateway": "Добавить шлюз",
@@ -46,8 +44,7 @@ const translations: Record<string, string> = {
     "out of bounds release": "выход за пределы",
     "more than {count} child lanes": "более {count} дочерних дорожек",
     "element required": "обязательный элемент",
-    "no parent for {element} in {parent}":
-        "нет родительского элемента для {element} в {parent}",
+    "no parent for {element} in {parent}": "нет родительского элемента для {element} в {parent}",
     "Create {type}": "Создать {type}",
     "Activate the hand tool": "Активировать инструмент свободного перемещения",
     "Activate the lasso tool": "Активировать интрумент лассо",
@@ -70,8 +67,7 @@ const translations: Record<string, string> = {
     "Ad-hoc": "Ad-hoc",
     "element {element} referenced by {referenced}#{property} not yet drawn":
         "элемент {element}, на который ссылается {referenced}#{property} еще не создан",
-    "unknown di {di} for element {semantic}":
-        "неизвестная директория {di} для элемента {semantic}",
+    "unknown di {di} for element {semantic}": "неизвестная директория {di} для элемента {semantic}",
     "missing {semantic}#attachedToRef": "потерянный {semantic}#attachedToRef",
     "{semantic}#{side} Ref not specified": "{semantic}#{side} Ссылка не указана",
     "already rendered {element}": "уже используемый {element}",
@@ -79,8 +75,7 @@ const translations: Record<string, string> = {
     "multiple DI elements defined for {element}":
         "несколько элементов DI, определенных для {element}",
     "no bpmnElement referenced in {element}": "нет ссылки на элемент BPMN в {element}",
-    "diagram not part of bpmn:Definitions":
-        "диаграмма не является частью bpmn:Definitions",
+    "diagram not part of bpmn:Definitions": "диаграмма не является частью bpmn:Definitions",
     "no diagram to display": "нет диаграммы для отображения",
     "no process or collaboration to display":
         "нет процесса или совместной процесса для отображения",

--- a/libs/bpmn-i18n/src/languages/ru/other.ts
+++ b/libs/bpmn-i18n/src/languages/ru/other.ts
@@ -83,15 +83,11 @@ const translations: Record<string, string> = {
     "Cancel Boundary Event": "Граничащее событие отмена",
     "Signal Boundary Event": "Граничащее событие  сигнал",
     "Compensation Boundary Event": "Граничащее событие компенсация",
-    "Message Boundary Event (non-interrupting)":
-        "Граничащее событие сообщение (непрерывное)",
+    "Message Boundary Event (non-interrupting)": "Граничащее событие сообщение (непрерывное)",
     "Timer Boundary Event (non-interrupting)": "Граничащее событие таймер (непрерывное)",
-    "Escalation Boundary Event (non-interrupting)":
-        "Граничащее событие эскалация (непрерывное)",
-    "Conditional Boundary Event (non-interrupting)":
-        "Граничащее событие компенсация (непрерывное)",
-    "Signal Boundary Event (non-interrupting)":
-        "Граничащее событие  сигнал (непрерывное)",
+    "Escalation Boundary Event (non-interrupting)": "Граничащее событие эскалация (непрерывное)",
+    "Conditional Boundary Event (non-interrupting)": "Граничащее событие компенсация (непрерывное)",
+    "Signal Boundary Event (non-interrupting)": "Граничащее событие  сигнал (непрерывное)",
     "Connect using Information/Knowledge/Authority Requirement or Association":
         "Подключение с использованием Информации/Знаний/Авторитетных требований или Ассоциации",
     "Empty": "Пусто",
@@ -102,8 +98,7 @@ const translations: Record<string, string> = {
     "Annotation": "Аннотация",
     "Output Expression": "Выходное выражение",
     "Data Type": "Тип данных",
-    "Create new BPMN Diagram (Camunda Platform)":
-        "Создать новую BPMN диграмму (Camunda Platform)",
+    "Create new BPMN Diagram (Camunda Platform)": "Создать новую BPMN диграмму (Camunda Platform)",
     "Navigate to referenced model": "Перейти к связанной модели",
 };
 

--- a/libs/bpmn-i18n/src/languages/zh-Hans/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hans/bpmn-js.ts
@@ -79,8 +79,7 @@ const translations: Record<string, string> = {
     "no process or collaboration to display": "没有要显示的流程或协作",
     "correcting missing bpmnElement on {plane} to {rootElement}":
         "正在将{plane}上缺少的bpmn元素更正为{rootElement}",
-    "unsupported bpmnElement for {plane}: {rootElement}":
-        "{plane}:{rootElement}的bpmn元素不受支持",
+    "unsupported bpmnElement for {plane}: {rootElement}": "{plane}:{rootElement}的bpmn元素不受支持",
     "unrecognized flowElement {element} in context {context}":
         "上下文{context}中无法识别的流程元素{element}",
     "HELLO {you}!": "你好 {you}!",

--- a/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
@@ -71,8 +71,7 @@ const translations: Record<string, string> = {
     "This maps to the task definition key.": "映射为任务定义Key.",
     "Collapsed Pool": "折叠泳道",
     "Expanded Pool": "展开泳道",
-    "flow elements must be children of pools/participants":
-        "流程元素必须是泳池/参与者的子元素",
+    "flow elements must be children of pools/participants": "流程元素必须是泳池/参与者的子元素",
     "The follow up date as an EL expression (e.g. ${someDate} or an ISO date (e.g. 2015-06-26T09:54:00)":
         "跟进日期可为EL表达式（例如${someDate}或ISO日期（例如2015-06-26T09:54:00）",
     "Message Boundary Event": "消息边界事件",

--- a/libs/bpmn-i18n/src/languages/zh-Hans/properties-panel.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hans/properties-panel.ts
@@ -24,8 +24,7 @@ const translations: Record<string, string> = {
     "Add Property": "添加属性",
     "Add Value": "添加值",
     "All": "所有",
-    "Available process variables, identified in the diagram.":
-        "图中标识的可用流程变量。",
+    "Available process variables, identified in the diagram.": "图中标识的可用流程变量。",
     "Assignee": "处理人",
     "assignment": "分配",
     "Asynchronous After": "异步后",
@@ -173,8 +172,7 @@ const translations: Record<string, string> = {
     "Source": "来源",
     "Source Expression": "来源表达式",
     "Specify more than one group as a comma separated list.": "若有多个组请用逗号分隔。",
-    "Specify more than one user as a comma separated list.":
-        "若有多个用户请用逗号分隔。",
+    "Specify more than one user as a comma separated list.": "若有多个用户请用逗号分隔。",
     "Specify more than one variable change event as a comma separated list.":
         "若有多个变量更改事件请用逗号分隔。",
     "start": "启动",

--- a/libs/bpmn-i18n/src/languages/zh-Hant/bpmn-js.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hant/bpmn-js.ts
@@ -79,8 +79,7 @@ const translations: Record<string, string> = {
     "no process or collaboration to display": "没有要顯示的流程或協作",
     "correcting missing bpmnElement on {plane} to {rootElement}":
         "正在將{plane}上缺少的bpmn元素更正為{rootElement}",
-    "unsupported bpmnElement for {plane}: {rootElement}":
-        "{plane}:{rootElement}的bpmn元素不受支持",
+    "unsupported bpmnElement for {plane}: {rootElement}": "{plane}:{rootElement}的bpmn元素不受支持",
     "unrecognized flowElement {element} in context {context}":
         "上下文{context}中无法識別的流程元素{element}",
     "HELLO {you}!": "你好 {you}!",

--- a/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
@@ -71,8 +71,7 @@ const translations: Record<string, string> = {
     "This maps to the task definition key.": "映射為任務定义Key.",
     "Collapsed Pool": "折叠泳道",
     "Expanded Pool": "展開泳道",
-    "flow elements must be children of pools/participants":
-        "流程元素必須是泳池/參與者的子元素",
+    "flow elements must be children of pools/participants": "流程元素必須是泳池/參與者的子元素",
     "The follow up date as an EL expression (e.g. ${someDate} or an ISO date (e.g. 2015-06-26T09:54:00)":
         "跟進日期可為EL表達式（例如${someDate}或ISO日期（例如2015-06-26T09:54:00）",
     "Message Boundary Event": "消息邊界事件",

--- a/libs/bpmn-i18n/src/languages/zh-Hant/properties-panel.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hant/properties-panel.ts
@@ -24,8 +24,7 @@ const translations: Record<string, string> = {
     "Add Property": "添加屬性",
     "Add Value": "添加值",
     "All": "所有",
-    "Available process variables, identified in the diagram.":
-        "圖中標識的可用流程變量。",
+    "Available process variables, identified in the diagram.": "圖中標識的可用流程變量。",
     "Assignee": "處理人",
     "assignment": "分配",
     "Asynchronous After": "異步后",
@@ -173,8 +172,7 @@ const translations: Record<string, string> = {
     "Source": "來源",
     "Source Expression": "來源表達式",
     "Specify more than one group as a comma separated list.": "若有多個組請用逗號分隔。",
-    "Specify more than one user as a comma separated list.":
-        "若有多個用戶請用逗號分隔。",
+    "Specify more than one user as a comma separated list.": "若有多個用戶請用逗號分隔。",
     "Specify more than one variable change event as a comma separated list.":
         "若有多個變量更改事件請用逗號分隔。",
     "start": "啓動",

--- a/libs/element-template-chooser/src/ElementTemplateChooser.ts
+++ b/libs/element-template-chooser/src/ElementTemplateChooser.ts
@@ -19,12 +19,7 @@ import { getBusinessObject } from "bpmn-js/lib/util/ModelUtil";
  * overlay, and applies the chosen template when the user confirms.
  */
 class ElementTemplateChooser {
-    static $inject = [
-        "config.connectorsExtension",
-        "eventBus",
-        "elementTemplates",
-        "canvas",
-    ];
+    static $inject = ["config.connectorsExtension", "eventBus", "elementTemplates", "canvas"];
 
     constructor(config: any, eventBus: any, elementTemplates: any, canvas: any) {
         const enableChooser = !config || config.elementTemplateChooser !== false;
@@ -56,11 +51,7 @@ class ElementTemplateChooser {
      * @param canvas The bpmn-js canvas service.
      * @returns A promise that resolves with the chosen template or rejects on cancel.
      */
-    private open(
-        element: any,
-        elementTemplates: any,
-        canvas: any,
-    ): Promise<ElementTemplate> {
+    private open(element: any, elementTemplates: any, canvas: any): Promise<ElementTemplate> {
         return new Promise((resolve, reject) => {
             const templates: ElementTemplate[] = elementTemplates
                 .getLatest(element)

--- a/libs/element-template-chooser/src/components/ChooserOverlay.tsx
+++ b/libs/element-template-chooser/src/components/ChooserOverlay.tsx
@@ -128,11 +128,7 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
 
     return (
         <div class="etc-backdrop" onClick={onCancel}>
-            <div
-                class="etc-modal"
-                onClick={(e) => e.stopPropagation()}
-                onKeyDown={handleKeyDown}
-            >
+            <div class="etc-modal" onClick={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
                 {/* Header */}
                 <div class="etc-header">
                     <h2 class="etc-title">Element Templates</h2>
@@ -142,12 +138,7 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
                         aria-label="Close"
                         type="button"
                     >
-                        <svg
-                            width="16"
-                            height="16"
-                            viewBox="0 0 16 16"
-                            fill="currentColor"
-                        >
+                        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                             <path d="M8 8.707l3.646 3.647.708-.708L8.707 8l3.647-3.646-.708-.708L8 7.293 4.354 3.646l-.708.708L7.293 8l-3.647 3.646.708.708L8 8.707z" />
                         </svg>
                     </button>
@@ -202,9 +193,7 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
                                 key={cat.id}
                                 class={`etc-chip ${activeCategory === cat.id ? "etc-chip--active" : ""}`}
                                 onClick={() =>
-                                    setActiveCategory(
-                                        activeCategory === cat.id ? null : cat.id,
-                                    )
+                                    setActiveCategory(activeCategory === cat.id ? null : cat.id)
                                 }
                                 type="button"
                             >
@@ -221,9 +210,7 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
                             <div class="etc-empty">
                                 <p class="etc-empty-text">No templates found</p>
                                 {search && (
-                                    <p class="etc-empty-hint">
-                                        Try a different search term
-                                    </p>
+                                    <p class="etc-empty-hint">Try a different search term</p>
                                 )}
                             </div>
                         ) : (
@@ -232,12 +219,8 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
                                     key={t.id}
                                     class={[
                                         "etc-template-card",
-                                        selectedId === t.id
-                                            ? "etc-template-card--selected"
-                                            : "",
-                                        focusIndex === idx
-                                            ? "etc-template-card--focused"
-                                            : "",
+                                        selectedId === t.id ? "etc-template-card--selected" : "",
+                                        focusIndex === idx ? "etc-template-card--focused" : "",
                                     ]
                                         .filter(Boolean)
                                         .join(" ")}
@@ -274,15 +257,12 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
                                                 );
                                                 return impl ? (
                                                     <span class="etc-card-impl">
-                                                        {impl.label}:
-                                                        <code>{impl.value}</code>
+                                                        {impl.label}:<code>{impl.value}</code>
                                                     </span>
                                                 ) : null;
                                             })()}
                                             {t.description && (
-                                                <span class="etc-card-desc">
-                                                    {t.description}
-                                                </span>
+                                                <span class="etc-card-desc">{t.description}</span>
                                             )}
                                         </div>
                                     </div>

--- a/libs/element-template-chooser/src/components/TemplatePreview.tsx
+++ b/libs/element-template-chooser/src/components/TemplatePreview.tsx
@@ -49,9 +49,7 @@ export function TemplatePreview({ template, onApply }: TemplatePreviewProps) {
 
                 {/* Collapsible details — scroll away as the user scrolls down */}
                 <div class="etc-preview-details">
-                    {template.description && (
-                        <p class="etc-preview-desc">{template.description}</p>
-                    )}
+                    {template.description && <p class="etc-preview-desc">{template.description}</p>}
                     {template.documentationRef && (
                         <a
                             class="etc-preview-docs-link"
@@ -59,12 +57,7 @@ export function TemplatePreview({ template, onApply }: TemplatePreviewProps) {
                             target="_blank"
                             rel="noopener noreferrer"
                         >
-                            <svg
-                                width="12"
-                                height="12"
-                                viewBox="0 0 16 16"
-                                fill="currentColor"
-                            >
+                            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
                                 <path d="M4.715 6.542L3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.001 1.001 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z" />
                                 <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 0 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 0 0-4.243-4.243L6.586 4.672z" />
                             </svg>
@@ -83,22 +76,18 @@ export function TemplatePreview({ template, onApply }: TemplatePreviewProps) {
 
                 {/* Parameter sections */}
                 <div class="etc-preview-params">
-                    {props.length > 0 && (
-                        <ParameterSection title="Properties" items={props} />
-                    )}
+                    {props.length > 0 && <ParameterSection title="Properties" items={props} />}
                     {inputs.length > 0 && (
                         <ParameterSection title="Input Parameters" items={inputs} />
                     )}
                     {outputs.length > 0 && (
                         <ParameterSection title="Output Parameters" items={outputs} />
                     )}
-                    {props.length === 0 &&
-                        inputs.length === 0 &&
-                        outputs.length === 0 && (
-                            <div class="etc-preview-no-params">
-                                <p>No visible parameters</p>
-                            </div>
-                        )}
+                    {props.length === 0 && inputs.length === 0 && outputs.length === 0 && (
+                        <div class="etc-preview-no-params">
+                            <p>No visible parameters</p>
+                        </div>
+                    )}
                 </div>
             </div>
 
@@ -118,13 +107,7 @@ export function TemplatePreview({ template, onApply }: TemplatePreviewProps) {
  * @param props.title Section heading text.
  * @param props.items Property items to display.
  */
-function ParameterSection({
-    title,
-    items,
-}: {
-    title: string;
-    items: TemplateProperty[];
-}) {
+function ParameterSection({ title, items }: { title: string; items: TemplateProperty[] }) {
     return (
         <div class="etc-param-section">
             <h4 class="etc-param-title">{title}</h4>
@@ -137,19 +120,13 @@ function ParameterSection({
                             </span>
                             <div class="etc-param-badges">
                                 {p.constraints?.notEmpty && (
-                                    <span class="etc-badge etc-badge--required">
-                                        required
-                                    </span>
+                                    <span class="etc-badge etc-badge--required">required</span>
                                 )}
                                 {p.editable === false && (
-                                    <span class="etc-badge etc-badge--readonly">
-                                        read-only
-                                    </span>
+                                    <span class="etc-badge etc-badge--readonly">read-only</span>
                                 )}
                                 {p.optional && (
-                                    <span class="etc-badge etc-badge--optional">
-                                        optional
-                                    </span>
+                                    <span class="etc-badge etc-badge--optional">optional</span>
                                 )}
                             </div>
                         </div>

--- a/libs/element-template-chooser/src/types.ts
+++ b/libs/element-template-chooser/src/types.ts
@@ -141,11 +141,7 @@ export function classifyBinding(binding: TemplateProperty["binding"]): BindingDi
     const type = binding.type;
 
     // Output bindings (C7 + C8)
-    if (
-        type === "camunda:out" ||
-        type === "camunda:outputParameter" ||
-        type === "zeebe:output"
-    ) {
+    if (type === "camunda:out" || type === "camunda:outputParameter" || type === "zeebe:output") {
         return "output";
     }
 

--- a/libs/model-navigation/src/NavigateContextPadProvider.spec.ts
+++ b/libs/model-navigation/src/NavigateContextPadProvider.spec.ts
@@ -132,9 +132,7 @@ describe("NavigateContextPadProvider", () => {
         const posted = vsCodeBridge.postMessage.mock.calls[0][0];
         expect(posted).toBeInstanceOf(NavigateToReferencedModelCommand);
         expect((posted as NavigateToReferencedModelCommand).referenceId).toBe("Updated");
-        expect((posted as NavigateToReferencedModelCommand).referenceKind).toBe(
-            "process",
-        );
+        expect((posted as NavigateToReferencedModelCommand).referenceKind).toBe("process");
     });
 
     it("does nothing when the reference id was cleared between render and click", () => {

--- a/libs/model-navigation/src/NavigateContextPadProvider.ts
+++ b/libs/model-navigation/src/NavigateContextPadProvider.ts
@@ -75,11 +75,7 @@ export class NavigateContextPadProvider {
 
     private readonly vsCodeBridge: VsCodeBridge;
 
-    constructor(
-        contextPad: ContextPad,
-        translate: Translate,
-        vsCodeBridge: VsCodeBridge,
-    ) {
+    constructor(contextPad: ContextPad, translate: Translate, vsCodeBridge: VsCodeBridge) {
         this.translate = translate;
         this.vsCodeBridge = vsCodeBridge;
         contextPad.registerProvider(this);
@@ -117,10 +113,7 @@ export class NavigateContextPadProvider {
                     // and click (e.g. via keyboard in the properties panel)
                     // navigates to the current id, not a stale one.
                     click: (_event, clickedElement) => {
-                        const current = extractReference(
-                            clickedElement.businessObject,
-                            kind,
-                        );
+                        const current = extractReference(clickedElement.businessObject, kind);
                         if (current) {
                             postMessage(current);
                         }

--- a/libs/model-navigation/src/extractReference.ts
+++ b/libs/model-navigation/src/extractReference.ts
@@ -66,10 +66,7 @@ export function extractReference(
             return camunda7Reference;
         }
         // Camunda 8: <zeebe:calledElement processId="…">
-        const camunda8Reference = findExtensionElement(
-            businessObject,
-            "zeebe:CalledElement",
-        );
+        const camunda8Reference = findExtensionElement(businessObject, "zeebe:CalledElement");
         if (camunda8Reference?.processId) {
             return camunda8Reference.processId;
         }
@@ -82,10 +79,7 @@ export function extractReference(
         return camunda7Reference;
     }
     // Camunda 8: <zeebe:calledDecision decisionId="…">
-    const camunda8Reference = findExtensionElement(
-        businessObject,
-        "zeebe:CalledDecision",
-    );
+    const camunda8Reference = findExtensionElement(businessObject, "zeebe:CalledDecision");
     if (camunda8Reference?.decisionId) {
         return camunda8Reference.decisionId;
     }

--- a/libs/model-navigation/vitest.config.ts
+++ b/libs/model-navigation/vitest.config.ts
@@ -7,10 +7,7 @@ export default defineConfig({
         environment: "node",
         include: ["src/**/*.{spec,test}.ts"],
         alias: {
-            "@miragon/bpmn-modeler-shared": resolve(
-                __dirname,
-                "../../libs/shared/src/index.ts",
-            ),
+            "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
         },
     },
 });

--- a/libs/standalone-extension/src/hide-builtin-views-contribution.ts
+++ b/libs/standalone-extension/src/hide-builtin-views-contribution.ts
@@ -14,10 +14,7 @@
  *   the Theia version (currently pinned to 1.70.x).
  */
 import { inject, injectable } from "@theia/core/shared/inversify";
-import {
-    FrontendApplication,
-    FrontendApplicationContribution,
-} from "@theia/core/lib/browser";
+import { FrontendApplication, FrontendApplicationContribution } from "@theia/core/lib/browser";
 import { WidgetManager } from "@theia/core/lib/browser/widget-manager";
 
 const HIDDEN_VIEW_CONTAINER_IDS = [
@@ -33,14 +30,11 @@ export class HideBuiltinViewsContribution implements FrontendApplicationContribu
     protected readonly widgetManager!: WidgetManager;
 
     async onDidInitializeLayout(app: FrontendApplication): Promise<void> {
-        await Promise.all(
-            HIDDEN_VIEW_CONTAINER_IDS.map((id) => this.hideWidget(app, id)),
-        );
+        await Promise.all(HIDDEN_VIEW_CONTAINER_IDS.map((id) => this.hideWidget(app, id)));
     }
 
     private async hideWidget(app: FrontendApplication, id: string): Promise<void> {
-        const widget =
-            app.shell.getWidgetById(id) ?? (await this.widgetManager.tryGetWidget(id));
+        const widget = app.shell.getWidgetById(id) ?? (await this.widgetManager.tryGetWidget(id));
         widget?.dispose();
     }
 }

--- a/libs/standalone-extension/src/miragon-theme-contribution.ts
+++ b/libs/standalone-extension/src/miragon-theme-contribution.ts
@@ -102,9 +102,7 @@ export class MiragonThemeContribution implements FrontendApplicationContribution
         this.preferences.ready.then(() => this.ensureMiragonTheme());
 
         if (!window.localStorage.getItem(FIRST_RUN_KEY)) {
-            this.stateService
-                .reachedState("ready")
-                .then(() => this.promptInitialThemeChoice());
+            this.stateService.reachedState("ready").then(() => this.promptInitialThemeChoice());
         }
     }
 


### PR DESCRIPTION
## Summary
- Bumps Prettier `printWidth` from 89 to 100 (closer to common defaults of 100/120).
- Reflows the 100 affected files in one mechanical pass — no behavior changes.

## Test plan
- [ ] `corepack yarn lint` is clean