### PR TITLE
refactor(service): split BpmnModelerService into focused adapters

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,3 @@
 {
-  "recommendations": [
-    "nrwl.angular-console",
-    "esbenp.prettier-vscode",
-    "vitest.explorer",
-    "dbaeumer.vscode-eslint"
-  ]
+    "recommendations": ["esbenp.prettier-vscode", "vitest.explorer", "dbaeumer.vscode-eslint"]
 }

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.navigate.spec.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.navigate.spec.ts
@@ -33,6 +33,10 @@ function createController() {
     const controller = new BpmnEditorController(
         editorStore as never,
         {} as never, // bpmnService
+        {} as never, // templatesSvc
+        {} as never, // settingsBroadcaster
+        {} as never, // panelSvc
+        {} as never, // clipboardMediator
         {} as never, // diffService
         {} as never, // artifactSvc
         {} as never, // scriptTaskSvc

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -22,6 +22,10 @@ import { EditorStore } from "../infrastructure/EditorStore";
 import { VsCodeStatusBar } from "../infrastructure/VsCodeStatusBar";
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
 import { BpmnModelerService } from "../service/BpmnModelerService";
+import { BpmnClipboardMediator } from "../service/BpmnClipboardMediator";
+import { BpmnElementTemplatesService } from "../service/BpmnElementTemplatesService";
+import { BpmnPropertiesPanelService } from "../service/BpmnPropertiesPanelService";
+import { BpmnSettingsBroadcaster } from "../service/BpmnSettingsBroadcaster";
 import { BpmnDiffService } from "../service/BpmnDiffService";
 import { ArtifactService } from "../service/ArtifactService";
 import { ScriptTaskService } from "./ScriptTaskService";
@@ -36,25 +40,17 @@ const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
  * VS Code `CustomTextEditorProvider` for `.bpmn` files.
  *
  * Thin wiring layer: creates the editor session, sets up all VS Code event
- * subscriptions, and delegates all business logic to {@link BpmnModelerService}
- * and {@link ArtifactService}.
+ * subscriptions, and fans webview messages out to the focused BPMN
+ * services (modeler, templates, settings, panel, clipboard).
  */
 export class BpmnEditorController implements CustomTextEditorProvider {
-    /**
-     * @param editorStore Central registry for open editor panels and subscriptions.
-     * @param bpmnService BPMN-specific business logic and session management.
-     * @param diffService Diff coordinator — queried on resolve to decide
-     *   whether to take the readonly viewer branch.
-     * @param artifactSvc Workspace artifact discovery and watcher creation.
-     * @param scriptTaskSvc Virtual script document management for script tasks.
-     * @param notifier User-facing message and logging helper.
-     * @param vsDocument Active-document read helper (for status bar version detection).
-     * @param statusBar Status bar item manager for engine version display.
-     * @param modelNavigationService Resolves references and opens the target file.
-     */
     constructor(
         private readonly editorStore: EditorStore,
         private readonly bpmnService: BpmnModelerService,
+        private readonly templatesSvc: BpmnElementTemplatesService,
+        private readonly settingsBroadcaster: BpmnSettingsBroadcaster,
+        private readonly panelSvc: BpmnPropertiesPanelService,
+        private readonly clipboardMediator: BpmnClipboardMediator,
         private readonly diffService: BpmnDiffService,
         private readonly artifactSvc: ArtifactService,
         private readonly scriptTaskSvc: ScriptTaskService,
@@ -72,8 +68,6 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      * re-fetches the document via `GetBpmnFileCommand` on reload and
      * `WebviewStateManager` round-trips viewport / selection / panel state
      * through `vscode.setState`.
-     *
-     * @param context The VS Code extension context.
      */
     register(context: ExtensionContext): void {
         const provider = window.registerCustomEditorProvider(BPMN_VIEW_TYPE, this);
@@ -85,10 +79,6 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      *
      * Creates the editor session, registers all event subscriptions, and starts
      * filesystem watchers for artifact directories (forms, element templates).
-     *
-     * @param document The text document being edited.
-     * @param webviewPanel The webview panel provided by VS Code.
-     * @param _token Cancellation token (unused).
      */
     async resolveCustomTextEditor(
         document: TextDocument,
@@ -121,13 +111,14 @@ export class BpmnEditorController implements CustomTextEditorProvider {
                 editorId,
                 webviewPanel,
                 document,
-                this.bpmnService.getPersistedPanelVisibility(),
+                this.panelSvc.getPersistedPanelVisibility(),
             );
             this.bpmnService.registerSession(editorId);
 
             this.subscribeToMessageEvent(editorId);
             this.subscribeToDocumentChangeEvent(editorId);
-            this.subscribeToSettingChangeEvent(editorId);
+            this.settingsBroadcaster.subscribe(editorId);
+            this.subscribeToConfigFolderChangeEvent(editorId);
             this.subscribeToViewStateChangeEvent(editorId, webviewPanel);
             this.editorStore.subscribeToTabChangeEvent(editorId);
             this.editorStore.subscribeToDisposeEvent(editorId, () => {
@@ -138,7 +129,7 @@ export class BpmnEditorController implements CustomTextEditorProvider {
 
             const { disposables, errors } = await this.artifactSvc.createWatcher(
                 editorId,
-                this.bpmnService,
+                this.templatesSvc,
             );
             for (const d of disposables) {
                 this.editorStore.addToDisposals(editorId, d);
@@ -158,8 +149,6 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      *
      * The session guard for `SyncDocumentCommand` is managed inside
      * {@link BpmnModelerService.sync}, keeping this controller free of guard logic.
-     *
-     * @param editorId Document URI path of the editor whose webview to listen to.
      */
     private subscribeToMessageEvent(editorId: string): void {
         this.editorStore.subscribeToMessageEvent(editorId, async (message: Command, id: string) => {
@@ -171,32 +160,34 @@ export class BpmnEditorController implements CustomTextEditorProvider {
                     }
                     break;
                 case "GetElementTemplatesCommand":
-                    this.bpmnService.setElementTemplates(id);
+                    this.templatesSvc.setElementTemplates(id);
                     break;
                 case "GetBpmnModelerSettingCommand":
-                    this.bpmnService.setSettings(id);
-                    this.bpmnService.setLanguage(id);
+                    this.settingsBroadcaster.setSettings(id);
+                    this.settingsBroadcaster.setLanguage(id);
                     this.scriptTaskSvc.resyncOpenDocuments(id); // (re)load for changes while webview was hidden
                     break;
                 case "GetPropertiesPanelStateCommand":
-                    this.bpmnService.sendPropertiesPanelState(id);
+                    this.panelSvc.sendPropertiesPanelState(id);
                     break;
                 case "SetPropertiesPanelStateCommand":
-                    this.bpmnService.setPropertiesPanelVisibility(
+                    this.panelSvc.setPropertiesPanelVisibility(
                         (message as SetPropertiesPanelStateCommand).visible,
                     );
                     break;
                 case "GetClipboardCommand":
-                    this.bpmnService.readClipboard(id);
+                    this.clipboardMediator.readClipboard(id);
                     break;
                 case "SetClipboardCommand":
-                    this.bpmnService.writeClipboard((message as SetClipboardCommand).text);
+                    this.clipboardMediator.writeClipboard((message as SetClipboardCommand).text);
                     break;
                 case "GetTextClipboardCommand":
-                    this.bpmnService.readTextClipboard(id);
+                    this.clipboardMediator.readTextClipboard(id);
                     break;
                 case "SetTextClipboardCommand":
-                    this.bpmnService.writeClipboard((message as SetTextClipboardCommand).text);
+                    this.clipboardMediator.writeClipboard(
+                        (message as SetTextClipboardCommand).text,
+                    );
                     break;
                 case "SyncDocumentCommand":
                     await this.bpmnService.sync(id, (message as SyncDocumentCommand).content);
@@ -247,8 +238,6 @@ export class BpmnEditorController implements CustomTextEditorProvider {
      *
      * The editorId is captured at subscription time so the callback only
      * triggers display for the specific editor it was created for.
-     *
-     * @param editorId Document URI path of the target editor.
      */
     private subscribeToDocumentChangeEvent(editorId: string): void {
         this.editorStore.subscribeToDocumentChangeEvent(
@@ -267,30 +256,15 @@ export class BpmnEditorController implements CustomTextEditorProvider {
     }
 
     /**
-     * Subscribes to VS Code configuration changes and forwards relevant
-     * setting updates to the webview.
-     *
-     * @param editorId Document URI path of the target editor.
+     * Re-loads element templates when the `configFolder` setting changes.
+     * Other modeler settings are owned by
+     * {@link BpmnSettingsBroadcaster.subscribe}; only the templates branch
+     * stays here because it lives in a different service.
      */
-    private subscribeToSettingChangeEvent(editorId: string): void {
+    private subscribeToConfigFolderChangeEvent(editorId: string): void {
         this.editorStore.subscribeToSettingChangeEvent(editorId, (event, id) => {
-            if (event.affectsConfiguration("miragon.bpmnModeler.alignToOrigin")) {
-                this.bpmnService.setSettings(id);
-            }
-            if (event.affectsConfiguration("miragon.bpmnModeler.showTransactionBoundaries")) {
-                this.bpmnService.setSettings(id);
-            }
-            if (event.affectsConfiguration("miragon.bpmnModeler.colorTheme")) {
-                this.bpmnService.setSettings(id);
-            }
-            if (event.affectsConfiguration("miragon.bpmnModeler.favouriteBpmnElements")) {
-                this.bpmnService.setSettings(id);
-            }
             if (event.affectsConfiguration("miragon.bpmnModeler.configFolder")) {
-                this.bpmnService.setElementTemplates(id);
-            }
-            if (event.affectsConfiguration("miragon.bpmnModeler.language")) {
-                this.bpmnService.setLanguage(id);
+                this.templatesSvc.setElementTemplates(id);
             }
         });
     }
@@ -298,9 +272,6 @@ export class BpmnEditorController implements CustomTextEditorProvider {
     /**
      * Subscribes to webview panel view-state changes to show or hide the
      * engine version status bar item when the BPMN editor gains or loses focus.
-     *
-     * @param editorId Document URI path of the target editor.
-     * @param webviewPanel The webview panel to observe.
      */
     private subscribeToViewStateChangeEvent(editorId: string, webviewPanel: WebviewPanel): void {
         webviewPanel.onDidChangeViewState(() => {
@@ -315,8 +286,6 @@ export class BpmnEditorController implements CustomTextEditorProvider {
     /**
      * Reads the current document content and updates the engine-version status
      * bar with the detected platform and version.
-     *
-     * @param editorId Document URI path of the target editor.
      */
     private updateEngineVersionStatusBar(editorId: string): void {
         try {

--- a/apps/modeler-plugin/src/controller/CommandController.ts
+++ b/apps/modeler-plugin/src/controller/CommandController.ts
@@ -17,6 +17,7 @@ import { VsCodeDocument } from "../infrastructure/VsCodeDocument";
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
 import { VsCodeTextEditor } from "../infrastructure/VsCodeTextEditor";
 import { BpmnModelerService } from "../service/BpmnModelerService";
+import { BpmnMigrationService } from "../service/BpmnMigrationService";
 
 // VS Code command ID for toggling the text editor.
 const TOGGLE_CMD = "bpmn-modeler.toggleTextEditor";
@@ -50,6 +51,7 @@ export class CommandController {
      * @param notifier User-facing message and logging helper.
      * @param textEditor Toggles the companion text editor pane for the active document.
      * @param bpmnService BPMN-specific business logic for engine version changes.
+     * @param migrationSvc Workspace-wide BPMN migration orchestrator.
      */
     constructor(
         private readonly editorStore: EditorStore,
@@ -57,6 +59,7 @@ export class CommandController {
         private readonly notifier: VsCodeNotifier,
         private readonly textEditor: VsCodeTextEditor,
         private readonly bpmnService: BpmnModelerService,
+        private readonly migrationSvc: BpmnMigrationService,
     ) {}
 
     /**
@@ -108,10 +111,10 @@ export class CommandController {
     /**
      * Migrates all BPMN diagrams in the workspace to a user-selected version.
      *
-     * Delegates to {@link BpmnModelerService.migrateAllDiagrams}.
+     * Delegates to {@link BpmnMigrationService.migrateAllDiagrams}.
      */
     migrateAllDiagrams(): Promise<boolean> {
-        return this.bpmnService.migrateAllDiagrams();
+        return this.migrationSvc.migrateAllDiagrams();
     }
 
     /**

--- a/apps/modeler-plugin/src/infrastructure/VsCodeNotifier.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeNotifier.ts
@@ -26,6 +26,17 @@ export class VsCodeNotifier {
         window.showErrorMessage(message);
     }
 
+    /**
+     * Logs `error` and surfaces a toast that pairs a caller-supplied
+     * `context` line with the error's own message. Centralises the
+     * log-then-show pattern so each service only specifies what it was
+     * doing rather than re-deriving the message format.
+     */
+    notifyError(context: string, error: Error): void {
+        this.logError(error);
+        this.showError(`${context}\n${error.message ?? error}`);
+    }
+
     openLoggingConsole(): void {
         this.channel.show(true);
     }

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -17,6 +17,11 @@ import { VsCodeTextEditor } from "./infrastructure/VsCodeTextEditor";
 import { ArtifactService } from "./service/ArtifactService";
 import { BpmnDiffService } from "./service/BpmnDiffService";
 import { BpmnModelerService } from "./service/BpmnModelerService";
+import { BpmnClipboardMediator } from "./service/BpmnClipboardMediator";
+import { BpmnElementTemplatesService } from "./service/BpmnElementTemplatesService";
+import { BpmnMigrationService } from "./service/BpmnMigrationService";
+import { BpmnPropertiesPanelService } from "./service/BpmnPropertiesPanelService";
+import { BpmnSettingsBroadcaster } from "./service/BpmnSettingsBroadcaster";
 import { DmnModelerService } from "./service/DmnModelerService";
 import { ModelNavigationService } from "./service/ModelNavigationService";
 import { ReferencedModelLocator } from "./service/modelNavigation/ReferencedModelLocator";
@@ -72,15 +77,27 @@ export function activate(context: ExtensionContext): void {
     const bpmnService = new BpmnModelerService(
         editorStore,
         vsDocument,
-        vsSettings,
-        notifier,
         picker,
-        clipboard,
+        statusBar,
+        notifier,
+    );
+    const templatesSvc = new BpmnElementTemplatesService(
+        editorStore,
+        vsDocument,
         artifactSvc,
         statusBar,
-        vsWorkspace,
-        panelStateRepo,
+        notifier,
     );
+    const migrationSvc = new BpmnMigrationService(
+        editorStore,
+        vsDocument,
+        vsWorkspace,
+        picker,
+        notifier,
+    );
+    const clipboardMediator = new BpmnClipboardMediator(editorStore, clipboard, notifier);
+    const settingsBroadcaster = new BpmnSettingsBroadcaster(editorStore, vsSettings, notifier);
+    const panelSvc = new BpmnPropertiesPanelService(editorStore, panelStateRepo, notifier);
     const dmnService = new DmnModelerService(editorStore, vsDocument, notifier);
     const diffService = new BpmnDiffService(notifier, vsSettings);
     context.subscriptions.push(diffService);
@@ -120,10 +137,15 @@ export function activate(context: ExtensionContext): void {
         notifier,
         textEditor,
         bpmnService,
+        migrationSvc,
     );
     new BpmnEditorController(
         editorStore,
         bpmnService,
+        templatesSvc,
+        settingsBroadcaster,
+        panelSvc,
+        clipboardMediator,
         diffService,
         artifactSvc,
         scriptTaskSvc,

--- a/apps/modeler-plugin/src/service/ArtifactService.ts
+++ b/apps/modeler-plugin/src/service/ArtifactService.ts
@@ -5,8 +5,9 @@ import { VsCodeWorkspace } from "../infrastructure/VsCodeWorkspace";
 import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
 
 /**
- * Implemented by {@link BpmnModelerService} and accepted by
- * {@link ArtifactService.createWatcher} to avoid a circular module import.
+ * Implemented by {@link import("./BpmnElementTemplatesService").BpmnElementTemplatesService}
+ * and accepted by {@link ArtifactService.createWatcher} to avoid a circular
+ * module import.
  */
 export interface ArtifactChangeTarget {
     setElementTemplates(editorId: string): Promise<boolean>;
@@ -134,7 +135,7 @@ export class ArtifactService {
 
     /**
      * `target` is a method parameter (not a constructor argument) to break
-     * the `BpmnModelerService ↔ ArtifactService` circular dependency.
+     * the templates-service ↔ ArtifactService circular dependency.
      */
     async createWatcher(editorId: string, target: ArtifactChangeTarget): Promise<WatcherResult> {
         const documentDir = posix.dirname(editorId);

--- a/apps/modeler-plugin/src/service/BpmnClipboardMediator.ts
+++ b/apps/modeler-plugin/src/service/BpmnClipboardMediator.ts
@@ -1,0 +1,48 @@
+import { ClipboardQuery, TextClipboardQuery } from "@miragon/bpmn-modeler-shared";
+
+import { EditorStore } from "../infrastructure/EditorStore";
+import { VsCodeClipboard } from "../infrastructure/VsCodeClipboard";
+import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
+
+/**
+ * Mediates clipboard access between the webview and the system clipboard.
+ *
+ * VS Code sandboxed iframes lack `clipboard-read` / `clipboard-write`
+ * permissions, so the extension host has to perform the actual read/write
+ * and post the value back over the webview channel.
+ */
+export class BpmnClipboardMediator {
+    constructor(
+        private readonly editorStore: EditorStore,
+        private readonly clipboard: VsCodeClipboard,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    async readClipboard(editorId: string): Promise<boolean> {
+        try {
+            const text = await this.clipboard.readClipboard();
+            return await this.editorStore.postMessage(editorId, new ClipboardQuery(text));
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            return false;
+        }
+    }
+
+    async readTextClipboard(editorId: string): Promise<boolean> {
+        try {
+            const text = await this.clipboard.readClipboard();
+            return await this.editorStore.postMessage(editorId, new TextClipboardQuery(text));
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            return false;
+        }
+    }
+
+    async writeClipboard(text: string): Promise<void> {
+        try {
+            await this.clipboard.writeClipboard(text);
+        } catch (error) {
+            this.notifier.logError(error as Error);
+        }
+    }
+}

--- a/apps/modeler-plugin/src/service/BpmnElementTemplatesService.ts
+++ b/apps/modeler-plugin/src/service/BpmnElementTemplatesService.ts
@@ -67,10 +67,7 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
     }
 
     private handleError(error: Error): boolean {
-        this.notifier.logError(error);
-        this.notifier.showError(
-            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
-        );
+        this.notifier.notifyError("A problem occurred while loading element templates.", error);
         return false;
     }
 }

--- a/apps/modeler-plugin/src/service/BpmnElementTemplatesService.ts
+++ b/apps/modeler-plugin/src/service/BpmnElementTemplatesService.ts
@@ -1,0 +1,76 @@
+import { posix } from "path";
+
+import { ElementTemplatesQuery } from "@miragon/bpmn-modeler-shared";
+
+import { EditorStore } from "../infrastructure/EditorStore";
+import { VsCodeDocument } from "../infrastructure/VsCodeDocument";
+import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
+import { VsCodeStatusBar } from "../infrastructure/VsCodeStatusBar";
+import { ArtifactChangeTarget, ArtifactService } from "./ArtifactService";
+
+/**
+ * Loads BPMN element templates from the workspace and pushes them to the
+ * webview. Implements {@link ArtifactChangeTarget} so the artifact watcher
+ * created by {@link ArtifactService.createWatcher} can re-trigger a load
+ * when a template file changes on disk.
+ */
+export class BpmnElementTemplatesService implements ArtifactChangeTarget {
+    constructor(
+        private readonly editorStore: EditorStore,
+        private readonly vsDocument: VsCodeDocument,
+        private readonly artifactSvc: ArtifactService,
+        private readonly statusBar: VsCodeStatusBar,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    async setElementTemplates(editorId: string): Promise<boolean> {
+        this.statusBar.showElementTemplatesLoading();
+        try {
+            const documentDir = posix.dirname(this.vsDocument.getFilePath(editorId));
+
+            const [artifacts] = await this.artifactSvc.getArtifactPaths(documentDir);
+
+            const parsed = await Promise.all(
+                artifacts.map(async (a) => {
+                    try {
+                        return JSON.parse(await this.artifactSvc.readFile(a));
+                    } catch (error) {
+                        this.notifier.logError(
+                            new Error(
+                                `Failed to parse element template "${a}": ${(error as Error).message}`,
+                            ),
+                        );
+                        return [];
+                    }
+                }),
+            );
+            const sorted = parsed
+                .flat()
+                .sort((a: Record<string, unknown>, b: Record<string, unknown>) =>
+                    String(a.name ?? "").localeCompare(String(b.name ?? "")),
+                );
+
+            if (await this.editorStore.postMessage(editorId, new ElementTemplatesQuery(sorted))) {
+                this.statusBar.showElementTemplatesReady(sorted.length);
+                if (artifacts.length > 0) {
+                    this.notifier.logInfo(`${artifacts.length} element templates are set.`);
+                }
+                return true;
+            } else {
+                this.statusBar.hideElementTemplatesStatus();
+                return this.handleError(new Error("Setting the `elementTemplates` failed."));
+            }
+        } catch (error) {
+            this.statusBar.hideElementTemplatesStatus();
+            return this.handleError(error as Error);
+        }
+    }
+
+    private handleError(error: Error): boolean {
+        this.notifier.logError(error);
+        this.notifier.showError(
+            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
+        );
+        return false;
+    }
+}

--- a/apps/modeler-plugin/src/service/BpmnMigrationService.spec.ts
+++ b/apps/modeler-plugin/src/service/BpmnMigrationService.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { UserCancelledError } from "../domain/errors";
-import { BpmnModelerService } from "./BpmnModelerService";
+import { BpmnMigrationService } from "./BpmnMigrationService";
 
 // ─── Sample BPMN XML ────────────────────────────────────────────────────────
 
@@ -39,23 +39,21 @@ const unknownBpmn = `<?xml version="1.0" encoding="UTF-8"?>
 function createMocks() {
     const editorStore = {
         findEditorIdByPath: vi.fn().mockReturnValue(undefined),
-        postMessage: vi.fn(),
-        getActiveEditorId: vi.fn(),
-        getDocumentForEditor: vi.fn(),
-        subscribeToMessageEvent: vi.fn(),
-        subscribeToActiveEditorMessage: vi.fn(),
     };
 
     const vsDocument = {
         write: vi.fn().mockResolvedValue(true),
-        getContent: vi.fn(),
-        getFilePath: vi.fn(),
-        save: vi.fn(),
     };
 
-    const vsSettings = {
-        getAlignToOrigin: vi.fn(),
-        getShowTransactionBoundaries: vi.fn(),
+    const vsWorkspace = {
+        findFiles: vi.fn().mockResolvedValue([]),
+        readFile: vi.fn(),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const picker = {
+        pickEngineVersion: vi.fn(),
+        pickMigrationScope: vi.fn(),
     };
 
     const notifier = {
@@ -64,56 +62,14 @@ function createMocks() {
         logInfo: vi.fn(),
         logWarning: vi.fn(),
         logError: vi.fn(),
-        openLoggingConsole: vi.fn(),
-    };
-    const picker = {
-        pickExecutionPlatform: vi.fn(),
-        pickEngineVersion: vi.fn(),
-        pickMigrationScope: vi.fn(),
-    };
-    const clipboard = {
-        readClipboard: vi.fn(),
-        writeClipboard: vi.fn(),
     };
 
-    const artifactSvc = {
-        getArtifactPaths: vi.fn(),
-        readFile: vi.fn(),
-        createWatcher: vi.fn(),
-    };
-
-    const statusBar = {
-        showEngineVersion: vi.fn(),
-        showElementTemplatesLoading: vi.fn(),
-        showElementTemplatesReady: vi.fn(),
-        hideElementTemplatesStatus: vi.fn(),
-    };
-
-    const vsWorkspace = {
-        findFiles: vi.fn().mockResolvedValue([]),
-        readFile: vi.fn(),
-        writeFile: vi.fn().mockResolvedValue(undefined),
-        getWorkspaceFolderForDocument: vi.fn(),
-        readDirectory: vi.fn(),
-        findGitRoot: vi.fn(),
-    };
-
-    const panelStateRepo = {
-        getVisibility: vi.fn().mockReturnValue(true),
-        setVisibility: vi.fn().mockResolvedValue(undefined),
-    };
-
-    const service = new BpmnModelerService(
+    const service = new BpmnMigrationService(
         editorStore as any,
         vsDocument as any,
-        vsSettings as any,
-        notifier as any,
-        picker as any,
-        clipboard as any,
-        artifactSvc as any,
-        statusBar as any,
         vsWorkspace as any,
-        panelStateRepo as any,
+        picker as any,
+        notifier as any,
     );
 
     return { service, editorStore, vsDocument, notifier, picker, vsWorkspace };

--- a/apps/modeler-plugin/src/service/BpmnMigrationService.ts
+++ b/apps/modeler-plugin/src/service/BpmnMigrationService.ts
@@ -179,10 +179,7 @@ export class BpmnMigrationService {
     }
 
     private handleError(error: Error): boolean {
-        this.notifier.logError(error);
-        this.notifier.showError(
-            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
-        );
+        this.notifier.notifyError("A problem occurred while migrating BPMN diagrams.", error);
         return false;
     }
 }

--- a/apps/modeler-plugin/src/service/BpmnMigrationService.ts
+++ b/apps/modeler-plugin/src/service/BpmnMigrationService.ts
@@ -1,0 +1,188 @@
+import { Engine } from "@miragon/bpmn-modeler-shared";
+
+import { BpmnDocument } from "../domain/BpmnDocument";
+import { UserCancelledError } from "../domain/errors";
+import { getVersions } from "../domain/engineVersions";
+import { BpmnFileEntry, MigrationPlan, MigrationScope } from "../domain/MigrationPlan";
+import { EditorStore } from "../infrastructure/EditorStore";
+import { VsCodeDocument } from "../infrastructure/VsCodeDocument";
+import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
+import { VsCodePicker } from "../infrastructure/VsCodePicker";
+import { VsCodeWorkspace } from "../infrastructure/VsCodeWorkspace";
+
+/**
+ * Workspace-wide migration of BPMN diagrams to a user-selected engine
+ * version. Same-engine only — no cross-platform migration (C7↔C8).
+ *
+ * Lives apart from {@link import("./BpmnModelerService").BpmnModelerService}
+ * because the orchestration of picker/scope/version selection and bulk
+ * file writes has no overlap with per-editor session management.
+ */
+export class BpmnMigrationService {
+    constructor(
+        private readonly editorStore: EditorStore,
+        private readonly vsDocument: VsCodeDocument,
+        private readonly vsWorkspace: VsCodeWorkspace,
+        private readonly picker: VsCodePicker,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    async migrateAllDiagrams(): Promise<boolean> {
+        try {
+            const paths = await this.vsWorkspace.findFiles("**/*.bpmn");
+            if (paths.length === 0) {
+                this.notifier.showInfo("No BPMN files found in the workspace.");
+                return false;
+            }
+
+            const plan = await this.buildMigrationPlan(paths);
+            if (plan.isEmpty()) {
+                this.notifier.showInfo(
+                    "Could not detect the engine for any BPMN file in the workspace.",
+                );
+                return false;
+            }
+
+            if (plan.undetected.length > 0) {
+                this.notifier.logWarning(
+                    `Skipped ${plan.undetected.length} file(s) with undetectable engine: ${plan.undetected.join(", ")}`,
+                );
+            }
+
+            let scope: MigrationScope;
+            if (plan.hasBothPlatforms()) {
+                scope = await this.picker.pickMigrationScope(
+                    plan.c7Files.length,
+                    plan.c8Files.length,
+                );
+            } else if (plan.hasC7()) {
+                scope = "c7";
+            } else {
+                scope = "c8";
+            }
+
+            // Collect all input before any writes: document-change listeners
+            // triggered by a write would steal focus and dismiss a subsequent
+            // QuickPick.
+            let c7Version: string | undefined;
+            let c8Version: string | undefined;
+
+            if (scope === "c7" || scope === "both") {
+                c7Version = await this.picker.pickEngineVersion("c7", getVersions("c7"));
+            }
+            if (scope === "c8" || scope === "both") {
+                c8Version = await this.picker.pickEngineVersion("c8", getVersions("c8"));
+            }
+
+            const summaryParts: string[] = [];
+
+            if (c7Version) {
+                const c7Updated = await this.applyVersionUpdate(plan.c7Files, c7Version, "c7");
+                if (c7Updated > 0) {
+                    summaryParts.push(`${c7Updated} diagram(s) to Camunda 7 (${c7Version})`);
+                }
+            }
+
+            if (c8Version) {
+                const c8Updated = await this.applyVersionUpdate(plan.c8Files, c8Version, "c8");
+                if (c8Updated > 0) {
+                    summaryParts.push(`${c8Updated} diagram(s) to Camunda 8 (${c8Version})`);
+                }
+            }
+
+            if (summaryParts.length > 0) {
+                this.notifier.showInfo(`Updated ${summaryParts.join(" and ")}.`);
+            } else {
+                this.notifier.showInfo("All diagrams are already at the selected version.");
+            }
+
+            return true;
+        } catch (error) {
+            if (error instanceof UserCancelledError) {
+                return false;
+            }
+            return this.handleError(error as Error);
+        }
+    }
+
+    private async buildMigrationPlan(paths: string[]): Promise<MigrationPlan> {
+        const c7Files: BpmnFileEntry[] = [];
+        const c8Files: BpmnFileEntry[] = [];
+        const undetected: string[] = [];
+
+        for (const filePath of paths) {
+            const content = await this.vsWorkspace.readFile(filePath);
+            const doc = new BpmnDocument(content);
+            try {
+                const platform = doc.detectPlatform();
+                const entry: BpmnFileEntry = { path: filePath, document: doc, platform };
+                if (platform === "c7") {
+                    c7Files.push(entry);
+                } else {
+                    c8Files.push(entry);
+                }
+            } catch {
+                undetected.push(filePath);
+            }
+        }
+
+        return new MigrationPlan(c7Files, c8Files, undetected);
+    }
+
+    /**
+     * Files open in an editor are updated via {@link VsCodeDocument.write};
+     * files only on disk are written via {@link VsCodeWorkspace.writeFile}.
+     */
+    private async applyVersionUpdate(
+        files: readonly BpmnFileEntry[],
+        targetVersion: string,
+        platform: Engine,
+    ): Promise<number> {
+        let updatedCount = 0;
+
+        for (const file of files) {
+            const currentVersion = file.document.detectPlatformVersion();
+            if (currentVersion === targetVersion) {
+                continue;
+            }
+
+            let updatedDoc: BpmnDocument;
+            if (currentVersion === undefined) {
+                const platformName = platform === "c7" ? "Camunda Platform" : "Camunda Cloud";
+                const schema =
+                    platform === "c7"
+                        ? `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`
+                        : `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"`;
+                updatedDoc = file.document.withExecutionPlatform(
+                    platformName,
+                    targetVersion,
+                    schema,
+                );
+                this.notifier.logWarning(
+                    `Added missing executionPlatform attribute to: ${file.path}`,
+                );
+            } else {
+                updatedDoc = file.document.withVersion(targetVersion);
+            }
+
+            const editorId = this.editorStore.findEditorIdByPath(file.path);
+            if (editorId !== undefined) {
+                await this.vsDocument.write(editorId, updatedDoc.xml);
+            } else {
+                await this.vsWorkspace.writeFile(file.path, updatedDoc.xml);
+            }
+
+            updatedCount++;
+        }
+
+        return updatedCount;
+    }
+
+    private handleError(error: Error): boolean {
+        this.notifier.logError(error);
+        this.notifier.showError(
+            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
+        );
+        return false;
+    }
+}

--- a/apps/modeler-plugin/src/service/BpmnModelerService.ts
+++ b/apps/modeler-plugin/src/service/BpmnModelerService.ts
@@ -1,32 +1,14 @@
-import { posix } from "path";
-
-import {
-    BpmnFileQuery,
-    BpmnModelerSettingQuery,
-    ClipboardQuery,
-    ElementTemplatesQuery,
-    Engine,
-    LanguageQuery,
-    PropertiesPanelStateQuery,
-    TextClipboardQuery,
-} from "@miragon/bpmn-modeler-shared";
+import { BpmnFileQuery } from "@miragon/bpmn-modeler-shared";
 
 import { ModelerSession } from "../domain/session";
-import { SettingBuilder } from "../domain/model";
 import { ExecutionPlatformNotDetectedError, UserCancelledError } from "../domain/errors";
 import { getLatestVersion, getVersions } from "../domain/engineVersions";
 import { BpmnDocument } from "../domain/BpmnDocument";
-import { BpmnFileEntry, MigrationPlan, MigrationScope } from "../domain/MigrationPlan";
 import { EditorStore } from "../infrastructure/EditorStore";
-import { PropertiesPanelStateRepository } from "../infrastructure/PropertiesPanelStateRepository";
 import { VsCodeDocument } from "../infrastructure/VsCodeDocument";
-import { VsCodeWorkspace } from "../infrastructure/VsCodeWorkspace";
-import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
 import { VsCodeStatusBar } from "../infrastructure/VsCodeStatusBar";
-import { VsCodeClipboard } from "../infrastructure/VsCodeClipboard";
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
 import { VsCodePicker } from "../infrastructure/VsCodePicker";
-import { ArtifactChangeTarget, ArtifactService } from "./ArtifactService";
 
 /**
  * Owns the per-editor {@link ModelerSession} map that drives echo
@@ -34,20 +16,15 @@ import { ArtifactChangeTarget, ArtifactService } from "./ArtifactService";
  * extension writes back, so the resulting `onDidChangeTextDocument` event
  * is skipped by {@link display} instead of being re-rendered.
  */
-export class BpmnModelerService implements ArtifactChangeTarget {
+export class BpmnModelerService {
     private readonly sessions: Map<string, ModelerSession> = new Map();
 
     constructor(
         private readonly editorStore: EditorStore,
         private readonly vsDocument: VsCodeDocument,
-        private readonly vsSettings: VsCodeSettings,
-        private readonly notifier: VsCodeNotifier,
         private readonly picker: VsCodePicker,
-        private readonly clipboard: VsCodeClipboard,
-        private readonly artifactSvc: ArtifactService,
         private readonly statusBar: VsCodeStatusBar,
-        private readonly vsWorkspace: VsCodeWorkspace,
-        private readonly panelStateRepo: PropertiesPanelStateRepository,
+        private readonly notifier: VsCodeNotifier,
     ) {}
 
     registerSession(editorId: string): void {
@@ -144,153 +121,6 @@ export class BpmnModelerService implements ArtifactChangeTarget {
         }
     }
 
-    async setElementTemplates(editorId: string): Promise<boolean> {
-        this.statusBar.showElementTemplatesLoading();
-        try {
-            const documentDir = posix.dirname(this.vsDocument.getFilePath(editorId));
-
-            const [artifacts] = await this.artifactSvc.getArtifactPaths(documentDir);
-
-            const parsed = await Promise.all(
-                artifacts.map(async (a) => {
-                    try {
-                        return JSON.parse(await this.artifactSvc.readFile(a));
-                    } catch (error) {
-                        this.notifier.logError(
-                            new Error(
-                                `Failed to parse element template "${a}": ${(error as Error).message}`,
-                            ),
-                        );
-                        return [];
-                    }
-                }),
-            );
-            const sorted = parsed
-                .flat()
-                .sort((a: Record<string, unknown>, b: Record<string, unknown>) =>
-                    String(a.name ?? "").localeCompare(String(b.name ?? "")),
-                );
-
-            if (await this.editorStore.postMessage(editorId, new ElementTemplatesQuery(sorted))) {
-                this.statusBar.showElementTemplatesReady(sorted.length);
-                if (artifacts.length > 0) {
-                    this.notifier.logInfo(`${artifacts.length} element templates are set.`);
-                }
-                return true;
-            } else {
-                this.statusBar.hideElementTemplatesStatus();
-                return this.handleError(new Error("Setting the `elementTemplates` failed."));
-            }
-        } catch (error) {
-            this.statusBar.hideElementTemplatesStatus();
-            return this.handleError(error as Error);
-        }
-    }
-
-    async setSettings(editorId: string): Promise<boolean> {
-        try {
-            const settings = new SettingBuilder()
-                .alignToOrigin(this.vsSettings.getAlignToOrigin())
-                .showTransactionBoundaries(this.vsSettings.getShowTransactionBoundaries())
-                .colorTheme(this.vsSettings.getColorTheme())
-                .favouriteBpmnElements(this.vsSettings.getFavouriteBpmnElements())
-                .buildBpmnModeler();
-
-            if (
-                await this.editorStore.postMessage(
-                    editorId,
-                    new BpmnModelerSettingQuery({
-                        alignToOrigin: settings.alignToOrigin,
-                        showTransactionBoundaries: settings.showTransactionBoundaries,
-                        colorTheme: settings.colorTheme,
-                        favouriteBpmnElements: settings.favouriteBpmnElements,
-                    }),
-                )
-            ) {
-                return true;
-            } else {
-                return this.handleError(new Error("Unable to set preferences."));
-            }
-        } catch (error) {
-            this.notifier.logError(error as Error);
-            return false;
-        }
-    }
-
-    /**
-     * Sync read so the webview HTML can be pre-rendered with the correct
-     * collapsed state and the panel never flashes visible before
-     * {@link sendPropertiesPanelState} delivers the value over the channel.
-     */
-    getPersistedPanelVisibility(): boolean {
-        return this.panelStateRepo.getVisibility();
-    }
-
-    async sendPropertiesPanelState(editorId: string): Promise<boolean> {
-        try {
-            const visible = this.panelStateRepo.getVisibility();
-            return await this.editorStore.postMessage(
-                editorId,
-                new PropertiesPanelStateQuery(visible),
-            );
-        } catch (error) {
-            this.notifier.logError(error as Error);
-            return false;
-        }
-    }
-
-    /**
-     * Intentionally does not re-broadcast to other open webviews: each
-     * webview is authoritative over its own panel, so hiding it in one
-     * side-by-side editor must not close it in its neighbour.
-     */
-    async setPropertiesPanelVisibility(visible: boolean): Promise<void> {
-        try {
-            await this.panelStateRepo.setVisibility(visible);
-        } catch (error) {
-            this.notifier.logError(error as Error);
-        }
-    }
-
-    /**
-     * The extension host mediates clipboard access: VS Code sandboxed iframes
-     * lack `clipboard-read` / `clipboard-write` permissions.
-     */
-    async readClipboard(editorId: string): Promise<boolean> {
-        try {
-            const text = await this.clipboard.readClipboard();
-            return await this.editorStore.postMessage(editorId, new ClipboardQuery(text));
-        } catch (error) {
-            this.notifier.logError(error as Error);
-            return false;
-        }
-    }
-
-    async readTextClipboard(editorId: string): Promise<boolean> {
-        try {
-            const text = await this.clipboard.readClipboard();
-            return await this.editorStore.postMessage(editorId, new TextClipboardQuery(text));
-        } catch (error) {
-            this.notifier.logError(error as Error);
-            return false;
-        }
-    }
-
-    async writeClipboard(text: string): Promise<void> {
-        try {
-            await this.clipboard.writeClipboard(text);
-        } catch (error) {
-            this.notifier.logError(error as Error);
-        }
-    }
-
-    setLanguage(editorId: string): void {
-        const locale = this.vsSettings.getLanguage();
-        this.editorStore.postMessage(editorId, new LanguageQuery(locale)).catch((error) => {
-            this.notifier.logError(error instanceof Error ? error : new Error(String(error)));
-        });
-    }
-
     async changeEngineVersion(editorId: string): Promise<boolean> {
         try {
             const doc = new BpmnDocument(this.vsDocument.getContent(editorId));
@@ -310,160 +140,6 @@ export class BpmnModelerService implements ArtifactChangeTarget {
             }
             return this.handleError(error as Error);
         }
-    }
-
-    /**
-     * Same-engine only — no cross-platform migration (C7↔C8).
-     */
-    async migrateAllDiagrams(): Promise<boolean> {
-        try {
-            const paths = await this.vsWorkspace.findFiles("**/*.bpmn");
-            if (paths.length === 0) {
-                this.notifier.showInfo("No BPMN files found in the workspace.");
-                return false;
-            }
-
-            const plan = await this.buildMigrationPlan(paths);
-            if (plan.isEmpty()) {
-                this.notifier.showInfo(
-                    "Could not detect the engine for any BPMN file in the workspace.",
-                );
-                return false;
-            }
-
-            if (plan.undetected.length > 0) {
-                this.notifier.logWarning(
-                    `Skipped ${plan.undetected.length} file(s) with undetectable engine: ${plan.undetected.join(", ")}`,
-                );
-            }
-
-            let scope: MigrationScope;
-            if (plan.hasBothPlatforms()) {
-                scope = await this.picker.pickMigrationScope(
-                    plan.c7Files.length,
-                    plan.c8Files.length,
-                );
-            } else if (plan.hasC7()) {
-                scope = "c7";
-            } else {
-                scope = "c8";
-            }
-
-            // Collect all input before any writes: document-change listeners
-            // triggered by a write would steal focus and dismiss a subsequent
-            // QuickPick.
-            let c7Version: string | undefined;
-            let c8Version: string | undefined;
-
-            if (scope === "c7" || scope === "both") {
-                c7Version = await this.picker.pickEngineVersion("c7", getVersions("c7"));
-            }
-            if (scope === "c8" || scope === "both") {
-                c8Version = await this.picker.pickEngineVersion("c8", getVersions("c8"));
-            }
-
-            const summaryParts: string[] = [];
-
-            if (c7Version) {
-                const c7Updated = await this.applyVersionUpdate(plan.c7Files, c7Version, "c7");
-                if (c7Updated > 0) {
-                    summaryParts.push(`${c7Updated} diagram(s) to Camunda 7 (${c7Version})`);
-                }
-            }
-
-            if (c8Version) {
-                const c8Updated = await this.applyVersionUpdate(plan.c8Files, c8Version, "c8");
-                if (c8Updated > 0) {
-                    summaryParts.push(`${c8Updated} diagram(s) to Camunda 8 (${c8Version})`);
-                }
-            }
-
-            if (summaryParts.length > 0) {
-                this.notifier.showInfo(`Updated ${summaryParts.join(" and ")}.`);
-            } else {
-                this.notifier.showInfo("All diagrams are already at the selected version.");
-            }
-
-            return true;
-        } catch (error) {
-            if (error instanceof UserCancelledError) {
-                return false;
-            }
-            return this.handleError(error as Error);
-        }
-    }
-
-    private async buildMigrationPlan(paths: string[]): Promise<MigrationPlan> {
-        const c7Files: BpmnFileEntry[] = [];
-        const c8Files: BpmnFileEntry[] = [];
-        const undetected: string[] = [];
-
-        for (const filePath of paths) {
-            const content = await this.vsWorkspace.readFile(filePath);
-            const doc = new BpmnDocument(content);
-            try {
-                const platform = doc.detectPlatform();
-                const entry: BpmnFileEntry = { path: filePath, document: doc, platform };
-                if (platform === "c7") {
-                    c7Files.push(entry);
-                } else {
-                    c8Files.push(entry);
-                }
-            } catch {
-                undetected.push(filePath);
-            }
-        }
-
-        return new MigrationPlan(c7Files, c8Files, undetected);
-    }
-
-    /**
-     * Files open in an editor are updated via {@link VsCodeDocument.write};
-     * files only on disk are written via {@link VsCodeWorkspace.writeFile}.
-     */
-    private async applyVersionUpdate(
-        files: readonly BpmnFileEntry[],
-        targetVersion: string,
-        platform: Engine,
-    ): Promise<number> {
-        let updatedCount = 0;
-
-        for (const file of files) {
-            const currentVersion = file.document.detectPlatformVersion();
-            if (currentVersion === targetVersion) {
-                continue;
-            }
-
-            let updatedDoc: BpmnDocument;
-            if (currentVersion === undefined) {
-                const platformName = platform === "c7" ? "Camunda Platform" : "Camunda Cloud";
-                const schema =
-                    platform === "c7"
-                        ? `xmlns:camunda="http://camunda.org/schema/1.0/bpmn"`
-                        : `xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"`;
-                updatedDoc = file.document.withExecutionPlatform(
-                    platformName,
-                    targetVersion,
-                    schema,
-                );
-                this.notifier.logWarning(
-                    `Added missing executionPlatform attribute to: ${file.path}`,
-                );
-            } else {
-                updatedDoc = file.document.withVersion(targetVersion);
-            }
-
-            const editorId = this.editorStore.findEditorIdByPath(file.path);
-            if (editorId !== undefined) {
-                await this.vsDocument.write(editorId, updatedDoc.xml);
-            } else {
-                await this.vsWorkspace.writeFile(file.path, updatedDoc.xml);
-            }
-
-            updatedCount++;
-        }
-
-        return updatedCount;
     }
 
     private handleError(error: Error): boolean {

--- a/apps/modeler-plugin/src/service/BpmnModelerService.ts
+++ b/apps/modeler-plugin/src/service/BpmnModelerService.ts
@@ -143,18 +143,15 @@ export class BpmnModelerService {
     }
 
     private handleError(error: Error): boolean {
-        this.notifier.logError(error);
-        this.notifier.showError(
-            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
+        this.notifier.notifyError(
+            "A problem occurred while trying to display the BPMN Modeler.",
+            error,
         );
         return false;
     }
 
     private handleSyncError(error: Error): boolean {
-        this.notifier.logError(error);
-        this.notifier.showError(
-            `A problem occurred while trying to sync the BPMN file.\n${error.message}`,
-        );
+        this.notifier.notifyError("A problem occurred while trying to sync the BPMN file.", error);
         return false;
     }
 }

--- a/apps/modeler-plugin/src/service/BpmnPropertiesPanelService.ts
+++ b/apps/modeler-plugin/src/service/BpmnPropertiesPanelService.ts
@@ -1,0 +1,55 @@
+import { PropertiesPanelStateQuery } from "@miragon/bpmn-modeler-shared";
+
+import { EditorStore } from "../infrastructure/EditorStore";
+import { PropertiesPanelStateRepository } from "../infrastructure/PropertiesPanelStateRepository";
+import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
+
+/**
+ * Owns persisted properties-panel visibility and pushes it to the webview.
+ *
+ * Reads are synchronous so the webview HTML can be pre-rendered with the
+ * correct collapsed state — the async channel push only confirms the value
+ * after the webview has booted.
+ */
+export class BpmnPropertiesPanelService {
+    constructor(
+        private readonly editorStore: EditorStore,
+        private readonly panelStateRepo: PropertiesPanelStateRepository,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    /**
+     * Sync read so the webview HTML can be pre-rendered with the correct
+     * collapsed state and the panel never flashes visible before
+     * {@link sendPropertiesPanelState} delivers the value over the channel.
+     */
+    getPersistedPanelVisibility(): boolean {
+        return this.panelStateRepo.getVisibility();
+    }
+
+    async sendPropertiesPanelState(editorId: string): Promise<boolean> {
+        try {
+            const visible = this.panelStateRepo.getVisibility();
+            return await this.editorStore.postMessage(
+                editorId,
+                new PropertiesPanelStateQuery(visible),
+            );
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            return false;
+        }
+    }
+
+    /**
+     * Intentionally does not re-broadcast to other open webviews: each
+     * webview is authoritative over its own panel, so hiding it in one
+     * side-by-side editor must not close it in its neighbour.
+     */
+    async setPropertiesPanelVisibility(visible: boolean): Promise<void> {
+        try {
+            await this.panelStateRepo.setVisibility(visible);
+        } catch (error) {
+            this.notifier.logError(error as Error);
+        }
+    }
+}

--- a/apps/modeler-plugin/src/service/BpmnSettingsBroadcaster.ts
+++ b/apps/modeler-plugin/src/service/BpmnSettingsBroadcaster.ts
@@ -54,10 +54,7 @@ export class BpmnSettingsBroadcaster {
     }
 
     private handleError(error: Error): boolean {
-        this.notifier.logError(error);
-        this.notifier.showError(
-            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
-        );
+        this.notifier.notifyError("A problem occurred while applying modeler settings.", error);
         return false;
     }
 

--- a/apps/modeler-plugin/src/service/BpmnSettingsBroadcaster.ts
+++ b/apps/modeler-plugin/src/service/BpmnSettingsBroadcaster.ts
@@ -1,0 +1,91 @@
+import { BpmnModelerSettingQuery, LanguageQuery } from "@miragon/bpmn-modeler-shared";
+
+import { SettingBuilder } from "../domain/model";
+import { EditorStore } from "../infrastructure/EditorStore";
+import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
+import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
+
+/**
+ * Pushes user-facing modeler settings (toolbar layout, theme, language, …)
+ * from VS Code's configuration store into the webview, and subscribes to
+ * configuration changes so the webview stays in sync.
+ *
+ * Owns its own subscription rather than letting the controller dispatch
+ * setting branches: every setting routed through here belongs to *this*
+ * service, so the fan-out logic lives next to the methods it triggers.
+ * {@link EditorStore} is infrastructure, so the subscription does not
+ * leak `vscode` into the service layer.
+ */
+export class BpmnSettingsBroadcaster {
+    constructor(
+        private readonly editorStore: EditorStore,
+        private readonly vsSettings: VsCodeSettings,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    async setSettings(editorId: string): Promise<boolean> {
+        try {
+            const settings = new SettingBuilder()
+                .alignToOrigin(this.vsSettings.getAlignToOrigin())
+                .showTransactionBoundaries(this.vsSettings.getShowTransactionBoundaries())
+                .colorTheme(this.vsSettings.getColorTheme())
+                .favouriteBpmnElements(this.vsSettings.getFavouriteBpmnElements())
+                .buildBpmnModeler();
+
+            if (
+                await this.editorStore.postMessage(
+                    editorId,
+                    new BpmnModelerSettingQuery({
+                        alignToOrigin: settings.alignToOrigin,
+                        showTransactionBoundaries: settings.showTransactionBoundaries,
+                        colorTheme: settings.colorTheme,
+                        favouriteBpmnElements: settings.favouriteBpmnElements,
+                    }),
+                )
+            ) {
+                return true;
+            } else {
+                return this.handleError(new Error("Unable to set preferences."));
+            }
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            return false;
+        }
+    }
+
+    private handleError(error: Error): boolean {
+        this.notifier.logError(error);
+        this.notifier.showError(
+            `A problem occurred while trying to display the BPMN Modeler.\n${error.message ?? error}`,
+        );
+        return false;
+    }
+
+    setLanguage(editorId: string): void {
+        const locale = this.vsSettings.getLanguage();
+        this.editorStore.postMessage(editorId, new LanguageQuery(locale)).catch((error) => {
+            this.notifier.logError(error instanceof Error ? error : new Error(String(error)));
+        });
+    }
+
+    /**
+     * Subscribes to configuration-change events for the editor and forwards
+     * relevant setting updates to the webview. Disposal is owned by the
+     * editor's disposable bag inside {@link EditorStore}.
+     */
+    subscribe(editorId: string): void {
+        this.editorStore.subscribeToSettingChangeEvent(editorId, (event, id) => {
+            if (
+                event.affectsConfiguration("miragon.bpmnModeler.alignToOrigin") ||
+                event.affectsConfiguration("miragon.bpmnModeler.showTransactionBoundaries") ||
+                event.affectsConfiguration("miragon.bpmnModeler.colorTheme") ||
+                event.affectsConfiguration("miragon.bpmnModeler.favouriteBpmnElements")
+            ) {
+                this.setSettings(id);
+            }
+            if (event.affectsConfiguration("miragon.bpmnModeler.language")) {
+                this.setLanguage(id);
+            }
+        });
+    }
+}


### PR DESCRIPTION
**Issue**

Closes: #1037

**Description**

Extract element-templates, settings, panel state, and clipboard handling
into dedicated service classes. This decouples session management from
cross-cutting concerns and lets each service own its configuration
subscriptions.

- BpmnElementTemplatesService: loads and broadcasts element templates
- BpmnSettingsBroadcaster: manages modeler settings and language
- BpmnPropertiesPanelService: owns panel visibility persistence
- BpmnClipboardMediator: mediates webview↔system clipboard access
- BpmnMigrationService: extracted workspace-wide diagram migration

Update BpmnEditorController to dispatch webview messages to the focused
services instead of routing everything through BpmnModelerService. Rename
subscribeToSettingChangeEvent to subscribeToConfigFolderChangeEvent since
other settings are now owned by BpmnSettingsBroadcaster.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
