### PR TITLE
refactor(deployment): add toHeaders method to auth classes

### DIFF
--- a/apps/modeler-plugin/src/domain/deployment.spec.ts
+++ b/apps/modeler-plugin/src/domain/deployment.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { BasicAuth, NoAuth } from "./deployment";
+
+describe("NoAuth", () => {
+    describe("toHeaders", () => {
+        it("should return an empty header set", () => {
+            expect(new NoAuth().toHeaders()).toEqual({});
+        });
+    });
+});
+
+describe("BasicAuth", () => {
+    describe("toHeaders", () => {
+        it("should return a Base64-encoded Authorization header", () => {
+            const expected = Buffer.from("admin:secret").toString("base64");
+
+            expect(new BasicAuth("admin", "secret").toHeaders()).toEqual({
+                Authorization: `Basic ${expected}`,
+            });
+        });
+
+        // Guards the RFC 7617 UTF-8 contract — Latin-1 (e.g. btoa) would
+        // produce a different base64 string and break interoperability.
+        it("should UTF-8-encode non-ASCII credentials before base64", () => {
+            const expected = Buffer.from("user:name:p@ss:wörd").toString("base64");
+
+            expect(new BasicAuth("user:name", "p@ss:wörd").toHeaders()).toEqual({
+                Authorization: `Basic ${expected}`,
+            });
+        });
+    });
+});

--- a/apps/modeler-plugin/src/domain/deployment.ts
+++ b/apps/modeler-plugin/src/domain/deployment.ts
@@ -5,6 +5,13 @@ export type AuthConfig = NoAuth | BasicAuth | OAuth2Auth;
 
 export class NoAuth {
     readonly type = "none" as const;
+
+    /**
+     * No credentials to send, so the request needs no auth headers.
+     */
+    toHeaders(): Record<string, string> {
+        return {};
+    }
 }
 
 /**
@@ -17,6 +24,16 @@ export class BasicAuth {
         readonly username: string,
         readonly password: string,
     ) {}
+
+    /**
+     * RFC 7617 mandates UTF-8 for the userid:password octet sequence before
+     * base64 — `btoa()` would Latin-1-encode and silently corrupt non-ASCII
+     * credentials, so we go through `Buffer` which encodes UTF-8 by default.
+     */
+    toHeaders(): Record<string, string> {
+        const credentials = Buffer.from(`${this.username}:${this.password}`).toString("base64");
+        return { Authorization: `Basic ${credentials}` };
+    }
 }
 
 /**

--- a/apps/modeler-plugin/src/infrastructure/camunda/AuthHeaderResolver.ts
+++ b/apps/modeler-plugin/src/infrastructure/camunda/AuthHeaderResolver.ts
@@ -17,31 +17,20 @@ export class AuthHeaderResolver {
     /**
      * Converts an {@link AuthConfig} into the corresponding HTTP headers.
      *
-     * - `NoAuth`   → empty object
-     * - `BasicAuth` → `{ Authorization: "Basic <base64>" }`
-     * - `OAuth2Auth` → fetches an access token, returns `{ Authorization: "Bearer <token>" }`
+     * OAuth2 needs an async token fetch and is therefore handled here;
+     * the pure schemes (`NoAuth`, `BasicAuth`) own their own header
+     * formatting via `toHeaders()` and are delegated to.
      *
      * @param auth Authentication configuration to resolve.
      * @returns A record of HTTP headers to merge into the outgoing request.
      * @throws {TokenFetchError} If the OAuth2 token fetch fails.
      */
     async resolve(auth: AuthConfig): Promise<Record<string, string>> {
-        switch (auth.type) {
-            case "none":
-                return {};
-
-            case "basic": {
-                const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString(
-                    "base64",
-                );
-                return { Authorization: `Basic ${credentials}` };
-            }
-
-            case "oauth2": {
-                const accessToken = await this.fetchAccessToken(auth);
-                return { Authorization: `Bearer ${accessToken}` };
-            }
+        if (auth.type === "oauth2") {
+            const accessToken = await this.fetchAccessToken(auth);
+            return { Authorization: `Bearer ${accessToken}` };
         }
+        return auth.toHeaders();
     }
 
     /**


### PR DESCRIPTION
**Issue**

Closes: #1032

**Description**

Extract BasicAuth and NoAuth header formatting into dedicated methods
on the domain classes. This delegates pure authentication schemes to
their domain logic while keeping async OAuth2 token fetching in the
infrastructure layer.

- Add `toHeaders()` method to NoAuth and BasicAuth classes
- Refactor AuthHeaderResolver to delegate pure schemes via `toHeaders()`
- Add comprehensive unit tests for BasicAuth UTF-8 handling per RFC 7617

**Checklist**

- Code is easy to understand
- No obvious errors or bugs
- CI/CD Pipelines did run successfully
- Tests were implemented
- Documentation was created
