### PR TITLE
fix(props-panel): consolidate panel UI state restoration

### DIFF
--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -4,19 +4,32 @@ import { BpmnModeler } from "./modeler";
 
 const PANEL_SCROLL_CONTAINER = ".bio-properties-panel-scroll-container";
 const PANEL_GROUP = ".bio-properties-panel-group";
-const PANEL_GROUP_OPEN_CLASS = "open";
 const PANEL_GROUP_HEADER = ".bio-properties-panel-group-header";
+const PANEL_GROUP_OPEN_CLASS = "open";
 const SCROLL_DEBOUNCE_MS = 100;
+
+/**
+ * Returns whether the given properties-panel group is currently expanded.
+ *
+ * `@bpmn-io/properties-panel` puts the `open` class on the header child,
+ * never on the group root — and the body element differs between regular
+ * groups (`.bio-properties-panel-group-entries`) and list groups
+ * (`.bio-properties-panel-list`). The header is the only element common to
+ * both that reliably tracks expansion state.
+ */
+function isGroupOpen(group: HTMLElement): boolean {
+    const header = group.querySelector<HTMLElement>(PANEL_GROUP_HEADER);
+    return header?.classList.contains(PANEL_GROUP_OPEN_CLASS) ?? false;
+}
 
 /**
  * Manages webview state persistence and restoration across VS Code tab switches.
  *
  * Lifecycle phases (call in order):
- * 1. {@link restoreViewport}        — after importXML (canvas must exist)
- * 2. {@link restoreSelection}       — after element templates + settings applied
- * 3. {@link restorePanelScroll}     — after properties panel is rendered
- * 4. {@link restoreExpandedGroups}  — after properties panel is rendered
- * 5. {@link startPersisting}        — subscribes to change events for ongoing persistence
+ * 1. {@link restoreViewport}       — after importXML (canvas must exist)
+ * 2. {@link restoreSelection}      — after element templates + settings applied
+ * 3. {@link restorePanelUiState}   — after properties panel is rendered
+ * 4. {@link startPersisting}       — subscribes to change events for ongoing persistence
  */
 export class WebviewStateManager {
     constructor(
@@ -48,44 +61,49 @@ export class WebviewStateManager {
     }
 
     /**
-     * Restores the properties-panel scroll position.  Must be called after
-     * {@link import("./resizer").initResizer} → `setVisible(true)` so the
-     * scroll container exists in the DOM.
+     * Restores the properties-panel UI state (expanded groups + scroll) in a
+     * single coordinated pass.  Must be called after the resizer has made
+     * the panel visible so the scroll container exists in the DOM.
+     *
+     * Order matters: groups are toggled first, then scroll is applied on a
+     * follow-up frame so Preact has flushed the click-induced re-renders.
+     * Applying scroll before expansion would clamp to a smaller scrollHeight.
      */
-    restorePanelScroll(): void {
+    restorePanelUiState(): void {
         const saved = this.getSavedState();
-        if (saved?.panelScroll == null) {
+        if (!saved) {
             return;
         }
-        const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
-        if (container) {
-            container.scrollTop = saved.panelScroll;
-        }
-    }
-
-    /**
-     * Restores expanded/collapsed group state by clicking through the
-     * library's own header handlers, keeping its Preact state in sync.
-     * Deferred one frame so the panel has fully rendered.
-     */
-    restoreExpandedGroups(): void {
-        const saved = this.getSavedState();
-        const wanted = saved?.expandedGroupIndexes;
-        if (!wanted || wanted.length === 0) {
+        const wanted = saved.expandedGroupIndexes;
+        const savedScroll = saved.panelScroll;
+        if ((!wanted || wanted.length === 0) && savedScroll == null) {
             return;
         }
-        const target = new Set(wanted);
         requestAnimationFrame(() => {
-            const groups = document.querySelectorAll<HTMLElement>(PANEL_GROUP);
-            groups.forEach((group, index) => {
-                const isOpen = group.classList.contains(PANEL_GROUP_OPEN_CLASS);
-                const shouldBeOpen = target.has(index);
-                if (isOpen === shouldBeOpen) {
-                    return;
-                }
-                const header = group.querySelector<HTMLElement>(PANEL_GROUP_HEADER);
-                header?.click();
-            });
+            const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+            if (!container) {
+                return;
+            }
+            if (wanted && wanted.length > 0) {
+                const target = new Set(wanted);
+                const groups = container.querySelectorAll<HTMLElement>(PANEL_GROUP);
+                groups.forEach((group, index) => {
+                    const shouldBeOpen = target.has(index);
+                    if (isGroupOpen(group) === shouldBeOpen) {
+                        return;
+                    }
+                    const header = group.querySelector<HTMLElement>(PANEL_GROUP_HEADER);
+                    header?.click();
+                });
+            }
+            if (savedScroll != null) {
+                // Second rAF waits for Preact to commit the click-induced
+                // re-renders; only then has scrollHeight grown to fit the
+                // restored open groups so scrollTop lands where the user left it.
+                requestAnimationFrame(() => {
+                    container.scrollTop = savedScroll;
+                });
+            }
         });
     }
 
@@ -156,9 +174,10 @@ export class WebviewStateManager {
      * collapse toggles (which the library does via internal Preact state, no
      * public event) are mirrored into persisted state.
      *
-     * Filters mutations to only those on `.bio-properties-panel-group`
-     * elements — without that filter, input focus / hover class changes in
-     * the panel subtree would also trigger writes.
+     * The `open` class lives on the header child of each group, not on the
+     * group root, so the filter only accepts class mutations on
+     * `.bio-properties-panel-group-header` — discarding unrelated class
+     * changes elsewhere in the panel subtree (input focus, hover, etc.).
      */
     private subscribeGroupExpansion(): void {
         const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
@@ -167,7 +186,7 @@ export class WebviewStateManager {
         }
         const observer = new MutationObserver((mutations) => {
             const groupChanged = mutations.some(
-                (m) => m.target instanceof HTMLElement && m.target.matches(PANEL_GROUP),
+                (m) => m.target instanceof HTMLElement && m.target.matches(PANEL_GROUP_HEADER),
             );
             if (!groupChanged) {
                 return;
@@ -175,7 +194,7 @@ export class WebviewStateManager {
             const groups = container.querySelectorAll<HTMLElement>(PANEL_GROUP);
             const indexes: number[] = [];
             groups.forEach((group, index) => {
-                if (group.classList.contains(PANEL_GROUP_OPEN_CLASS)) {
+                if (isGroupOpen(group)) {
                     indexes.push(index);
                 }
             });

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -243,8 +243,7 @@ window.onload = async function () {
 
     // Phase 2: restore selection + panel-side UI state (safe now — side-effects done)
     stateManager.restoreSelection();
-    stateManager.restorePanelScroll();
-    stateManager.restoreExpandedGroups();
+    stateManager.restorePanelUiState();
 
     // Phase 3: begin persisting changes
     stateManager.startPersisting();

--- a/apps/dmn-webview/src/app/state.ts
+++ b/apps/dmn-webview/src/app/state.ts
@@ -3,9 +3,23 @@ import { WebviewState } from "./vscode";
 
 const PANEL_SCROLL_CONTAINER = ".bio-properties-panel-scroll-container";
 const PANEL_GROUP = ".bio-properties-panel-group";
-const PANEL_GROUP_OPEN_CLASS = "open";
 const PANEL_GROUP_HEADER = ".bio-properties-panel-group-header";
+const PANEL_GROUP_OPEN_CLASS = "open";
 const SCROLL_DEBOUNCE_MS = 100;
+
+/**
+ * Returns whether the given properties-panel group is currently expanded.
+ *
+ * `@bpmn-io/properties-panel` puts the `open` class on the header child,
+ * never on the group root — and the body element differs between regular
+ * groups (`.bio-properties-panel-group-entries`) and list groups
+ * (`.bio-properties-panel-list`). The header is the only element common to
+ * both that reliably tracks expansion state.
+ */
+function isGroupOpen(group: HTMLElement): boolean {
+    const header = group.querySelector<HTMLElement>(PANEL_GROUP_HEADER);
+    return header?.classList.contains(PANEL_GROUP_OPEN_CLASS) ?? false;
+}
 
 /**
  * Manages DMN webview state persistence and restoration across VS Code tab
@@ -13,47 +27,51 @@ const SCROLL_DEBOUNCE_MS = 100;
  * and selection round-tripping is not yet implemented for dmn-js.
  *
  * Lifecycle:
- * 1. {@link restorePanelScroll}     — after properties panel is rendered
- * 2. {@link restoreExpandedGroups}  — after properties panel is rendered
- * 3. {@link startPersisting}        — installs the change listeners
+ * 1. {@link restorePanelUiState}   — after properties panel is rendered
+ * 2. {@link startPersisting}       — installs the change listeners
  */
 export class WebviewStateManager {
     constructor(private readonly vscode: VsCodeApi<WebviewState, Command | Query>) {}
 
-    restorePanelScroll(): void {
-        const saved = this.getSavedState();
-        if (saved?.panelScroll == null) {
-            return;
-        }
-        const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
-        if (container) {
-            container.scrollTop = saved.panelScroll;
-        }
-    }
-
     /**
-     * Restores expanded/collapsed group state via the library's own header
-     * click handlers so Preact's internal state stays in sync.  Deferred one
-     * frame so the panel has fully rendered.
+     * Restores the properties-panel UI state (expanded groups + scroll) in a
+     * single coordinated pass.  Order matters: groups are toggled first, then
+     * scroll is applied on a follow-up frame so Preact has flushed the
+     * click-induced re-renders.  Applying scroll before expansion would clamp
+     * to a smaller scrollHeight.
      */
-    restoreExpandedGroups(): void {
+    restorePanelUiState(): void {
         const saved = this.getSavedState();
-        const wanted = saved?.expandedGroupIndexes;
-        if (!wanted || wanted.length === 0) {
+        if (!saved) {
             return;
         }
-        const target = new Set(wanted);
+        const wanted = saved.expandedGroupIndexes;
+        const savedScroll = saved.panelScroll;
+        if ((!wanted || wanted.length === 0) && savedScroll == null) {
+            return;
+        }
         requestAnimationFrame(() => {
-            const groups = document.querySelectorAll<HTMLElement>(PANEL_GROUP);
-            groups.forEach((group, index) => {
-                const isOpen = group.classList.contains(PANEL_GROUP_OPEN_CLASS);
-                const shouldBeOpen = target.has(index);
-                if (isOpen === shouldBeOpen) {
-                    return;
-                }
-                const header = group.querySelector<HTMLElement>(PANEL_GROUP_HEADER);
-                header?.click();
-            });
+            const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
+            if (!container) {
+                return;
+            }
+            if (wanted && wanted.length > 0) {
+                const target = new Set(wanted);
+                const groups = container.querySelectorAll<HTMLElement>(PANEL_GROUP);
+                groups.forEach((group, index) => {
+                    const shouldBeOpen = target.has(index);
+                    if (isGroupOpen(group) === shouldBeOpen) {
+                        return;
+                    }
+                    const header = group.querySelector<HTMLElement>(PANEL_GROUP_HEADER);
+                    header?.click();
+                });
+            }
+            if (savedScroll != null) {
+                requestAnimationFrame(() => {
+                    container.scrollTop = savedScroll;
+                });
+            }
         });
     }
 
@@ -100,9 +118,10 @@ export class WebviewStateManager {
      * collapse toggles (which the library does via internal Preact state, no
      * public event) are mirrored into persisted state.
      *
-     * Filters mutations to only those on `.bio-properties-panel-group`
-     * elements — without that filter, input focus / hover class changes in
-     * the panel subtree would also trigger writes.
+     * The `open` class lives on the header child of each group, not on the
+     * group root, so the filter only accepts class mutations on
+     * `.bio-properties-panel-group-header` — discarding unrelated class
+     * changes elsewhere in the panel subtree (input focus, hover, etc.).
      */
     private subscribeGroupExpansion(): void {
         const container = document.querySelector<HTMLElement>(PANEL_SCROLL_CONTAINER);
@@ -111,7 +130,7 @@ export class WebviewStateManager {
         }
         const observer = new MutationObserver((mutations) => {
             const groupChanged = mutations.some(
-                (m) => m.target instanceof HTMLElement && m.target.matches(PANEL_GROUP),
+                (m) => m.target instanceof HTMLElement && m.target.matches(PANEL_GROUP_HEADER),
             );
             if (!groupChanged) {
                 return;
@@ -119,7 +138,7 @@ export class WebviewStateManager {
             const groups = container.querySelectorAll<HTMLElement>(PANEL_GROUP);
             const indexes: number[] = [];
             groups.forEach((group, index) => {
-                if (group.classList.contains(PANEL_GROUP_OPEN_CLASS)) {
+                if (isGroupOpen(group)) {
                     indexes.push(index);
                 }
             });

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -65,8 +65,7 @@ window.onload = async function () {
     await initializeModeler(dmnFile?.content);
     modelerIsInitialized = true;
 
-    stateManager.restorePanelScroll();
-    stateManager.restoreExpandedGroups();
+    stateManager.restorePanelUiState();
     stateManager.startPersisting();
 };
 


### PR DESCRIPTION
**Issue**

Properties Panel groups are closed after the webview gets hidden.

**Description**

Merge `restorePanelScroll` and `restoreExpandedGroups` into a single
`restorePanelUiState` method that coordinates group expansion and scroll
restoration in the correct order to avoid scroll clamping.

Extract `isGroupOpen` helper to reliably detect expansion state by checking
the `open` class on the group header (the only element common to both regular
and list groups), replacing direct class checks on group root elements.

Update mutation observer to filter on `PANEL_GROUP_HEADER` matches instead of
`PANEL_GROUP` to avoid triggering state writes for unrelated class changes
(focus, hover, etc.) elsewhere in the panel subtree.

Apply changes consistently across both BPMN and DMN webviews.

**Checklist**

- Code is easy to understand
- No obvious errors or bugs
- CI/CD Pipelines did run successfully
- Tests were implemented
- Documentation was created
