### PR TITLE
chore(ci): simplify version bumping in release workflow with yarn version apply

### DIFF
--- a/.github/workflows/prepare-release-vscode-modeler.yml
+++ b/.github/workflows/prepare-release-vscode-modeler.yml
@@ -62,31 +62,22 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
 
-      # Edit package.json in place rather than using `yarn workspace ... version`
-      # + `yarn version apply --all`: yarn's version apply triggers a full
-      # (non-focused) install, which builds native deps from the standalone
-      # Theia workspace (native-keymap, electron, @theia/ffmpeg, ...) and
-      # fails on the runner. The lockfile uses `workspace:` resolution for the
-      # bumped package, so no lockfile sync is needed.
+      # `yarn version apply --all` triggers a full (non-focused) install, which
+      # runs postinstall scripts in the standalone Theia workspace
+      # (native-keymap, electron, @theia/ffmpeg). `native-keymap`'s `node-gyp
+      # rebuild` fails on the Linux runner. Setting YARN_ENABLE_SCRIPTS=false
+      # for this step suppresses those postinstalls; the lint/test/build steps
+      # below run in their own shell with scripts re-enabled.
       - name: Bump version
         id: version
         env:
-          RELEASE_TYPE: ${{ inputs.release-type }}
+          YARN_ENABLE_SCRIPTS: 'false'
         run: |
           PKG_PATH="./apps/modeler-plugin/package.json"
-          NEW_VERSION=$(node -e "
-            const fs = require('fs');
-            const path = '$PKG_PATH';
-            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-            const [maj, min, pat] = pkg.version.split('.').map(Number);
-            const type = process.env.RELEASE_TYPE;
-            const next = type === 'major' ? \`\${maj + 1}.0.0\`
-                       : type === 'minor' ? \`\${maj}.\${min + 1}.0\`
-                       : \`\${maj}.\${min}.\${pat + 1}\`;
-            pkg.version = next;
-            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-            process.stdout.write(next);
-          ")
+          PKG_NAME=$(node -e "console.log(require('$PKG_PATH').name)")
+          yarn workspace "$PKG_NAME" version "${{ inputs.release-type }}"
+          yarn version apply --all
+          NEW_VERSION=$(node -e "console.log(require('$PKG_PATH').version)")
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Ensure tag does not exist

--- a/.github/workflows/prepare-release-vscode-modeler.yml
+++ b/.github/workflows/prepare-release-vscode-modeler.yml
@@ -62,14 +62,31 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
 
+      # Edit package.json in place rather than using `yarn workspace ... version`
+      # + `yarn version apply --all`: yarn's version apply triggers a full
+      # (non-focused) install, which builds native deps from the standalone
+      # Theia workspace (native-keymap, electron, @theia/ffmpeg, ...) and
+      # fails on the runner. The lockfile uses `workspace:` resolution for the
+      # bumped package, so no lockfile sync is needed.
       - name: Bump version
         id: version
+        env:
+          RELEASE_TYPE: ${{ inputs.release-type }}
         run: |
           PKG_PATH="./apps/modeler-plugin/package.json"
-          PKG_NAME=$(node -e "console.log(require('$PKG_PATH').name)")
-          yarn workspace "$PKG_NAME" version "${{ inputs.release-type }}"
-          yarn version apply --all
-          NEW_VERSION=$(node -e "console.log(require('$PKG_PATH').version)")
+          NEW_VERSION=$(node -e "
+            const fs = require('fs');
+            const path = '$PKG_PATH';
+            const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const [maj, min, pat] = pkg.version.split('.').map(Number);
+            const type = process.env.RELEASE_TYPE;
+            const next = type === 'major' ? \`\${maj + 1}.0.0\`
+                       : type === 'minor' ? \`\${maj}.\${min + 1}.0\`
+                       : \`\${maj}.\${min}.\${pat + 1}\`;
+            pkg.version = next;
+            fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+            process.stdout.write(next);
+          ")
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Ensure tag does not exist


### PR DESCRIPTION
**Issue**

Worklfow `prepare-release-vscode-modeler` fails.

**Description**

Replace custom version calculation logic with `yarn version apply --all`, and suppress postinstall scripts during the step to prevent native module build failures on the Linux runner. Scripts are re-enabled in subsequent lint/test/build steps.

**Checklist**

- Code is easy to understand
- No obvious errors or bugs
- CI/CD Pipelines did run successfully
- Tests were implemented
- Documentation was created
