### PR TITLE
refactor(deployment): plug vscode leak in DeploymentService.selectAdditionalFiles

### DIFF
--- a/apps/modeler-plugin/src/infrastructure/VsCodeUI.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeUI.spec.ts
@@ -36,6 +36,13 @@ vi.mock("./extensionContext", () => ({
 }));
 
 import { VsCodeUI } from "./VsCodeUI";
+import type { VsCodeWorkspace } from "./VsCodeWorkspace";
+
+function stubWorkspace(findFilesResult: string[] = []): VsCodeWorkspace {
+    return {
+        findFiles: vi.fn().mockResolvedValue(findFilesResult),
+    } as unknown as VsCodeWorkspace;
+}
 
 beforeEach(() => {
     showQuickPickMock.mockReset();
@@ -49,7 +56,7 @@ describe("VsCodeUI.pickReferencedModel", () => {
             Promise.resolve(items[0]),
         );
 
-        const sut = new VsCodeUI();
+        const sut = new VsCodeUI(stubWorkspace());
 
         const result = await sut.pickReferencedModel(["/src/a.bpmn"]);
 
@@ -59,7 +66,7 @@ describe("VsCodeUI.pickReferencedModel", () => {
     it("returns undefined when the user dismisses the picker", async () => {
         showQuickPickMock.mockResolvedValue(undefined);
 
-        const sut = new VsCodeUI();
+        const sut = new VsCodeUI(stubWorkspace());
 
         const result = await sut.pickReferencedModel(["/src/a.bpmn"]);
 
@@ -69,7 +76,7 @@ describe("VsCodeUI.pickReferencedModel", () => {
     it("builds items with basename label + workspace-relative description", async () => {
         showQuickPickMock.mockResolvedValue(undefined);
 
-        const sut = new VsCodeUI();
+        const sut = new VsCodeUI(stubWorkspace());
         await sut.pickReferencedModel(["/repo/src/a.bpmn"]);
 
         const items = showQuickPickMock.mock.calls[0][0] as {
@@ -87,7 +94,7 @@ describe("VsCodeUI.pickReferencedModel", () => {
         showQuickPickMock.mockResolvedValue(undefined);
         // Inputs in non-alphabetical order; expect the picker to receive
         // them sorted by `description` so nearby files surface first.
-        const sut = new VsCodeUI();
+        const sut = new VsCodeUI(stubWorkspace());
         await sut.pickReferencedModel(["/repo/src/z.bpmn", "/repo/lib/a.bpmn", "/repo/src/m.bpmn"]);
 
         const items = showQuickPickMock.mock.calls[0][0] as { path: string }[];
@@ -101,12 +108,99 @@ describe("VsCodeUI.pickReferencedModel", () => {
     it("passes the placeholder to the picker", async () => {
         showQuickPickMock.mockResolvedValue(undefined);
 
-        const sut = new VsCodeUI();
+        const sut = new VsCodeUI(stubWorkspace());
         await sut.pickReferencedModel(["/a.bpmn"]);
 
         const options = showQuickPickMock.mock.calls[0][1] as {
             placeHolder: string;
         };
         expect(options.placeHolder).toBe("Select the referenced model to open");
+    });
+});
+
+describe("VsCodeUI.pickWorkspaceFiles", () => {
+    it("returns the file paths of the chosen items", async () => {
+        showQuickPickMock.mockImplementation((items: { filePath: string }[]) =>
+            Promise.resolve([items[0], items[1]]),
+        );
+        const workspace = stubWorkspace(["/a.form", "/b.dmn", "/c.json"]);
+        const sut = new VsCodeUI(workspace);
+
+        const result = await sut.pickWorkspaceFiles({
+            glob: "**/*.{form,json,dmn}",
+            placeholder: "pick",
+        });
+
+        expect(result).toEqual(["/a.form", "/b.dmn"]);
+    });
+
+    it("returns [] when the user dismisses the picker", async () => {
+        showQuickPickMock.mockResolvedValue(undefined);
+        const sut = new VsCodeUI(stubWorkspace(["/a.form"]));
+
+        const result = await sut.pickWorkspaceFiles({
+            glob: "**/*.form",
+            placeholder: "pick",
+        });
+
+        expect(result).toEqual([]);
+    });
+
+    it("forwards glob, exclude and limit to the workspace search", async () => {
+        showQuickPickMock.mockResolvedValue(undefined);
+        const workspace = stubWorkspace([]);
+        const sut = new VsCodeUI(workspace);
+
+        await sut.pickWorkspaceFiles({
+            glob: "**/*.{form,json,dmn}",
+            exclude: "**/element-templates/**",
+            placeholder: "pick",
+            limit: 20,
+        });
+
+        expect(workspace.findFiles).toHaveBeenCalledWith(
+            "**/*.{form,json,dmn}",
+            "**/element-templates/**",
+            20,
+        );
+    });
+
+    it("passes the placeholder and multi-select option to the picker", async () => {
+        showQuickPickMock.mockResolvedValue(undefined);
+        const sut = new VsCodeUI(stubWorkspace(["/a.form"]));
+
+        await sut.pickWorkspaceFiles({
+            glob: "**/*.form",
+            placeholder: "Select files",
+        });
+
+        const options = showQuickPickMock.mock.calls[0][1] as {
+            placeHolder: string;
+            canPickMany: boolean;
+            matchOnDescription: boolean;
+        };
+        expect(options.placeHolder).toBe("Select files");
+        expect(options.canPickMany).toBe(true);
+        expect(options.matchOnDescription).toBe(true);
+    });
+
+    it("builds items with basename label and absolute-path description", async () => {
+        showQuickPickMock.mockResolvedValue(undefined);
+        const sut = new VsCodeUI(stubWorkspace(["/repo/src/order.form"]));
+
+        await sut.pickWorkspaceFiles({
+            glob: "**/*.form",
+            placeholder: "pick",
+        });
+
+        const items = showQuickPickMock.mock.calls[0][0] as {
+            label: string;
+            description: string;
+            filePath: string;
+        }[];
+        expect(items).toHaveLength(1);
+        expect(items[0].label).toBe("order.form");
+        expect(items[0].description).toBe("/repo/src/order.form");
+        expect(items[0].filePath).toBe("/repo/src/order.form");
     });
 });

--- a/apps/modeler-plugin/src/infrastructure/VsCodeUI.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeUI.ts
@@ -4,6 +4,7 @@ import { env, Uri, window, workspace } from "vscode";
 
 import { UserCancelledError } from "../domain/errors";
 import { MigrationScope } from "../domain/MigrationPlan";
+import { VsCodeWorkspace } from "./VsCodeWorkspace";
 import { VsCodeLogger, VsCodeTextEditor } from "./window";
 
 import { Engine } from "@miragon/bpmn-modeler-shared";
@@ -11,6 +12,8 @@ export class VsCodeUI {
     private readonly textEditor = new VsCodeTextEditor();
 
     private readonly logger = new VsCodeLogger("bpmn.modeler");
+
+    constructor(private readonly vsWorkspace: VsCodeWorkspace) {}
 
     showInfo(message: string): void {
         window.showInformationMessage(message);
@@ -106,6 +109,38 @@ export class VsCodeUI {
             throw new UserCancelledError();
         }
         return result;
+    }
+
+    /**
+     * Opens a multi-select quick pick over workspace files matching `glob`.
+     *
+     * Composes the workspace search and the picker so callers in `service/`
+     * don't reach into the `vscode` namespace for either step.
+     *
+     * @returns Absolute paths of the chosen files, or `[]` if the user
+     *   dismisses the picker.
+     */
+    async pickWorkspaceFiles(opts: {
+        glob: string;
+        exclude?: string | null;
+        placeholder: string;
+        limit?: number;
+    }): Promise<string[]> {
+        const paths = await this.vsWorkspace.findFiles(opts.glob, opts.exclude, opts.limit);
+
+        const items = paths.map((p) => ({
+            label: posix.basename(p),
+            description: p,
+            filePath: p,
+        }));
+
+        const picked = await window.showQuickPick(items, {
+            canPickMany: true,
+            placeHolder: opts.placeholder,
+            matchOnDescription: true,
+        });
+
+        return picked?.map((item) => item.filePath) ?? [];
     }
 
     /**

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.spec.ts
@@ -30,7 +30,7 @@ describe("VsCodeWorkspace.findFiles", () => {
         const result = await sut.findFiles("**/*.bpmn");
 
         expect(result).toEqual(["/a.bpmn", "/b.bpmn"]);
-        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", undefined);
+        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", undefined, undefined);
     });
 
     it("forwards a glob exclude pattern when supplied", async () => {
@@ -38,7 +38,7 @@ describe("VsCodeWorkspace.findFiles", () => {
 
         await sut.findFiles("**/*.bpmn", "**/dist/**");
 
-        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", "**/dist/**");
+        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", "**/dist/**", undefined);
     });
 
     it("forwards null as exclude to opt out of all default excludes", async () => {
@@ -49,7 +49,15 @@ describe("VsCodeWorkspace.findFiles", () => {
 
         await sut.findFiles("**/*.bpmn", null);
 
-        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", null);
+        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", null, undefined);
+    });
+
+    it("forwards the limit as maxResults to workspace.findFiles", async () => {
+        const sut = new VsCodeWorkspace();
+
+        await sut.findFiles("**/*.bpmn", "**/dist/**", 20);
+
+        expect(findFilesMock).toHaveBeenCalledWith("**/*.bpmn", "**/dist/**", 20);
     });
 
     it("returns the .path of every matching Uri", async () => {

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
@@ -121,10 +121,16 @@ export class VsCodeWorkspace {
      *   {@link workspace.findFiles}.  `undefined` keeps VS Code's default
      *   (`files.exclude` only); a glob string adds those patterns on top;
      *   `null` opts out of every default exclude.
+     * @param limit Optional cap on the number of results returned, forwarded
+     *   as `maxResults` to {@link workspace.findFiles}.
      * @returns An array of absolute file paths.
      */
-    async findFiles(pattern: GlobPattern, exclude?: GlobPattern | null): Promise<string[]> {
-        const uris = await workspace.findFiles(pattern, exclude);
+    async findFiles(
+        pattern: GlobPattern,
+        exclude?: GlobPattern | null,
+        limit?: number,
+    ): Promise<string[]> {
+        const uris = await workspace.findFiles(pattern, exclude, limit);
         return uris.map((uri) => uri.path);
     }
 

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -51,7 +51,7 @@ export function activate(context: ExtensionContext): void {
     const vsWorkspace = new VsCodeWorkspace();
     const vsSettings = new VsCodeSettings();
     const statusBar = new VsCodeStatusBar();
-    const vsUI = new VsCodeUI();
+    const vsUI = new VsCodeUI(vsWorkspace);
     const deploymentState = new VsCodeDeploymentState();
     const compareSelection = new CompareSelectionStore();
     const secretStore = new VsCodeSecretStore();

--- a/apps/modeler-plugin/src/service/DeploymentService.ts
+++ b/apps/modeler-plugin/src/service/DeploymentService.ts
@@ -1,5 +1,4 @@
 import * as path from "path";
-import { Uri, window, workspace } from "vscode";
 
 import { AuthConfigPayload, DeploymentFormDefaults, Engine } from "@miragon/bpmn-modeler-shared";
 
@@ -113,40 +112,19 @@ export class DeploymentService {
     }
 
     /**
-     * Opens a VS Code QuickPick (multi-select) showing workspace files that
-     * are relevant for deployment (`.form`, `.json`, `.dmn`).
-     *
-     * Uses `workspace.findFiles` from the VS Code API directly to search across
-     * all workspace folders without requiring a dedicated method on
-     * {@link VsCodeWorkspace}.
+     * Opens a multi-select picker over workspace files relevant for
+     * deployment (`.form`, `.json`, `.dmn`), excluding element templates.
      *
      * @returns Absolute paths of the selected files, or an empty array if the
      *   user cancels or no files match.
      */
     async selectAdditionalFiles(): Promise<string[]> {
-        const uris: Uri[] = await workspace.findFiles(
-            "**/*.{form,json,dmn}",
-            "**/element-templates/**",
-            20,
-        );
-
-        const items = uris.map((uri) => ({
-            label: path.basename(uri.fsPath),
-            description: uri.fsPath,
-            filePath: uri.fsPath,
-        }));
-
-        const selected = await window.showQuickPick(items, {
-            canPickMany: true,
-            placeHolder: "Select additional files to include in the deployment",
-            matchOnDescription: true,
+        return this.vsUI.pickWorkspaceFiles({
+            glob: "**/*.{form,json,dmn}",
+            exclude: "**/element-templates/**",
+            placeholder: "Select additional files to include in the deployment",
+            limit: 20,
         });
-
-        if (!selected) {
-            return [];
-        }
-
-        return selected.map((item) => item.filePath);
     }
 
     /**


### PR DESCRIPTION
**Issue**

Closes: #1033

**Description**

Extract file picking logic from DeploymentService into a new
`pickWorkspaceFiles` method on VsCodeUI to improve separation of concerns.

- Add VsCodeWorkspace dependency to VsCodeUI constructor
- Implement pickWorkspaceFiles method supporting glob, exclude, limit, and
  placeholder options
- Update VsCodeWorkspace.findFiles to accept optional limit parameter
- Refactor DeploymentService.selectAdditionalFiles to use new UI method
- Update all VsCodeUI instantiation sites to pass VsCodeWorkspace

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
