### PR TITLE
refactor(diff): decouple session from vscode APIs via DiffPaneHandle

### DIFF
--- a/apps/modeler-plugin/src/controller/BpmnEditorController.navigate.spec.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.navigate.spec.ts
@@ -83,7 +83,7 @@ describe("BpmnEditorController — NavigateToReferencedModelCommand dispatch", (
         expect(modelNavigationService.navigate).toHaveBeenCalledWith(
             "ProcessB",
             "process",
-            documentUri,
+            documentUri.fsPath,
         );
     });
 
@@ -104,7 +104,7 @@ describe("BpmnEditorController — NavigateToReferencedModelCommand dispatch", (
         expect(modelNavigationService.navigate).toHaveBeenCalledWith(
             "Decision_1",
             "decision",
-            documentUri,
+            documentUri.fsPath,
         );
     });
 

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -233,7 +233,7 @@ export class BpmnEditorController implements CustomTextEditorProvider {
                     await this.modelNavigationService.navigate(
                         cmd.referenceId,
                         cmd.referenceKind,
-                        sourceDocument.uri,
+                        sourceDocument.uri.fsPath,
                     );
                     break;
                 }

--- a/apps/modeler-plugin/src/infrastructure/VsCodeNotifier.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeNotifier.ts
@@ -1,4 +1,4 @@
-import { LogOutputChannel, window } from "vscode";
+import { commands, LogOutputChannel, ProgressLocation, Uri, window } from "vscode";
 
 const LOG_CHANNEL_ID = "bpmn.modeler";
 const LOG_PREFIX = `[${LOG_CHANNEL_ID}] `;
@@ -40,5 +40,26 @@ export class VsCodeNotifier {
 
     logError(error: Error): void {
         this.channel.error(LOG_PREFIX, error);
+    }
+
+    /**
+     * Runs `task` while showing a status-bar progress indicator titled
+     * `title`. Status-bar location (`ProgressLocation.Window`) is the only
+     * surface this adapter exposes — the modal/notification variants belong
+     * on a future Picker or modal helper if a caller ever needs them.
+     */
+    withProgress<T>(title: string, task: () => Promise<T>): Promise<T> {
+        return Promise.resolve(
+            window.withProgress({ location: ProgressLocation.Window, title }, task),
+        );
+    }
+
+    /**
+     * Opens the file at `absolutePath` in its registered (custom) editor via
+     * the built-in `vscode.open` command. Centralised here so service callers
+     * stay free of `commands` and `Uri`.
+     */
+    async openDocument(absolutePath: string): Promise<void> {
+        await commands.executeCommand("vscode.open", Uri.file(absolutePath));
     }
 }

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
@@ -1,6 +1,6 @@
 import { posix } from "path";
 
-import { FileType, GlobPattern, Uri, workspace } from "vscode";
+import { FileType, GlobPattern, RelativePattern, Uri, workspace } from "vscode";
 
 import { DirectoryNotFound, FileNotFound, NoWorkspaceFolderFoundError } from "../domain/errors";
 
@@ -132,6 +132,44 @@ export class VsCodeWorkspace {
     ): Promise<string[]> {
         const uris = await workspace.findFiles(pattern, exclude, limit);
         return uris.map((uri) => uri.path);
+    }
+
+    /**
+     * Creates a workspace-scoped filesystem watcher for `glob` rooted at
+     * `rootPath`. Hides `workspace.createFileSystemWatcher` + `RelativePattern`
+     * and the `Uri`-typed event payloads so service callers stay free of
+     * `vscode` imports — handlers receive the absolute `uri.fsPath` string.
+     *
+     * The returned handle disposes the underlying watcher and unsubscribes
+     * the wired listeners in one call.
+     */
+    createWatcher(
+        rootPath: string,
+        glob: string,
+        handlers: {
+            onChange?: (path: string) => void;
+            onCreate?: (path: string) => void;
+            onDelete?: (path: string) => void;
+        },
+    ): { dispose(): void } {
+        const watcher = workspace.createFileSystemWatcher(new RelativePattern(rootPath, glob));
+        const subscriptions: { dispose(): void }[] = [watcher];
+        if (handlers.onCreate) {
+            subscriptions.push(watcher.onDidCreate((uri) => handlers.onCreate!(uri.fsPath)));
+        }
+        if (handlers.onChange) {
+            subscriptions.push(watcher.onDidChange((uri) => handlers.onChange!(uri.fsPath)));
+        }
+        if (handlers.onDelete) {
+            subscriptions.push(watcher.onDidDelete((uri) => handlers.onDelete!(uri.fsPath)));
+        }
+        return {
+            dispose(): void {
+                for (const s of subscriptions) {
+                    s.dispose();
+                }
+            },
+        };
     }
 
     /**

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
@@ -154,14 +154,15 @@ export class VsCodeWorkspace {
     ): { dispose(): void } {
         const watcher = workspace.createFileSystemWatcher(new RelativePattern(rootPath, glob));
         const subscriptions: { dispose(): void }[] = [watcher];
-        if (handlers.onCreate) {
-            subscriptions.push(watcher.onDidCreate((uri) => handlers.onCreate!(uri.fsPath)));
+        const { onCreate, onChange, onDelete } = handlers;
+        if (onCreate) {
+            subscriptions.push(watcher.onDidCreate((uri) => onCreate(uri.fsPath)));
         }
-        if (handlers.onChange) {
-            subscriptions.push(watcher.onDidChange((uri) => handlers.onChange!(uri.fsPath)));
+        if (onChange) {
+            subscriptions.push(watcher.onDidChange((uri) => onChange(uri.fsPath)));
         }
-        if (handlers.onDelete) {
-            subscriptions.push(watcher.onDidDelete((uri) => handlers.onDelete!(uri.fsPath)));
+        if (onDelete) {
+            subscriptions.push(watcher.onDidDelete((uri) => onDelete(uri.fsPath)));
         }
         return {
             dispose(): void {

--- a/apps/modeler-plugin/src/service/ArtifactService.ts
+++ b/apps/modeler-plugin/src/service/ArtifactService.ts
@@ -1,7 +1,5 @@
 import { posix } from "path";
 
-import { Disposable, RelativePattern, workspace } from "vscode";
-
 import { DirectoryNotFound, NoWorkspaceFolderFoundError } from "../domain/errors";
 import { VsCodeWorkspace } from "../infrastructure/VsCodeWorkspace";
 import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
@@ -15,7 +13,7 @@ export interface ArtifactChangeTarget {
 }
 
 export interface WatcherResult {
-    disposables: Disposable[];
+    disposables: { dispose(): void }[];
     errors: Error[];
 }
 
@@ -144,15 +142,13 @@ export class ArtifactService {
         const workspaceRoot = await this.getWorkspaceRoot(documentDir);
 
         const pattern = `**/${configFolder}/element-templates/**/*.json`;
-        const watcher = workspace.createFileSystemWatcher(
-            new RelativePattern(workspaceRoot, pattern),
-        );
+        const handle = this.vsWorkspace.createWatcher(workspaceRoot, pattern, {
+            onCreate: () => void target.setElementTemplates(editorId),
+            onChange: () => void target.setElementTemplates(editorId),
+            onDelete: () => void target.setElementTemplates(editorId),
+        });
 
-        watcher.onDidCreate(() => target.setElementTemplates(editorId));
-        watcher.onDidChange(() => target.setElementTemplates(editorId));
-        watcher.onDidDelete(() => target.setElementTemplates(editorId));
-
-        return { disposables: [watcher], errors: [] };
+        return { disposables: [handle], errors: [] };
     }
 
     async readDirectory(folder: string, extension: string): Promise<string[]> {

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -40,7 +40,45 @@ import { bootstrapWebview } from "../infrastructure/bootstrapWebview";
 import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
 import { BpmnDocument } from "../domain/BpmnDocument";
-import { DiffPaneEntry, DiffSession } from "./DiffSession";
+import { DiffPaneHandle, DiffSession } from "./DiffSession";
+
+/**
+ * Infrastructure adapter that wraps a real `WebviewPanel` + `TextDocument`
+ * pair into the {@link DiffPaneHandle} the session uses. Lives next to the
+ * service so the rest of the diff machinery can stay vscode-free.
+ */
+class WebviewPaneHandle implements DiffPaneHandle {
+    private readyFlag = false;
+
+    constructor(
+        readonly panel: WebviewPanel,
+        readonly document: TextDocument,
+    ) {}
+
+    get uri(): string {
+        return this.document.uri.toString();
+    }
+
+    isReady(): boolean {
+        return this.readyFlag;
+    }
+
+    setReady(): void {
+        this.readyFlag = true;
+    }
+
+    getText(): string {
+        return this.document.getText();
+    }
+
+    postMessage(msg: unknown): Promise<boolean> {
+        return Promise.resolve(this.panel.webview.postMessage(msg));
+    }
+
+    dispose(): void {
+        this.panel.dispose();
+    }
+}
 
 const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
 
@@ -71,7 +109,7 @@ const COMPARE_FILES_TTL_MS = 30_000;
  * into a full {@link DiffSession} and register it.
  */
 interface PendingScmPane {
-    readonly entry: DiffPaneEntry;
+    readonly handle: WebviewPaneHandle;
 }
 
 /**
@@ -165,7 +203,7 @@ export class BpmnDiffService {
      *   ignore the return value).
      */
     registerCompareFilesSession(leftUri: Uri, rightUri: Uri): DiffSession {
-        const session = DiffSession.forCompareFiles(leftUri, rightUri);
+        const session = DiffSession.forCompareFiles(leftUri.toString(), rightUri.toString());
         this.indexSession(session);
         this.ttlTimers.set(
             session,
@@ -190,7 +228,7 @@ export class BpmnDiffService {
      */
     async openCompareFilesDiff(leftUri: Uri, rightUri: Uri): Promise<void> {
         this.registerCompareFilesSession(leftUri, rightUri);
-        const title = `${basenameOfUri(leftUri)} ↔ ${basenameOfUri(rightUri)}`;
+        const title = `${this.basenameOfUriString(leftUri.toString())} ↔ ${this.basenameOfUriString(rightUri.toString())}`;
         try {
             await commands.executeCommand("vscode.diff", leftUri, rightUri, title, {
                 preview: false,
@@ -208,6 +246,16 @@ export class BpmnDiffService {
      */
     findSessionFor(uri: Uri): DiffSession | undefined {
         return this.sessionByUri.get(uri.toString());
+    }
+
+    private basenameOfUriString(uri: string): string {
+        // Trim query/fragment so e.g. `file:///foo.bpmn?ref=HEAD` still
+        // resolves to `foo.bpmn`. `Uri.toString()` keeps `?` / `#` for any
+        // host that uses them; the bare path is what users see in the tab.
+        const noFragment = uri.split("#")[0];
+        const noQuery = noFragment.split("?")[0];
+        const parts = noQuery.split("/");
+        return decodeURIComponent(parts[parts.length - 1] ?? "");
     }
 
     /**
@@ -254,7 +302,7 @@ export class BpmnDiffService {
      * differ.
      */
     isPartOfDiff(uri: Uri): boolean {
-        const basename = basenameOfUri(uri);
+        const basename = this.basenameOfUriString(uri.toString());
         if (!basename.endsWith(".bpmn")) {
             return false;
         }
@@ -278,11 +326,11 @@ export class BpmnDiffService {
     hasPaneForUri(uri: Uri): boolean {
         const needle = uri.toString();
         const session = this.sessionByUri.get(needle);
-        if (session?.hasPaneFor(uri)) {
+        if (session?.hasPaneFor(needle)) {
             return true;
         }
         for (const pending of this.pendingScm.values()) {
-            if (pending.entry.document.uri.toString() === needle) {
+            if (pending.handle.uri === needle) {
                 return true;
             }
         }
@@ -307,21 +355,17 @@ export class BpmnDiffService {
         // drops webview-originated messages that arrive before the extension
         // has subscribed, and bootstrapping triggers an immediate
         // `GetBpmnFileCommand` as soon as the webview's scripts run.
-        const entry: DiffPaneEntry = {
-            panel,
-            document,
-            ready: false,
-        };
+        const handle = new WebviewPaneHandle(panel, document);
 
-        panel.webview.onDidReceiveMessage((message: Command) => this.onMessage(entry, message));
-        panel.onDidDispose(() => this.disposePane(entry));
+        panel.webview.onDidReceiveMessage((message: Command) => this.onMessage(handle, message));
+        panel.onDidDispose(() => this.disposePane(handle));
 
         const session = this.findSessionFor(document.uri);
         if (session) {
-            session.attachPane(entry);
+            session.attachPane(handle);
             this.cancelTtl(session);
         } else {
-            this.attachOrPendScmPane(entry);
+            this.attachOrPendScmPane(handle);
         }
 
         bootstrapWebview(BPMN_VIEW_TYPE, panel);
@@ -338,17 +382,18 @@ export class BpmnDiffService {
      *     `before`, second is `after` — arbitrary but matches the visual
      *     order VS Code's SCM diff chose.
      */
-    private attachOrPendScmPane(entry: DiffPaneEntry): void {
-        const key = this.scmPairingKey(entry.document.uri);
+    private attachOrPendScmPane(handle: WebviewPaneHandle): void {
+        const key = this.scmPairingKey(handle.document.uri);
         const pending = this.pendingScm.get(key);
 
         if (!pending) {
-            this.pendingScm.set(key, { entry });
+            this.pendingScm.set(key, { handle });
             return;
         }
 
         this.pendingScm.delete(key);
-        const { session, before, after } = DiffSession.forScm(pending.entry, entry);
+        const { before, after } = resolveScmSides(pending.handle, handle);
+        const session = DiffSession.forScm(before, after);
         session.attachPane(before);
         session.attachPane(after);
         this.indexSession(session);
@@ -375,12 +420,12 @@ export class BpmnDiffService {
      */
     private indexSession(session: DiffSession): void {
         this.sessions.set(this.sessionIdOf(session), session);
-        this.sessionByUri.set(session.beforeUri.toString(), session);
-        this.sessionByUri.set(session.afterUri.toString(), session);
+        this.sessionByUri.set(session.beforeUri, session);
+        this.sessionByUri.set(session.afterUri, session);
     }
 
     private sessionIdOf(session: DiffSession): string {
-        return `${session.beforeUri.toString()}|${session.afterUri.toString()}`;
+        return `${session.beforeUri}|${session.afterUri}`;
     }
 
     private cancelTtl(session: DiffSession): void {
@@ -397,51 +442,51 @@ export class BpmnDiffService {
             return;
         }
         this.sessions.delete(this.sessionIdOf(session));
-        this.sessionByUri.delete(session.beforeUri.toString());
-        this.sessionByUri.delete(session.afterUri.toString());
+        this.sessionByUri.delete(session.beforeUri);
+        this.sessionByUri.delete(session.afterUri);
     }
 
-    private disposePane(entry: DiffPaneEntry): void {
+    private disposePane(handle: DiffPaneHandle): void {
         /**
          * Drop from pending (no session ever formed)
          */
         for (const [key, pending] of this.pendingScm) {
-            if (pending.entry === entry) {
+            if (pending.handle === handle) {
                 this.pendingScm.delete(key);
                 return;
             }
         }
 
         // Drop from session; retire the session if both panes are gone.
-        const session = this.sessionByUri.get(entry.document.uri.toString());
+        const session = this.sessionByUri.get(handle.uri);
         if (!session) {
             return;
         }
-        session.detachPane(entry);
+        session.detachPane(handle);
         if (session.isEmpty()) {
             this.sessions.delete(this.sessionIdOf(session));
-            this.sessionByUri.delete(session.beforeUri.toString());
-            this.sessionByUri.delete(session.afterUri.toString());
+            this.sessionByUri.delete(session.beforeUri);
+            this.sessionByUri.delete(session.afterUri);
             this.cancelTtl(session);
         }
     }
 
-    private async onMessage(entry: DiffPaneEntry, message: Command): Promise<void> {
+    private async onMessage(handle: DiffPaneHandle, message: Command): Promise<void> {
         switch (message.type) {
             case "GetBpmnFileCommand":
-                await this.sendViewerFile(entry);
+                await this.sendViewerFile(handle);
                 break;
             case "DiffReadyCommand":
-                await this.markReady(entry);
+                await this.markReady(handle);
                 break;
             case "ViewportChangedCommand":
-                await this.forwardViewport(entry, (message as ViewportChangedCommand).viewport);
+                await this.forwardViewport(handle, (message as ViewportChangedCommand).viewport);
                 break;
             case "CursorChangedCommand":
-                await this.forwardCursor(entry, (message as CursorChangedCommand).index);
+                await this.forwardCursor(handle, (message as CursorChangedCommand).index);
                 break;
             case "SwapCompareSidesCommand":
-                await this.swapCompareFilesSides(entry);
+                await this.swapCompareFilesSides(handle);
                 break;
         }
     }
@@ -460,16 +505,16 @@ export class BpmnDiffService {
      * subsequent `openCompareFilesDiff` then registers a fresh session with
      * the reversed before/after assignment.
      */
-    private async swapCompareFilesSides(entry: DiffPaneEntry): Promise<void> {
-        const session = this.sessionByUri.get(entry.document.uri.toString());
+    private async swapCompareFilesSides(handle: DiffPaneHandle): Promise<void> {
+        const session = this.sessionByUri.get(handle.uri);
         if (!session || session.origin !== "compare-files") {
             return;
         }
         const { beforeUri, afterUri } = session;
         for (const pane of session.attachedPanes()) {
-            pane.panel.dispose();
+            pane.dispose();
         }
-        await this.openCompareFilesDiff(afterUri, beforeUri);
+        await this.openCompareFilesDiff(Uri.parse(afterUri), Uri.parse(beforeUri));
     }
 
     /**
@@ -478,26 +523,26 @@ export class BpmnDiffService {
      * an execution-platform attribute fall back to `"c7"`, since viewer mode
      * does not render engine-specific extensions anyway.
      */
-    private async sendViewerFile(entry: DiffPaneEntry): Promise<void> {
+    private async sendViewerFile(handle: DiffPaneHandle): Promise<void> {
         try {
-            const content = entry.document.getText();
+            const content = handle.getText();
             let engine: Engine;
             try {
                 engine = new BpmnDocument(content).detectPlatform();
             } catch {
                 engine = "c7";
             }
-            await entry.panel.webview.postMessage(new BpmnFileQuery(content, engine, "viewer"));
+            await handle.postMessage(new BpmnFileQuery(content, engine, "viewer"));
         } catch (error) {
             this.notifier.logError(error as Error);
         }
     }
 
-    private async markReady(entry: DiffPaneEntry): Promise<void> {
-        entry.ready = true;
-        await this.sendLanguage(entry);
+    private async markReady(handle: DiffPaneHandle): Promise<void> {
+        handle.setReady();
+        await this.sendLanguage(handle);
 
-        const session = this.sessionByUri.get(entry.document.uri.toString());
+        const session = this.sessionByUri.get(handle.uri);
         if (!session || !session.isArmed()) {
             return;
         }
@@ -514,9 +559,9 @@ export class BpmnDiffService {
      * when the pane is hidden or already disposed — the pane will request the
      * language again on its next resolve.
      */
-    private async sendLanguage(entry: DiffPaneEntry): Promise<void> {
+    private async sendLanguage(handle: DiffPaneHandle): Promise<void> {
         try {
-            await entry.panel.webview.postMessage(new LanguageQuery(this.vsSettings.getLanguage()));
+            await handle.postMessage(new LanguageQuery(this.vsSettings.getLanguage()));
         } catch (error) {
             this.notifier.logInfo(`setLanguage dropped: ${(error as Error).message}`);
         }
@@ -532,9 +577,9 @@ export class BpmnDiffService {
             return;
         }
         for (const session of this.sessions.values()) {
-            for (const entry of session.attachedPanes()) {
-                if (entry.ready) {
-                    void this.sendLanguage(entry);
+            for (const handle of session.attachedPanes()) {
+                if (handle.isReady()) {
+                    void this.sendLanguage(handle);
                 }
             }
         }
@@ -545,15 +590,15 @@ export class BpmnDiffService {
      * in lockstep.  Silently drops posts when the partner is hidden or gone.
      */
     private async forwardViewport(
-        entry: DiffPaneEntry,
+        handle: DiffPaneHandle,
         viewport: ViewportChangedCommand["viewport"],
     ): Promise<void> {
-        const partner = this.partnerOf(entry);
+        const partner = this.partnerOf(handle);
         if (!partner) {
             return;
         }
         try {
-            await partner.panel.webview.postMessage(new SyncViewportQuery(viewport));
+            await partner.postMessage(new SyncViewportQuery(viewport));
         } catch (error) {
             this.notifier.logInfo(`syncViewport dropped: ${(error as Error).message}`);
         }
@@ -564,21 +609,21 @@ export class BpmnDiffService {
      * navigation stays in lockstep.  Mirrors {@link forwardViewport} — same
      * partner lookup, same drop-silently-on-failure semantics.
      */
-    private async forwardCursor(entry: DiffPaneEntry, index: number): Promise<void> {
-        const partner = this.partnerOf(entry);
+    private async forwardCursor(handle: DiffPaneHandle, index: number): Promise<void> {
+        const partner = this.partnerOf(handle);
         if (!partner) {
             return;
         }
         try {
-            await partner.panel.webview.postMessage(new SyncCursorQuery(index));
+            await partner.postMessage(new SyncCursorQuery(index));
         } catch (error) {
             this.notifier.logInfo(`syncCursor dropped: ${(error as Error).message}`);
         }
     }
 
-    private partnerOf(entry: DiffPaneEntry): DiffPaneEntry | undefined {
-        const session = this.sessionByUri.get(entry.document.uri.toString());
-        return session?.partnerOf(entry);
+    private partnerOf(handle: DiffPaneHandle): DiffPaneHandle | undefined {
+        const session = this.sessionByUri.get(handle.uri);
+        return session?.partnerOf(handle);
     }
 
     /**
@@ -591,11 +636,11 @@ export class BpmnDiffService {
      */
     private async computeAndBroadcast(
         session: DiffSession,
-        before: DiffPaneEntry,
-        after: DiffPaneEntry,
+        before: DiffPaneHandle,
+        after: DiffPaneHandle,
     ): Promise<void> {
-        const beforeXml = before.document.getText();
-        const afterXml = after.document.getText();
+        const beforeXml = before.getText();
+        const afterXml = after.getText();
 
         let beforeDefs: unknown;
         let afterDefs: unknown;
@@ -673,7 +718,7 @@ export class BpmnDiffService {
         const navigationOrder = sortIdsByOrder(merged, afterOrder, removedAnchors);
 
         await this.postHighlights(
-            before.panel,
+            before,
             new ApplyDiffHighlightsQuery(
                 "before",
                 [],
@@ -683,11 +728,11 @@ export class BpmnDiffService {
                 counts,
                 navigationOrder,
                 session.origin,
-                basenameOfUri(before.document.uri),
+                this.basenameOfUriString(before.uri),
             ),
         );
         await this.postHighlights(
-            after.panel,
+            after,
             new ApplyDiffHighlightsQuery(
                 "after",
                 sortedAdded,
@@ -697,24 +742,43 @@ export class BpmnDiffService {
                 counts,
                 navigationOrder,
                 session.origin,
-                basenameOfUri(after.document.uri),
+                this.basenameOfUriString(after.uri),
             ),
         );
     }
 
     private async postHighlights(
-        panel: WebviewPanel,
+        handle: DiffPaneHandle,
         query: ApplyDiffHighlightsQuery,
     ): Promise<void> {
         try {
-            await panel.webview.postMessage(query);
+            await handle.postMessage(query);
         } catch (error) {
             this.notifier.logInfo(`ApplyDiffHighlights dropped: ${(error as Error).message}`);
         }
     }
 }
 
-function basenameOfUri(uri: Uri): string {
-    const parts = uri.path.split("/");
-    return parts[parts.length - 1] ?? "";
+/**
+ * SCM-diff side assignment for two panes that share a path.
+ *
+ * Invariant: `file:` URIs represent the working tree and must be `after`.
+ * For ref-vs-ref diffs (both `git:` in VS Code, both `gitfs:` in Theia) side
+ * follows resolution order, which mirrors the host's own visual ordering.
+ *
+ * Lives in the infrastructure-adjacent half of this file because it reads
+ * `document.uri.scheme` from the vscode-typed handle; pushing it into the
+ * vscode-free {@link DiffSession} would require parsing the string URI.
+ */
+function resolveScmSides(
+    first: WebviewPaneHandle,
+    second: WebviewPaneHandle,
+): { before: WebviewPaneHandle; after: WebviewPaneHandle } {
+    if (second.document.uri.scheme === "file") {
+        return { before: first, after: second };
+    }
+    if (first.document.uri.scheme === "file") {
+        return { before: second, after: first };
+    }
+    return { before: first, after: second };
 }

--- a/apps/modeler-plugin/src/service/DiffSession.ts
+++ b/apps/modeler-plugin/src/service/DiffSession.ts
@@ -1,29 +1,40 @@
-import { TextDocument, Uri, WebviewPanel } from "vscode";
-
 import { DiffOrigin, DiffSide } from "@miragon/bpmn-modeler-shared";
 
 export { DiffOrigin };
 
 /**
- * A single webview pane inside a diff session.
+ * Domain handle for a single diff pane.
  *
- * `ready` flips to `true` once the webview has imported its XML and emitted
- * `DiffReadyCommand`.  The session is armed — and the differ runs — when both
- * panes report ready.
+ * Wraps whatever the host gave us (in production: a `WebviewPanel` +
+ * `TextDocument` pair — see `WebviewPaneHandle` in {@link BpmnDiffService}).
+ * The session sees only this handle, which lets `DiffSession` stay free of
+ * `vscode` imports and lets tests substitute a plain object.
+ *
+ * `uri` is the canonical identity used by the session's lookups — it must
+ * be the stringified URI of the underlying document (i.e.
+ * `document.uri.toString()`).
  */
-export interface DiffPaneEntry {
-    readonly panel: WebviewPanel;
-    readonly document: TextDocument;
-    ready: boolean;
+export interface DiffPaneHandle {
+    readonly uri: string;
+    /**
+     * `true` once the webview has imported its XML and emitted
+     * `DiffReadyCommand`. The session is armed — and the differ runs —
+     * when both panes report ready.
+     */
+    isReady(): boolean;
+    setReady(): void;
+    getText(): string;
+    postMessage(msg: unknown): Promise<boolean>;
+    dispose(): void;
 }
 
 /**
- * A paired BPMN diff view — the domain object the rest of the service
- * revolves around.
+ * A paired BPMN diff view — the domain object the diff service revolves
+ * around.
  *
- * Promotes what used to be implicit pairing (mutual `partner` pointers on two
- * `DiffPaneEntry` records) into an explicit object that owns both URIs and
- * both pane slots.  A session can exist with zero, one, or two attached panes
+ * Promotes what used to be implicit pairing (mutual `partner` pointers on
+ * two pane records) into an explicit object that owns both URIs and both
+ * pane slots. A session can exist with zero, one, or two attached panes
  * — this matters because:
  *
  * - `compare-files` sessions are created up front with both URIs known but
@@ -34,75 +45,63 @@ export interface DiffPaneEntry {
  *
  * Side assignment is fixed at construction time — `before` and `after` are
  * inherent to the session, not inferred from the pane that attaches first.
- * This is the key change versus the previous scheme-based heuristic, which
- * could not discriminate two `file:` URIs.
  */
 export class DiffSession {
     // Wall-clock ms at construction — used by the TTL sweeper in the service.
     readonly createdAt: number = Date.now();
 
-    private beforePane?: DiffPaneEntry;
+    private beforePane?: DiffPaneHandle;
 
-    private afterPane?: DiffPaneEntry;
+    private afterPane?: DiffPaneHandle;
 
     /**
      * Prefer the origin-specific factories ({@link forCompareFiles},
      * {@link forScm}) over calling this directly — they encapsulate each
      * origin's side-assignment rule.
      *
-     * @param origin How this session came to be.  Surfaces in the diff-legend
+     * @param origin How this session came to be. Surfaces in the diff-legend
      *   UI so compare-files panes can show origin-specific affordances (the
      *   filename label, the swap button) that don't apply to SCM diffs.
-     * @param beforeUri URI rendered in the left pane.
-     * @param afterUri URI rendered in the right pane.
+     * @param beforeUri Stringified URI rendered in the left pane.
+     * @param afterUri Stringified URI rendered in the right pane.
      */
     constructor(
         readonly origin: DiffOrigin,
-        readonly beforeUri: Uri,
-        readonly afterUri: Uri,
+        readonly beforeUri: string,
+        readonly afterUri: string,
     ) {}
 
     /**
      * Builds a `compare-files` session with the caller's left/right order
-     * fixed as before/after.  Matches the visual order VS Code renders
+     * fixed as before/after. Matches the visual order VS Code renders
      * `vscode.diff(a, b)` in — no inference is necessary because the
      * extension itself supplied both URIs.
      */
-    static forCompareFiles(leftUri: Uri, rightUri: Uri): DiffSession {
+    static forCompareFiles(leftUri: string, rightUri: string): DiffSession {
         return new DiffSession("compare-files", leftUri, rightUri);
     }
 
     /**
-     * Builds an `scm` session from the two panes VS Code handed us, applying
-     * the SCM side-assignment rule:
-     *
-     *   - If one URI is `file:` it is the working tree → `after`.
-     *   - Otherwise (ref-vs-ref, both `git:` / both `gitfs:`) the
-     *     first-resolved pane is `before`, second is `after` — arbitrary but
-     *     matches the visual order VS Code's / Theia's SCM diff chose.
-     *
-     * The panes are returned alongside the session so the caller can attach
-     * them without re-deriving the pairing.
+     * Builds an `scm` session from the two panes the caller has already
+     * sorted into before/after roles. The SCM side-assignment rule (working
+     * tree `file:` → `after`; ref-vs-ref → resolution order) lives in the
+     * caller because it needs the URI scheme, which a string-typed handle
+     * exposes only by parsing — cleaner to do it once where vscode `Uri` is
+     * still in scope.
      */
-    static forScm(
-        first: DiffPaneEntry,
-        second: DiffPaneEntry,
-    ): { session: DiffSession; before: DiffPaneEntry; after: DiffPaneEntry } {
-        const { before, after } = resolveScmSides(first, second);
-        const session = new DiffSession("scm", before.document.uri, after.document.uri);
-        return { session, before, after };
+    static forScm(before: DiffPaneHandle, after: DiffPaneHandle): DiffSession {
+        return new DiffSession("scm", before.uri, after.uri);
     }
 
     /**
      * Returns the canonical side for the given URI, or `undefined` when the
      * URI belongs to neither slot of this session.
      */
-    sideFor(uri: Uri): DiffSide | undefined {
-        const needle = uri.toString();
-        if (needle === this.beforeUri.toString()) {
+    sideFor(uri: string): DiffSide | undefined {
+        if (uri === this.beforeUri) {
             return "before";
         }
-        if (needle === this.afterUri.toString()) {
+        if (uri === this.afterUri) {
             return "after";
         }
         return undefined;
@@ -111,7 +110,7 @@ export class DiffSession {
     /**
      * Returns `true` when a pane has already attached for `uri`'s side.
      */
-    hasPaneFor(uri: Uri): boolean {
+    hasPaneFor(uri: string): boolean {
         const side = this.sideFor(uri);
         if (side === "before") {
             return this.beforePane !== undefined;
@@ -123,32 +122,32 @@ export class DiffSession {
     }
 
     /**
-     * Attaches `entry` to the slot matching its document URI.
+     * Attaches `handle` to the slot matching its URI.
      *
-     * @returns The assigned side, or `undefined` when the entry's URI does
-     *   not belong to this session.  Callers should treat `undefined` as a
-     *   programming error — only the owning {@link BpmnDiffService} should
-     *   be attaching panes, and it should only do so after a successful
+     * @returns The assigned side, or `undefined` when the handle's URI does
+     *   not belong to this session. Callers should treat `undefined` as a
+     *   programming error — only the owning diff service should be
+     *   attaching panes, and it should only do so after a successful
      *   session lookup.
      */
-    attachPane(entry: DiffPaneEntry): DiffSide | undefined {
-        const side = this.sideFor(entry.document.uri);
+    attachPane(handle: DiffPaneHandle): DiffSide | undefined {
+        const side = this.sideFor(handle.uri);
         if (side === "before") {
-            this.beforePane = entry;
+            this.beforePane = handle;
         } else if (side === "after") {
-            this.afterPane = entry;
+            this.afterPane = handle;
         }
         return side;
     }
 
     /**
-     * Drops `entry` from whichever slot held it (no-op if unknown).
+     * Drops `handle` from whichever slot held it (no-op if unknown).
      */
-    detachPane(entry: DiffPaneEntry): void {
-        if (this.beforePane === entry) {
+    detachPane(handle: DiffPaneHandle): void {
+        if (this.beforePane === handle) {
             this.beforePane = undefined;
         }
-        if (this.afterPane === entry) {
+        if (this.afterPane === handle) {
             this.afterPane = undefined;
         }
     }
@@ -156,11 +155,11 @@ export class DiffSession {
     /**
      * Returns the opposite pane, or `undefined` when unpaired.
      */
-    partnerOf(entry: DiffPaneEntry): DiffPaneEntry | undefined {
-        if (this.beforePane === entry) {
+    partnerOf(handle: DiffPaneHandle): DiffPaneHandle | undefined {
+        if (this.beforePane === handle) {
             return this.afterPane;
         }
-        if (this.afterPane === entry) {
+        if (this.afterPane === handle) {
             return this.beforePane;
         }
         return undefined;
@@ -169,22 +168,22 @@ export class DiffSession {
     /**
      * The before-side pane, or `undefined` when not yet attached.
      */
-    before(): DiffPaneEntry | undefined {
+    before(): DiffPaneHandle | undefined {
         return this.beforePane;
     }
 
     /**
      * The after-side pane, or `undefined` when not yet attached.
      */
-    after(): DiffPaneEntry | undefined {
+    after(): DiffPaneHandle | undefined {
         return this.afterPane;
     }
 
     /**
      * All currently-attached panes (0 to 2).
      */
-    attachedPanes(): DiffPaneEntry[] {
-        const panes: DiffPaneEntry[] = [];
+    attachedPanes(): DiffPaneHandle[] {
+        const panes: DiffPaneHandle[] = [];
         if (this.beforePane) {
             panes.push(this.beforePane);
         }
@@ -208,28 +207,8 @@ export class DiffSession {
         return (
             this.beforePane !== undefined &&
             this.afterPane !== undefined &&
-            this.beforePane.ready &&
-            this.afterPane.ready
+            this.beforePane.isReady() &&
+            this.afterPane.isReady()
         );
     }
-}
-
-/**
- * Resolves SCM-diff side assignment for two panes that share a path.
- *
- * Invariant: `file:` URIs represent the working tree and must be `after`.
- * For ref-vs-ref diffs (both `git:` in VS Code, both `gitfs:` in Theia) side
- * follows resolution order, which mirrors the host's own visual ordering.
- */
-function resolveScmSides(
-    first: DiffPaneEntry,
-    second: DiffPaneEntry,
-): { before: DiffPaneEntry; after: DiffPaneEntry } {
-    if (second.document.uri.scheme === "file") {
-        return { before: first, after: second };
-    }
-    if (first.document.uri.scheme === "file") {
-        return { before: second, after: first };
-    }
-    return { before: first, after: second };
 }

--- a/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
@@ -1,16 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("vscode", () => ({
-    commands: { executeCommand: vi.fn() },
-    Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
-    ProgressLocation: { SourceControl: 1, Window: 10, Notification: 15 },
-    window: {
-        withProgress: <T>(_opts: unknown, task: () => Promise<T>): Promise<T> => task(),
-    },
-}));
-
-import { commands, ProgressLocation, window } from "vscode";
-
 import { ModelNavigationService } from "./ModelNavigationService";
 import { LocateResult } from "./modelNavigation/ReferencedModelLocator";
 
@@ -24,6 +13,8 @@ function createService(result: LocateResult) {
         logInfo: vi.fn(),
         logWarning: vi.fn(),
         logError: vi.fn(),
+        withProgress: vi.fn(<T>(_title: string, task: () => Promise<T>): Promise<T> => task()),
+        openDocument: vi.fn().mockResolvedValue(undefined),
     };
     const picker = {
         pickReferencedModel: vi.fn(),
@@ -37,13 +28,12 @@ function createService(result: LocateResult) {
 }
 
 beforeEach(() => {
-    vi.mocked(commands.executeCommand).mockReset();
+    vi.clearAllMocks();
 });
 
 describe("ModelNavigationService.navigate", () => {
     it("wraps the search in a status-bar progress indicator", async () => {
-        const progressSpy = vi.spyOn(window, "withProgress");
-        const { service } = createService({
+        const { service, notifier } = createService({
             kind: "matches",
             paths: ["/a.bpmn"],
             readFailures: [],
@@ -51,11 +41,9 @@ describe("ModelNavigationService.navigate", () => {
 
         await service.navigate("ProcessB", "process");
 
-        expect(progressSpy).toHaveBeenCalledTimes(1);
-        const [opts] = progressSpy.mock.calls[0];
-        expect((opts as { location: number }).location).toBe(ProgressLocation.Window);
-        expect((opts as { title: string }).title).toContain("ProcessB");
-        progressSpy.mockRestore();
+        expect(notifier.withProgress).toHaveBeenCalledTimes(1);
+        const [title] = notifier.withProgress.mock.calls[0];
+        expect(title).toContain("ProcessB");
     });
 
     it("delegates to the locator with the same arguments", async () => {
@@ -64,15 +52,14 @@ describe("ModelNavigationService.navigate", () => {
             paths: [],
             readFailures: [],
         });
-        const documentUri = { scheme: "file", path: "/x.bpmn" } as never;
 
-        await service.navigate("Id", "process", documentUri);
+        await service.navigate("Id", "process", "/x.bpmn");
 
-        expect(locator.findDeclaringFiles).toHaveBeenCalledWith("Id", "process", documentUri);
+        expect(locator.findDeclaringFiles).toHaveBeenCalledWith("Id", "process", "/x.bpmn");
     });
 
-    it("opens the file directly via vscode.open when the locator returns a single match", async () => {
-        const { service, picker } = createService({
+    it("opens the file directly via openDocument when the locator returns a single match", async () => {
+        const { service, picker, notifier } = createService({
             kind: "matches",
             paths: ["/a.bpmn"],
             readFailures: [],
@@ -81,14 +68,11 @@ describe("ModelNavigationService.navigate", () => {
         await service.navigate("ProcessB", "process");
 
         expect(picker.pickReferencedModel).not.toHaveBeenCalled();
-        expect(commands.executeCommand).toHaveBeenCalledWith(
-            "vscode.open",
-            expect.objectContaining({ path: "/a.bpmn" }),
-        );
+        expect(notifier.openDocument).toHaveBeenCalledWith("/a.bpmn");
     });
 
     it("opens the user's QuickPick selection when the locator returns multiple matches", async () => {
-        const { service, picker } = createService({
+        const { service, picker, notifier } = createService({
             kind: "matches",
             paths: ["/a.bpmn", "/b.bpmn"],
             readFailures: [],
@@ -98,14 +82,11 @@ describe("ModelNavigationService.navigate", () => {
         await service.navigate("Shared", "process");
 
         expect(picker.pickReferencedModel).toHaveBeenCalledWith(["/a.bpmn", "/b.bpmn"]);
-        expect(commands.executeCommand).toHaveBeenCalledWith(
-            "vscode.open",
-            expect.objectContaining({ path: "/b.bpmn" }),
-        );
+        expect(notifier.openDocument).toHaveBeenCalledWith("/b.bpmn");
     });
 
     it("does not open anything when the user cancels the QuickPick", async () => {
-        const { service, picker } = createService({
+        const { service, picker, notifier } = createService({
             kind: "matches",
             paths: ["/a.bpmn", "/b.bpmn"],
             readFailures: [],
@@ -114,7 +95,7 @@ describe("ModelNavigationService.navigate", () => {
 
         await service.navigate("Shared", "process");
 
-        expect(commands.executeCommand).not.toHaveBeenCalled();
+        expect(notifier.openDocument).not.toHaveBeenCalled();
     });
 
     it("shows an info notification when matches is empty", async () => {
@@ -127,7 +108,7 @@ describe("ModelNavigationService.navigate", () => {
         await service.navigate("Missing", "process");
 
         expect(notifier.showInfo).toHaveBeenCalledWith(expect.stringContaining("Missing"));
-        expect(commands.executeCommand).not.toHaveBeenCalled();
+        expect(notifier.openDocument).not.toHaveBeenCalled();
     });
 
     it("shows the 'open a folder' hint when the locator reports no-search-scope", async () => {
@@ -136,7 +117,7 @@ describe("ModelNavigationService.navigate", () => {
         await service.navigate("ProcessB", "process");
 
         expect(notifier.showInfo).toHaveBeenCalledWith(expect.stringContaining("Open a folder"));
-        expect(commands.executeCommand).not.toHaveBeenCalled();
+        expect(notifier.openDocument).not.toHaveBeenCalled();
     });
 
     it("logs each failure and shows an error when the locator reports all-unreadable", async () => {
@@ -152,7 +133,7 @@ describe("ModelNavigationService.navigate", () => {
         expect(notifier.showError).toHaveBeenCalledWith(
             expect.stringContaining("none of the candidate files were readable"),
         );
-        expect(commands.executeCommand).not.toHaveBeenCalled();
+        expect(notifier.openDocument).not.toHaveBeenCalled();
     });
 
     it("logs partial read failures alongside a successful match", async () => {
@@ -165,19 +146,16 @@ describe("ModelNavigationService.navigate", () => {
         await service.navigate("ProcessB", "process");
 
         expect(notifier.logWarning).toHaveBeenCalledWith(expect.stringContaining("EACCES"));
-        expect(commands.executeCommand).toHaveBeenCalledWith(
-            "vscode.open",
-            expect.objectContaining({ path: "/good.bpmn" }),
-        );
+        expect(notifier.openDocument).toHaveBeenCalledWith("/good.bpmn");
     });
 
-    it("surfaces an error when vscode.open rejects", async () => {
+    it("surfaces an error when openDocument rejects", async () => {
         const { service, notifier } = createService({
             kind: "matches",
             paths: ["/a.bpmn"],
             readFailures: [],
         });
-        vi.mocked(commands.executeCommand).mockRejectedValueOnce(new Error("File not found"));
+        notifier.openDocument.mockRejectedValueOnce(new Error("File not found"));
 
         await service.navigate("ProcessB", "process");
 

--- a/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { ModelNavigationService } from "./ModelNavigationService";
 import { LocateResult } from "./modelNavigation/ReferencedModelLocator";
@@ -26,10 +26,6 @@ function createService(result: LocateResult) {
     );
     return { service, locator, notifier, picker };
 }
-
-beforeEach(() => {
-    vi.clearAllMocks();
-});
 
 describe("ModelNavigationService.navigate", () => {
     it("wraps the search in a status-bar progress indicator", async () => {

--- a/apps/modeler-plugin/src/service/ModelNavigationService.ts
+++ b/apps/modeler-plugin/src/service/ModelNavigationService.ts
@@ -1,5 +1,3 @@
-import { commands, ProgressLocation, Uri, window } from "vscode";
-
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
 import { VsCodePicker } from "../infrastructure/VsCodePicker";
 
@@ -30,17 +28,14 @@ export class ModelNavigationService {
     async navigate(
         referenceId: string,
         kind: "process" | "decision",
-        sourceDocumentUri?: Uri,
+        sourceDocumentPath?: string,
     ): Promise<void> {
         const display = truncate(referenceId, REFERENCE_ID_DISPLAY_LIMIT);
         // Only the search itself is wrapped — the QuickPick (multi-match) and
-        // vscode.open are user-driven and must not keep a spinner visible.
-        const result = await window.withProgress(
-            {
-                location: ProgressLocation.Window,
-                title: `Searching for ${kind} "${truncate(referenceId, PROGRESS_LABEL_LIMIT)}"…`,
-            },
-            () => this.locator.findDeclaringFiles(referenceId, kind, sourceDocumentUri),
+        // openDocument are user-driven and must not keep a spinner visible.
+        const result = await this.notifier.withProgress(
+            `Searching for ${kind} "${truncate(referenceId, PROGRESS_LABEL_LIMIT)}"…`,
+            () => this.locator.findDeclaringFiles(referenceId, kind, sourceDocumentPath),
         );
 
         if (result.kind === "no-search-scope") {
@@ -78,7 +73,7 @@ export class ModelNavigationService {
         }
 
         try {
-            await commands.executeCommand("vscode.open", Uri.file(chosen));
+            await this.notifier.openDocument(chosen);
         } catch (error) {
             this.notifier.logError(error as Error);
             this.notifier.showError(`Could not open ${chosen}: ${(error as Error).message}`);

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
@@ -293,13 +293,11 @@ describe("findDeclaringFiles — walk-fallback (ripgrep silently failed)", () =>
         workspaceState.folderForUri = () => ({
             uri: { scheme: "file", path: "/work", fsPath: "/work" },
         });
-        const documentUri = {
-            scheme: "file",
-            path: "/work/parent.bpmn",
-            fsPath: "/work/parent.bpmn",
-        } as never;
-
-        const result = await locator.findDeclaringFiles("ChildProcess", "process", documentUri);
+        const result = await locator.findDeclaringFiles(
+            "ChildProcess",
+            "process",
+            "/work/parent.bpmn",
+        );
 
         expect(vsWorkspace.findFiles).toHaveBeenCalledTimes(1);
         expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");
@@ -384,13 +382,11 @@ describe("findDeclaringFiles — loose file (no workspace folder)", () => {
             },
             tree: { "/work": ["parent.bpmn", "child.bpmn"] },
         });
-        const documentUri = {
-            scheme: "file",
-            path: "/work/parent.bpmn",
-            fsPath: "/work/parent.bpmn",
-        } as never;
-
-        const result = await locator.findDeclaringFiles("ChildProcess", "process", documentUri);
+        const result = await locator.findDeclaringFiles(
+            "ChildProcess",
+            "process",
+            "/work/parent.bpmn",
+        );
 
         expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
         expect(vsWorkspace.readDirectory).toHaveBeenCalledWith("/work");

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
@@ -64,15 +64,15 @@ export class ReferencedModelLocator {
     async findDeclaringFiles(
         referenceId: string,
         kind: "process" | "decision",
-        sourceDocumentUri?: Uri,
+        sourceDocumentPath?: string,
     ): Promise<LocateResult> {
         const extension = kind === "process" ? ".bpmn" : ".dmn";
         const id = truncate(referenceId, ID_DISPLAY_LIMIT);
         this.notifier.logInfo(
-            `[nav] resolving ${kind} id="${id}" sourceUri=${sourceDocumentUri?.path ?? "<none>"}`,
+            `[nav] resolving ${kind} id="${id}" sourceUri=${sourceDocumentPath ?? "<none>"}`,
         );
 
-        const paths = await this.collectCandidateFiles(extension, sourceDocumentUri);
+        const paths = await this.collectCandidateFiles(extension, sourceDocumentPath);
         if (paths === undefined) {
             this.notifier.logInfo(`[nav] no search scope (no folder, no source uri)`);
             return { kind: "no-search-scope" };
@@ -82,12 +82,14 @@ export class ReferencedModelLocator {
 
     /**
      * Phase 1.  Returns `undefined` when nothing can be searched (no source
-     * URI and no workspace folder).  Otherwise returns the candidate paths.
+     * path and no workspace folder).  Otherwise returns the candidate paths.
      */
     private async collectCandidateFiles(
         extension: string,
-        sourceDocumentUri: Uri | undefined,
+        sourceDocumentPath: string | undefined,
     ): Promise<string[] | undefined> {
+        const sourceDocumentUri =
+            sourceDocumentPath !== undefined ? Uri.file(sourceDocumentPath) : undefined;
         const looseFile =
             sourceDocumentUri !== undefined &&
             workspace.getWorkspaceFolder(sourceDocumentUri) === undefined;


### PR DESCRIPTION
**Issue**

Closes: #1036

**Description**

Extract a vscode-free `DiffPaneHandle` interface that wraps webview panes, letting `DiffSession` operate on strings instead of `Uri` objects and remain testable without vscode imports. Introduce `WebviewPaneHandle` adapter in `BpmnDiffService` to bridge the gap, and move SCM side-assignment logic (`resolveScmSides`) from the session into the service where URI schemes are accessible.

Additionally:
- Extract progress-wrapping and document-opening helpers into `VsCodeNotifier`
- Add `createWatcher` to `VsCodeWorkspace` to hide `RelativePattern` and event conversion
- Update `ModelNavigationService` and `ReferencedModelLocator` to work with string paths instead of `Uri` objects
- Pass `documentUri.fsPath` instead of `documentUri` to `navigate()` calls throughout

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
