### PR TITLE
docs: finish rename to "BPMN Modeler" in READMEs + drop centered hero blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,13 @@
 [![Issues][issues-shield]][issues-url]
 [![MIT License][license-shield]][license-url]
 
-<br />
-<div align="center">
-    <a href="#">
-        <img src="https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
-    </a>
-    <h3>BPMN, where your work already happens.</h3>
-    <p>A growing family of BPMN/DMN tools built around a shared modeler core — in VS Code, on the desktop, and (soon) talking to your AI assistant.</p>
-    <p>
-        <a href="https://miragon.github.io/bpmn-modeler/">Documentation</a>
-        ·
-        <a href="https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler">Install on Marketplace</a>
-        ·
-        <a href="https://github.com/Miragon/bpmn-modeler/issues">Issues</a>
-    </p>
-</div>
+<img src="https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/miragon-logo.png" alt="Miragon" height="160">
+
+### BPMN, where your work already happens.
+
+A growing family of BPMN/DMN tools built around a shared modeler core — in VS Code, on the desktop, and (soon) talking to your AI assistant.
+
+[Documentation](https://miragon.github.io/bpmn-modeler/) · [Install on Marketplace](https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler) · [Issues](https://github.com/Miragon/bpmn-modeler/issues)
 
 ---
 
@@ -72,7 +64,7 @@ Different surfaces, one modeling engine, one repo.
 
 ### Try it in 30 seconds
 
-> Install **[Camunda Modeler by Miragon][marketplace-url]** from the VS Code
+> Install **[BPMN Modeler][marketplace-url]** from the VS Code
 > Marketplace, open any `.bpmn` or `.dmn` file — the modeler opens
 > automatically as a custom editor. That's it.
 

--- a/apps/modeler-plugin/README.md
+++ b/apps/modeler-plugin/README.md
@@ -1,15 +1,10 @@
-<div align="center">
-    <img src="https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/miragon-logo.png" alt="Miragon" height="140">
-    <h3>Camunda Modeler by Miragon</h3>
-    <p>BPMN 2.0 and DMN modeling for Camunda 7 and Camunda 8 — directly in VS Code.</p>
-    <p>
-        <a href="https://miragon.github.io/bpmn-modeler/">Documentation</a>
-        ·
-        <a href="https://github.com/Miragon/bpmn-modeler/issues">Report Bug</a>
-        ·
-        <a href="https://github.com/Miragon/bpmn-modeler/pulls">Request Feature</a>
-    </p>
-</div>
+<img src="https://raw.githubusercontent.com/Miragon/bpmn-modeler/main/images/miragon-logo.png" alt="Miragon" height="140">
+
+### BPMN Modeler
+
+BPMN 2.0 and DMN modeling for Camunda 7 and Camunda 8 — directly in VS Code.
+
+[Documentation](https://miragon.github.io/bpmn-modeler/) · [Report Bug](https://github.com/Miragon/bpmn-modeler/issues) · [Request Feature](https://github.com/Miragon/bpmn-modeler/pulls)
 
 ## Why this extension
 
@@ -46,7 +41,7 @@ project.
 
 ## Getting started
 
-Install **Camunda Modeler by Miragon** from the VS Code Marketplace, then open
+Install **BPMN Modeler** from the VS Code Marketplace, then open
 any `.bpmn` or `.dmn` file — the modeler opens automatically as a custom
 editor.
 


### PR DESCRIPTION
## Summary

- Picks up the three README references the rebrand PR (#958) missed — "Camunda Modeler by Miragon" → **BPMN Modeler** in the root `README.md` and `apps/modeler-plugin/README.md`.
- Drops the `<div align="center">` hero wrappers from both READMEs so the logo, tagline, and link row align left like the rest of the document.

## Test plan

- [ ] Preview both READMEs on GitHub and confirm the hero blocks render left-aligned with no broken markup
- [ ] Confirm "Camunda Modeler by Miragon" no longer appears in any README (`rg "Camunda Modeler by Miragon"`)