### PR TITLE
fix(nav): apply EXCLUDED_DIRS to findFiles result, not just walker

### DIFF
--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
@@ -143,7 +143,7 @@ describe("findDeclaringFiles — workspace folder open (findFiles path)", () => 
         });
     });
 
-    it("passes undefined as exclude — VS Code applies files.exclude automatically", async () => {
+    it("passes undefined as exclude — VS Code layers files.exclude and search.exclude", async () => {
         const { locator, vsWorkspace } = createLocator({
             fileContents: { "/a.bpmn": bpmnWithProcess("ProcessB") },
         });
@@ -152,6 +152,57 @@ describe("findDeclaringFiles — workspace folder open (findFiles path)", () => 
 
         // Only one positional arg → second is implicitly undefined.
         expect(vsWorkspace.findFiles).toHaveBeenCalledWith("**/*.bpmn");
+    });
+
+    it("filters out paths inside build/output dirs that VS Code defaults miss", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: {
+                "/work/wanted.bpmn": bpmnWithProcess("Wanted"),
+                "/work/dist/inner.bpmn": bpmnWithProcess("Wanted"),
+                "/work/build/inner.bpmn": bpmnWithProcess("Wanted"),
+                "/work/out/inner.bpmn": bpmnWithProcess("Wanted"),
+                "/work/target/inner.bpmn": bpmnWithProcess("Wanted"),
+                "/work/coverage/inner.bpmn": bpmnWithProcess("Wanted"),
+                "/work/node_modules/lib/inner.bpmn": bpmnWithProcess("Wanted"),
+                "/work/nested/dist/deep.bpmn": bpmnWithProcess("Wanted"),
+            },
+        });
+
+        const result = await locator.findDeclaringFiles("Wanted", "process");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/work/wanted.bpmn"]);
+        }
+        // Excluded paths should not even be read.
+        expect(vsWorkspace.readFile).toHaveBeenCalledTimes(1);
+        expect(vsWorkspace.readFile).toHaveBeenCalledWith("/work/wanted.bpmn");
+    });
+
+    it("falls back to fs-walk when every findFiles result is excluded", async () => {
+        workspaceState.folders = [{ uri: { scheme: "file", path: "/work", fsPath: "/work" } }];
+        const { locator, vsWorkspace } = createLocator({
+            fileContents: {
+                "/work/dist/stale.bpmn": bpmnWithProcess("Wanted"),
+                "/work/src/real.bpmn": bpmnWithProcess("Wanted"),
+            },
+            tree: {
+                "/work": [
+                    { name: "dist", type: "directory" },
+                    { name: "src", type: "directory" },
+                ],
+                "/work/src": ["real.bpmn"],
+            },
+        });
+        vsWorkspace.findFiles.mockResolvedValue(["/work/dist/stale.bpmn"]);
+
+        const result = await locator.findDeclaringFiles("Wanted", "process");
+
+        expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/work/src/real.bpmn"]);
+        }
     });
 
     it("returns kind=all-unreadable when every candidate read fails", async () => {

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
@@ -6,9 +6,12 @@ import { VsCodeUI } from "../../infrastructure/VsCodeUI";
 import { VsCodeWorkspace } from "../../infrastructure/VsCodeWorkspace";
 
 /**
- * Directory names skipped during the fs walk.  The `workspace.findFiles`
- * path inherits the user's `files.exclude` from VS Code automatically and
- * doesn't need a parallel list.
+ * Directory names that never contain user-authored process/decision sources.
+ * Applied uniformly to both code paths: as a post-filter on the
+ * `workspace.findFiles` result, and per-directory during the fs-walk
+ * fallback.  VS Code's default `files.exclude` / `search.exclude` only
+ * cover a subset of these (notably `**\/node_modules`), so we cannot rely
+ * on the platform defaults alone.
  */
 const EXCLUDED_DIRS: ReadonlySet<string> = new Set([
     "node_modules",
@@ -100,14 +103,19 @@ export class ReferencedModelLocator {
             return undefined;
         }
 
-        // Pass undefined for excludes — VS Code applies user's `files.exclude`.
+        // Pass undefined for excludes — VS Code layers user's `files.exclude`
+        // and `search.exclude` on top.  We then post-filter with
+        // `EXCLUDED_DIRS` because the VS Code defaults do not cover all of
+        // them (e.g. `dist`, `build`, `out`, `target`, `coverage`).
         const startedAt = Date.now();
         const found = await this.vsWorkspace.findFiles(`**/*${extension}`);
+        const filtered = found.filter((path) => !pathIsInsideExcludedDir(path));
         this.vsUI.logInfo(
-            `[nav] findFiles returned ${found.length} path(s) in ${Date.now() - startedAt}ms`,
+            `[nav] findFiles returned ${found.length} path(s) ` +
+                `(${filtered.length} after exclude filter) in ${Date.now() - startedAt}ms`,
         );
-        if (found.length > 0) {
-            return found;
+        if (filtered.length > 0) {
+            return filtered;
         }
 
         // Fallback: findFiles failed silently (ripgrep missing in packaged .app).
@@ -267,6 +275,13 @@ export class ReferencedModelLocator {
 
 function escapeRegex(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function pathIsInsideExcludedDir(path: string): boolean {
+    for (const segment of path.split("/")) {
+        if (segment !== "" && EXCLUDED_DIRS.has(segment)) return true;
+    }
+    return false;
 }
 
 function truncate(value: string, max: number): string {


### PR DESCRIPTION
## Summary

- The build-directory filter for the "open referenced process" Quick Pick was only being applied in the fs-walk fallback path. In VS Code the primary `workspace.findFiles` call passed `undefined` for `exclude`, relying on the platform's `files.exclude` / `search.exclude` defaults — those cover `**/node_modules` but **not** `dist`, `build`, `out`, `target`, or `coverage`. Standalone (Theia) hides them because it usually hits the walker fallback; VS Code did not, so users navigating from a Call Activity saw `.bpmn` files inside `dist/` and `build/`.
- Apply `EXCLUDED_DIRS` as a post-filter on the `findFiles` result so both code paths converge on the same exclusion semantics from a single source of truth. Post-filtering is preferred over passing an explicit `exclude` glob because the latter would replace VS Code's defaults entirely and silently break any user-tuned `files.exclude` / `search.exclude` settings.
- Corrected the misleading comment at the top of `ReferencedModelLocator.ts` that previously claimed `findFiles` inherited the full exclusion list from VS Code.

## Test plan

- [x] `corepack yarn test apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts` — 23/23 pass (two new tests cover the post-filter on the `findFiles` path and the all-excluded → walker fallback case).
- [x] `corepack yarn lint` — clean (no new errors).
- [ ] Manual smoke in the Extension Host (F5):
  - Open a workspace that contains a `dist/` (or `build/`) folder with at least one `.bpmn` inside it.
  - On a Call Activity, trigger "Open referenced process".
  - The Quick Pick should no longer list any file inside `dist/`, `build/`, `out/`, `target/`, `coverage/`, `node_modules/`, or VCS metadata folders.
- [ ] Sanity-check standalone (Theia): unchanged — it already filtered via the walker, and now passes through the same post-filter as a no-op.