### PR TITLE
refactor(diff): split BpmnDiffService into controller and store layers

### DIFF
--- a/apps/modeler-plugin/package.json
+++ b/apps/modeler-plugin/package.json
@@ -9,6 +9,7 @@
         "@miragon/bpmn-modeler-i18n": "workspace:*",
         "@miragon/bpmn-modeler-shared": "workspace:*",
         "bpmn-js-differ": "3.2.0",
+        "bpmn-moddle": "10.0.0",
         "lodash": "4.18.1",
         "min-dash": "5.0.0",
         "tslib": "2.8.1",

--- a/apps/modeler-plugin/src/controller/BpmnCompareController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnCompareController.ts
@@ -2,7 +2,7 @@ import { commands, ExtensionContext, Uri, window } from "vscode";
 
 import { CompareSelectionStore } from "../infrastructure/CompareSelectionStore";
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
-import { BpmnDiffService } from "../service/BpmnDiffService";
+import { BpmnDiffController } from "./BpmnDiffController";
 
 // VS Code command ID for the first step of a two-file BPMN compare.
 const SELECT_FOR_COMPARE_CMD = "bpmn-modeler.selectForCompare";
@@ -22,14 +22,14 @@ const STATUS_MESSAGE_TIMEOUT_MS = 3_000;
  * - **Two-step** (single right-click at a time): "Select for Compare" stores
  *   the URI in {@link CompareSelectionStore} and activates a context key so
  *   "Compare with Selected" appears on the next right-click.  The second
- *   step opens the diff via {@link BpmnDiffService.openCompareFilesDiff} and
+ *   step opens the diff via {@link BpmnDiffController.openCompareFilesDiff} and
  *   clears the selection (one-shot).
  * - **Single-step** (multi-selection of exactly two files): "Compare Selected"
  *   receives both URIs at once via the Explorer's `(uri, uris)` callback
  *   signature, skips the store entirely, and dispatches the same diff-open
  *   path.
  *
- * Both paths funnel through {@link BpmnDiffService.openCompareFilesDiff} so
+ * Both paths funnel through {@link BpmnDiffController.openCompareFilesDiff} so
  * session registration, tab-title construction, and error reporting stay in
  * one place — and the swap-sides flow can re-use the exact same entry point.
  *
@@ -42,14 +42,14 @@ export class BpmnCompareController {
     /**
      * @param selection Cross-command store holding the URI picked by the
      *   first step of the workflow.
-     * @param diffService Owns diff-session registration; must be notified
+     * @param diffController Owns diff-session registration; must be notified
      *   *before* `vscode.diff` is invoked so pane resolution finds the
      *   session synchronously.
      * @param notifier User-facing messages and logging.
      */
     constructor(
         private readonly selection: CompareSelectionStore,
-        private readonly diffService: BpmnDiffService,
+        private readonly diffController: BpmnDiffController,
         private readonly notifier: VsCodeNotifier,
     ) {}
 
@@ -111,7 +111,7 @@ export class BpmnCompareController {
             return;
         }
 
-        await this.diffService.openCompareFilesDiff(leftUri, rightUri);
+        await this.diffController.openCompareFilesDiff(leftUri, rightUri);
         await this.selection.clear();
     }
 
@@ -143,7 +143,7 @@ export class BpmnCompareController {
             return;
         }
 
-        await this.diffService.openCompareFilesDiff(leftUri, rightUri);
+        await this.diffController.openCompareFilesDiff(leftUri, rightUri);
     }
 }
 

--- a/apps/modeler-plugin/src/controller/BpmnDiffController.spec.ts
+++ b/apps/modeler-plugin/src/controller/BpmnDiffController.spec.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `window.tabGroups.all` is the only vscode value `shouldResolveAsDiff` reads;
+// the rest of the named imports are unused on this path. A mutable `tabs`
+// array lets each test stage the label heuristic. `vi.hoisted` keeps it usable
+// inside the (hoisted) `vi.mock` factory.
+const { tabs } = vi.hoisted(() => ({ tabs: [] as { input: unknown; label: string }[] }));
+vi.mock("vscode", () => ({
+    window: { tabGroups: { all: [{ tabs }] } },
+    workspace: { onDidChangeConfiguration: vi.fn() },
+    commands: { executeCommand: vi.fn() },
+    Uri: { parse: (value: string) => ({ scheme: value.split(":")[0], toString: () => value }) },
+}));
+
+import { DiffPaneStore } from "../infrastructure/DiffPaneStore";
+import { BpmnDiffController } from "./BpmnDiffController";
+
+/** Minimal vscode `Uri` stand-in carrying the two fields the controller reads. */
+function uri(scheme: string, value: string) {
+    return { scheme, toString: () => value } as never;
+}
+
+function createController() {
+    const store = new DiffPaneStore();
+    const service = {} as never;
+    const notifier = { logError: vi.fn(), showError: vi.fn() } as never;
+    return { controller: new BpmnDiffController(store, service, notifier), store };
+}
+
+describe("BpmnDiffController.shouldResolveAsDiff", () => {
+    beforeEach(() => {
+        tabs.length = 0;
+    });
+
+    it("returns false when a pane already exists for the URI (second resolve)", () => {
+        const { controller, store } = createController();
+        const value = "file:///repo/diagram.bpmn";
+        const session = store.registerCompareFiles("git:/repo/diagram.bpmn", value);
+        session.attachPane({
+            uri: value,
+            isReady: () => false,
+            setReady: vi.fn(),
+            getText: () => "",
+            postMessage: vi.fn().mockResolvedValue(true),
+            dispose: vi.fn(),
+        });
+
+        expect(controller.shouldResolveAsDiff(uri("file", value))).toBe(false);
+    });
+
+    it("returns true for a pre-registered compare-files URI with no pane yet", () => {
+        const { controller, store } = createController();
+        const value = "file:///repo/diagram.bpmn";
+        store.registerCompareFiles("git:/repo/diagram.bpmn", value);
+
+        expect(controller.shouldResolveAsDiff(uri("file", value))).toBe(true);
+    });
+
+    it("returns true for a Git-provided scheme (git / gitfs)", () => {
+        const { controller } = createController();
+        expect(controller.shouldResolveAsDiff(uri("git", "git:/repo/a.bpmn"))).toBe(true);
+        expect(controller.shouldResolveAsDiff(uri("gitfs", "gitfs:/repo/a.bpmn"))).toBe(true);
+    });
+
+    it("falls back to the diff-tab label heuristic for plain file URIs", () => {
+        const { controller } = createController();
+        const value = "file:///repo/diagram.bpmn";
+
+        // No diff tab open → not a diff.
+        expect(controller.shouldResolveAsDiff(uri("file", value))).toBe(false);
+
+        // A label-only tab (input undefined) annotated like a diff → diff.
+        tabs.push({ input: undefined, label: "diagram.bpmn (Working Tree)" });
+        expect(controller.shouldResolveAsDiff(uri("file", value))).toBe(true);
+    });
+
+    it("ignores tabs that carry an input (regular editors, not diffs)", () => {
+        const { controller } = createController();
+        const value = "file:///repo/diagram.bpmn";
+        tabs.push({ input: {}, label: "diagram.bpmn (Working Tree)" });
+
+        expect(controller.shouldResolveAsDiff(uri("file", value))).toBe(false);
+    });
+});

--- a/apps/modeler-plugin/src/controller/BpmnDiffController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnDiffController.ts
@@ -1,0 +1,344 @@
+import {
+    commands,
+    ConfigurationChangeEvent,
+    ExtensionContext,
+    TextDocument,
+    Uri,
+    WebviewPanel,
+    window,
+    workspace,
+} from "vscode";
+
+import {
+    Command,
+    CursorChangedCommand,
+    ViewportChangedCommand,
+} from "@miragon/bpmn-modeler-shared";
+
+import { DiffPaneHandle, DiffSession, basenameOfUriString } from "../domain/DiffSession";
+import { bootstrapWebview } from "../infrastructure/bootstrapWebview";
+import { DiffPaneStore } from "../infrastructure/DiffPaneStore";
+import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
+import { WebviewPaneHandle } from "../infrastructure/WebviewPaneHandle";
+import { BpmnDiffService } from "../service/BpmnDiffService";
+
+// VS Code view-type identifier for the BPMN custom editor.
+const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
+
+/**
+ * URI schemes used by Git-provider extensions to surface ref/index/working-tree
+ * documents. VS Code's built-in Git extension uses `git:`; Theia's `@theia/git`
+ * (used by the standalone desktop shell) uses `gitfs:`. Both are always
+ * readonly and always belong to a diff, so the scheme alone is a sufficient
+ * signal for `shouldResolveAsDiff`.
+ */
+const GIT_PROVIDED_SCHEMES = new Set<string>(["git", "gitfs"]);
+
+/**
+ * VS Code-facing surface for the BPMN diff feature.
+ *
+ * Owns every interaction with `vscode`: deciding whether a resolving editor is
+ * a diff pane, opening a `compare-files` diff (`vscode.diff`), bootstrapping a
+ * resolved pane, pairing SCM panes, routing webview messages, and the
+ * language-setting subscription. The session registry lives in
+ * {@link DiffPaneStore} and the diff content logic in {@link BpmnDiffService},
+ * both kept vscode-free.
+ *
+ * The domain moved from "pair of panes with mutual partner pointers" to
+ * {@link DiffSession}: an explicit object with fixed `before` / `after` URIs
+ * that any diff origin (SCM, `compare-files`) can register into. Pane
+ * resolution is a session lookup instead of a scheme-based heuristic.
+ */
+export class BpmnDiffController {
+    /**
+     * @param store Session registry (lookups, pending SCM panes, TTL timers).
+     * @param diffService Diff content driver (viewer file, differ, sync,
+     *   language broadcast).
+     * @param notifier Surfaces `vscode.diff` failures to the user.
+     */
+    constructor(
+        private readonly store: DiffPaneStore,
+        private readonly diffService: BpmnDiffService,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    /**
+     * Subscribes to language-setting changes so every open diff pane
+     * re-renders its locale-dependent chrome. The disposable lands on
+     * `context.subscriptions` for automatic release on extension deactivate.
+     */
+    register(context: ExtensionContext): void {
+        context.subscriptions.push(
+            workspace.onDidChangeConfiguration((event) => this.onConfigurationChanged(event)),
+        );
+    }
+
+    /**
+     * One-call `compare-files` diff-open: pre-registers the session, invokes
+     * `vscode.diff`, and constructs the tab title.
+     *
+     * Session registration must happen before `vscode.diff` so that when VS
+     * Code immediately resolves each pane through the
+     * `CustomTextEditorProvider`, pane lookup via {@link DiffPaneStore.findByUri}
+     * succeeds synchronously — otherwise the panes would fall through to the
+     * SCM label heuristic.
+     *
+     * Errors from `vscode.diff` are surfaced to the user here so both entry
+     * points (`BpmnCompareController` and {@link swapCompareFilesSides}) share
+     * the same failure UX.
+     */
+    async openCompareFilesDiff(leftUri: Uri, rightUri: Uri): Promise<void> {
+        this.store.registerCompareFiles(leftUri.toString(), rightUri.toString());
+        const title = `${basenameOfUriString(leftUri.toString())} ↔ ${basenameOfUriString(rightUri.toString())}`;
+        try {
+            await commands.executeCommand("vscode.diff", leftUri, rightUri, title, {
+                preview: false,
+            });
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            this.notifier.showError(`Failed to open compare view: ${(error as Error).message}`);
+        }
+    }
+
+    /**
+     * Returns `true` when this URI should resolve as a (new) diff pane.
+     *
+     * Decision tree:
+     *   1. A pane (full session or pending SCM entry) already exists for
+     *      this URI → false.  The caller is a *second* resolve, e.g. the
+     *      user opened the working-tree file in a normal editor tab after
+     *      the SCM diff was already open — that second tab is an editable
+     *      modeler, not another diff pane.
+     *   2. A pre-registered `compare-files` session exists → true.
+     *   3. The URI uses a Git-provided scheme (see
+     *      {@link GIT_PROVIDED_SCHEMES}) → true. Covers VS Code's `git:` and
+     *      Theia's `gitfs:` — both are always readonly and always belong to a
+     *      diff.
+     *   4. The URI sits in a diff tab per the label heuristic → true.  This
+     *      is the only signal for SCM diffs when both URIs share the `file:`
+     *      scheme (uncommon but possible for some diff-to-working-tree flows).
+     */
+    shouldResolveAsDiff(uri: Uri): boolean {
+        const needle = uri.toString();
+        if (this.store.hasPaneForUri(needle)) {
+            return false;
+        }
+        if (this.store.findByUri(needle)) {
+            return true;
+        }
+        if (GIT_PROVIDED_SCHEMES.has(uri.scheme)) {
+            return true;
+        }
+        return this.isPartOfDiff(uri);
+    }
+
+    /**
+     * Bootstraps a freshly-resolved diff pane.
+     *
+     * Resolution paths:
+     *   - Pre-registered `compare-files` session: looked up via the store,
+     *     pane attaches immediately, TTL cancels.
+     *   - First `scm` pane: stashed as pending, waits for partner.
+     *   - Second `scm` pane: paired with the pending entry, session created.
+     *
+     * Nothing about a diff pane flows through `EditorStore`, which keeps the
+     * two "same URI" panels (viewer + editable modeler that a user may open
+     * alongside the diff) from colliding.
+     */
+    resolveDiffPane(panel: WebviewPanel, document: TextDocument): void {
+        // Register listeners *before* we hand HTML to the webview: VS Code
+        // drops webview-originated messages that arrive before the extension
+        // has subscribed, and bootstrapping triggers an immediate
+        // `GetBpmnFileCommand` as soon as the webview's scripts run.
+        const handle = new WebviewPaneHandle(panel, document);
+
+        panel.webview.onDidReceiveMessage((message: Command) => this.onMessage(handle, message));
+        panel.onDidDispose(() => this.disposePane(handle));
+
+        const session = this.store.findByUri(handle.uri);
+        if (session) {
+            session.attachPane(handle);
+            this.store.cancelTtl(session);
+        } else {
+            this.attachOrPendScmPane(handle);
+        }
+
+        bootstrapWebview(BPMN_VIEW_TYPE, panel);
+    }
+
+    /**
+     * Returns `true` when `uri` belongs to an open BPMN diff tab.
+     *
+     * Label-based heuristic: when a file type has a `CustomTextEditorProvider`
+     * registered as default, VS Code's diff tabs surface as `Tab` objects with
+     * `input === undefined` — there is no `TabInputTextDiff` / `TabInputCustom`
+     * variant to branch on.  The only structural signal left is the label,
+     * which every diff annotates with a parenthetical (e.g.
+     * `"my-bpmn.bpmn (Working Tree)"`, `"… (HEAD)"`, `"… (HEAD~1 ↔ HEAD)"`)
+     * or the `↔` separator used by `vscode.diff(a, b)` when the two basenames
+     * differ.
+     */
+    private isPartOfDiff(uri: Uri): boolean {
+        const basename = basenameOfUriString(uri.toString());
+        if (!basename.endsWith(".bpmn")) {
+            return false;
+        }
+        for (const group of window.tabGroups.all) {
+            for (const tab of group.tabs) {
+                if (tab.input !== undefined) {
+                    continue;
+                }
+                if (tab.label.startsWith(`${basename} (`) || tab.label.includes(` ↔ `)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Either pairs `handle` with a pending SCM pane that shares its path
+     * (promoting both into a full {@link DiffSession}) or stashes `handle`
+     * as the pending pane for later pairing.
+     *
+     * Side assignment for SCM:
+     *   - If one URI is `file:` it is the working tree → `after`.
+     *   - Otherwise (ref-vs-ref, both `git:`) the first-registered pane is
+     *     `before`, second is `after` — arbitrary but matches the visual
+     *     order VS Code's SCM diff chose.
+     */
+    private attachOrPendScmPane(handle: WebviewPaneHandle): void {
+        const key = this.scmPairingKey(handle.document.uri);
+        const pending = this.store.getPendingScm(key);
+
+        if (!pending) {
+            this.store.addPendingScm(key, handle);
+            return;
+        }
+
+        this.store.deletePendingScm(key);
+        const { before, after } = resolveScmSides(pending, handle);
+        const session = DiffSession.forScm(before, after);
+        session.attachPane(before);
+        session.attachPane(after);
+        this.store.index(session);
+    }
+
+    /**
+     * Pairing key for matching the two panes of an SCM diff. Both VS Code
+     * (`git:foo.bpmn` ↔ `file:foo.bpmn`) and Theia (`gitfs:foo.bpmn` ↔
+     * `file:foo.bpmn`) surface the two sides with different schemes but the
+     * same workspace-relative `uri.path`, so the raw path is the pairing key.
+     *
+     * If a future host bakes ref metadata into the path (e.g.
+     * `/foo.bpmn@HEAD`), normalize it here so the two paths still meet.
+     */
+    private scmPairingKey(uri: Uri): string {
+        return uri.path;
+    }
+
+    private disposePane(handle: DiffPaneHandle): void {
+        // Drop from pending (no session ever formed).
+        if (this.store.removePendingByHandle(handle)) {
+            return;
+        }
+
+        // Drop from session; retire the session if both panes are gone.
+        const session = this.store.findByUri(handle.uri);
+        if (!session) {
+            return;
+        }
+        session.detachPane(handle);
+        if (session.isEmpty()) {
+            this.store.remove(session);
+        }
+    }
+
+    private async onMessage(handle: DiffPaneHandle, message: Command): Promise<void> {
+        switch (message.type) {
+            case "GetBpmnFileCommand":
+                await this.diffService.sendViewerFile(handle);
+                break;
+            case "DiffReadyCommand":
+                await this.diffService.markReady(handle);
+                break;
+            case "ViewportChangedCommand":
+                await this.diffService.forwardViewport(
+                    handle,
+                    (message as ViewportChangedCommand).viewport,
+                );
+                break;
+            case "CursorChangedCommand":
+                await this.diffService.forwardCursor(
+                    handle,
+                    (message as CursorChangedCommand).index,
+                );
+                break;
+            case "SwapCompareSidesCommand":
+                await this.swapCompareFilesSides(handle);
+                break;
+        }
+    }
+
+    /**
+     * Closes the current diff tab and reopens it with the two URIs swapped.
+     *
+     * Only applies to `compare-files` sessions: the extension owns both URIs
+     * and the tab title, so it can legitimately retire and recreate the diff.
+     * SCM panes never emit `SwapCompareSidesCommand` — the button is hidden
+     * there — but we still guard against misuse since message routing cannot
+     * encode origin at the type level.
+     *
+     * Disposing the webview panels triggers {@link disposePane} for both
+     * sides, which tears down the old session and removes it from the
+     * indexes.  The subsequent {@link openCompareFilesDiff} then registers a
+     * fresh session with the reversed before/after assignment.
+     */
+    private async swapCompareFilesSides(handle: DiffPaneHandle): Promise<void> {
+        const session = this.store.findByUri(handle.uri);
+        if (!session || session.origin !== "compare-files") {
+            return;
+        }
+        const { beforeUri, afterUri } = session;
+        for (const pane of session.attachedPanes()) {
+            pane.dispose();
+        }
+        await this.openCompareFilesDiff(Uri.parse(afterUri), Uri.parse(beforeUri));
+    }
+
+    /**
+     * Re-posts the current locale to every ready diff pane when the user
+     * changes `miragon.bpmnModeler.language`.  Ignores unrelated setting
+     * changes so panes only churn when the language actually moves.
+     */
+    private onConfigurationChanged(event: ConfigurationChangeEvent): void {
+        if (!event.affectsConfiguration("miragon.bpmnModeler.language")) {
+            return;
+        }
+        this.diffService.rebroadcastLanguage();
+    }
+}
+
+/**
+ * SCM-diff side assignment for two panes that share a path.
+ *
+ * Invariant: `file:` URIs represent the working tree and must be `after`.
+ * For ref-vs-ref diffs (both `git:` in VS Code, both `gitfs:` in Theia) side
+ * follows resolution order, which mirrors the host's own visual ordering.
+ *
+ * The scheme is read from each handle's stringified `uri` (round-trips
+ * identically to `document.uri.scheme`), so this works on the abstract
+ * {@link DiffPaneHandle} without reaching for the concrete panel.
+ */
+function resolveScmSides(
+    first: DiffPaneHandle,
+    second: DiffPaneHandle,
+): { before: DiffPaneHandle; after: DiffPaneHandle } {
+    if (Uri.parse(second.uri).scheme === "file") {
+        return { before: first, after: second };
+    }
+    if (Uri.parse(first.uri).scheme === "file") {
+        return { before: second, after: first };
+    }
+    return { before: first, after: second };
+}

--- a/apps/modeler-plugin/src/controller/BpmnEditorController.ts
+++ b/apps/modeler-plugin/src/controller/BpmnEditorController.ts
@@ -26,7 +26,7 @@ import { BpmnClipboardMediator } from "../service/BpmnClipboardMediator";
 import { BpmnElementTemplatesService } from "../service/BpmnElementTemplatesService";
 import { BpmnPropertiesPanelService } from "../service/BpmnPropertiesPanelService";
 import { BpmnSettingsBroadcaster } from "../service/BpmnSettingsBroadcaster";
-import { BpmnDiffService } from "../service/BpmnDiffService";
+import { BpmnDiffController } from "./BpmnDiffController";
 import { ArtifactService } from "../service/ArtifactService";
 import { ScriptTaskService } from "./ScriptTaskService";
 import { ModelNavigationService } from "../service/ModelNavigationService";
@@ -51,7 +51,7 @@ export class BpmnEditorController implements CustomTextEditorProvider {
         private readonly settingsBroadcaster: BpmnSettingsBroadcaster,
         private readonly panelSvc: BpmnPropertiesPanelService,
         private readonly clipboardMediator: BpmnClipboardMediator,
-        private readonly diffService: BpmnDiffService,
+        private readonly diffController: BpmnDiffController,
         private readonly artifactSvc: ArtifactService,
         private readonly scriptTaskSvc: ScriptTaskService,
         private readonly notifier: VsCodeNotifier,
@@ -87,17 +87,17 @@ export class BpmnEditorController implements CustomTextEditorProvider {
     ): Promise<void> {
         try {
             /**
-             * Diff branch: the service decides whether this URI should
-             * resolve as a diff pane.  It checks, in order: a pre-registered
-             * `compare-files` session (our own command), `git:` scheme
-             * (always readonly, always SCM), or the label-based SCM diff
-             * heuristic — while also guarding against a *second* resolve
+             * Diff branch: the diff controller decides whether this URI
+             * should resolve as a diff pane.  It checks, in order: a
+             * pre-registered `compare-files` session (our own command), `git:`
+             * scheme (always readonly, always SCM), or the label-based SCM
+             * diff heuristic — while also guarding against a *second* resolve
              * for a URI that already has a pane (e.g. user opens the
              * working-tree file in a normal editor tab while the SCM diff
              * is still open).
              */
-            if (this.diffService.shouldResolveAsDiff(document.uri)) {
-                this.diffService.resolveDiffPane(webviewPanel, document);
+            if (this.diffController.shouldResolveAsDiff(document.uri)) {
+                this.diffController.resolveDiffPane(webviewPanel, document);
                 return;
             }
 

--- a/apps/modeler-plugin/src/domain/DiffSession.spec.ts
+++ b/apps/modeler-plugin/src/domain/DiffSession.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DiffPaneHandle, DiffSession, basenameOfUriString } from "./DiffSession";
+
+// ─── Fakes ──────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal {@link DiffPaneHandle} stand-in — the session only reads `uri` and
+ * `isReady()`, so the rest are inert spies.
+ */
+function fakeHandle(uri: string, ready = false): DiffPaneHandle {
+    let readyFlag = ready;
+    return {
+        uri,
+        isReady: () => readyFlag,
+        setReady: () => {
+            readyFlag = true;
+        },
+        getText: vi.fn(() => ""),
+        postMessage: vi.fn().mockResolvedValue(true),
+        dispose: vi.fn(),
+    };
+}
+
+const BEFORE = "git:/repo/diagram.bpmn?ref=HEAD";
+const AFTER = "file:///repo/diagram.bpmn";
+
+// ─── basenameOfUriString ──────────────────────────────────────────────────────
+
+describe("basenameOfUriString", () => {
+    it("returns the bare filename for a plain file URI", () => {
+        expect(basenameOfUriString("file:///repo/sub/diagram.bpmn")).toBe("diagram.bpmn");
+    });
+
+    it("trims a query string so ref-annotated URIs still resolve", () => {
+        expect(basenameOfUriString("file:///repo/diagram.bpmn?ref=HEAD")).toBe("diagram.bpmn");
+    });
+
+    it("trims a fragment", () => {
+        expect(basenameOfUriString("file:///repo/diagram.bpmn#section")).toBe("diagram.bpmn");
+    });
+
+    it("URL-decodes percent-encoded characters", () => {
+        expect(basenameOfUriString("file:///repo/my%20diagram.bpmn")).toBe("my diagram.bpmn");
+    });
+});
+
+// ─── Factories & side assignment ──────────────────────────────────────────────
+
+describe("DiffSession", () => {
+    it("forCompareFiles fixes left=before, right=after", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        expect(session.origin).toBe("compare-files");
+        expect(session.beforeUri).toBe(BEFORE);
+        expect(session.afterUri).toBe(AFTER);
+    });
+
+    it("forScm takes the URIs from the pre-sorted before/after handles", () => {
+        const session = DiffSession.forScm(fakeHandle(BEFORE), fakeHandle(AFTER));
+        expect(session.origin).toBe("scm");
+        expect(session.beforeUri).toBe(BEFORE);
+        expect(session.afterUri).toBe(AFTER);
+    });
+
+    it("sideFor maps each URI to its slot and unknown URIs to undefined", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        expect(session.sideFor(BEFORE)).toBe("before");
+        expect(session.sideFor(AFTER)).toBe("after");
+        expect(session.sideFor("file:///other.bpmn")).toBeUndefined();
+    });
+
+    // ─── Attach / detach / partner ─────────────────────────────────────────
+
+    it("attachPane fills the slot matching the handle URI", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        const before = fakeHandle(BEFORE);
+
+        expect(session.attachPane(before)).toBe("before");
+        expect(session.before()).toBe(before);
+        expect(session.hasPaneFor(BEFORE)).toBe(true);
+        expect(session.hasPaneFor(AFTER)).toBe(false);
+    });
+
+    it("attachPane returns undefined for a foreign URI and leaves slots empty", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        expect(session.attachPane(fakeHandle("file:///foreign.bpmn"))).toBeUndefined();
+        expect(session.isEmpty()).toBe(true);
+    });
+
+    it("partnerOf returns the opposite attached pane", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        const before = fakeHandle(BEFORE);
+        const after = fakeHandle(AFTER);
+        session.attachPane(before);
+        session.attachPane(after);
+
+        expect(session.partnerOf(before)).toBe(after);
+        expect(session.partnerOf(after)).toBe(before);
+    });
+
+    it("partnerOf is undefined while the session is half-attached", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        const before = fakeHandle(BEFORE);
+        session.attachPane(before);
+        expect(session.partnerOf(before)).toBeUndefined();
+    });
+
+    it("detachPane empties the slot and is a no-op for unknown handles", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        const before = fakeHandle(BEFORE);
+        session.attachPane(before);
+
+        session.detachPane(fakeHandle("file:///unknown.bpmn"));
+        expect(session.before()).toBe(before);
+
+        session.detachPane(before);
+        expect(session.before()).toBeUndefined();
+        expect(session.isEmpty()).toBe(true);
+    });
+
+    it("attachedPanes lists only the attached slots", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        expect(session.attachedPanes()).toEqual([]);
+
+        const before = fakeHandle(BEFORE);
+        session.attachPane(before);
+        expect(session.attachedPanes()).toEqual([before]);
+
+        const after = fakeHandle(AFTER);
+        session.attachPane(after);
+        expect(session.attachedPanes()).toEqual([before, after]);
+    });
+
+    // ─── Armed state ────────────────────────────────────────────────────────
+
+    it("isArmed only when both panes are attached AND ready", () => {
+        const session = DiffSession.forCompareFiles(BEFORE, AFTER);
+        const before = fakeHandle(BEFORE, false);
+        const after = fakeHandle(AFTER, false);
+        session.attachPane(before);
+        session.attachPane(after);
+
+        expect(session.isArmed()).toBe(false); // neither ready
+        before.setReady();
+        expect(session.isArmed()).toBe(false); // only one ready
+        after.setReady();
+        expect(session.isArmed()).toBe(true); // both ready
+    });
+});

--- a/apps/modeler-plugin/src/domain/DiffSession.ts
+++ b/apps/modeler-plugin/src/domain/DiffSession.ts
@@ -6,9 +6,9 @@ export { DiffOrigin };
  * Domain handle for a single diff pane.
  *
  * Wraps whatever the host gave us (in production: a `WebviewPanel` +
- * `TextDocument` pair — see `WebviewPaneHandle` in {@link BpmnDiffService}).
- * The session sees only this handle, which lets `DiffSession` stay free of
- * `vscode` imports and lets tests substitute a plain object.
+ * `TextDocument` pair — see `WebviewPaneHandle`). The session sees only this
+ * handle, which lets `DiffSession` stay free of `vscode` imports and lets
+ * tests substitute a plain object.
  *
  * `uri` is the canonical identity used by the session's lookups — it must
  * be the stringified URI of the underlying document (i.e.
@@ -26,6 +26,20 @@ export interface DiffPaneHandle {
     getText(): string;
     postMessage(msg: unknown): Promise<boolean>;
     dispose(): void;
+}
+
+/**
+ * Extracts the human-visible basename from a stringified URI.
+ *
+ * Trims query/fragment so e.g. `file:///foo.bpmn?ref=HEAD` still resolves to
+ * `foo.bpmn`. `Uri.toString()` keeps `?` / `#` for any host that uses them;
+ * the bare path is what users see in the tab and in the diff legend label.
+ */
+export function basenameOfUriString(uri: string): string {
+    const noFragment = uri.split("#")[0];
+    const noQuery = noFragment.split("?")[0];
+    const parts = noQuery.split("/");
+    return decodeURIComponent(parts[parts.length - 1] ?? "");
 }
 
 /**
@@ -47,7 +61,7 @@ export interface DiffPaneHandle {
  * inherent to the session, not inferred from the pane that attaches first.
  */
 export class DiffSession {
-    // Wall-clock ms at construction — used by the TTL sweeper in the service.
+    // Wall-clock ms at construction — used by the TTL sweeper in the store.
     readonly createdAt: number = Date.now();
 
     private beforePane?: DiffPaneHandle;
@@ -126,7 +140,7 @@ export class DiffSession {
      *
      * @returns The assigned side, or `undefined` when the handle's URI does
      *   not belong to this session. Callers should treat `undefined` as a
-     *   programming error — only the owning diff service should be
+     *   programming error — only the owning diff machinery should be
      *   attaching panes, and it should only do so after a successful
      *   session lookup.
      */

--- a/apps/modeler-plugin/src/infrastructure/DiffPaneStore.spec.ts
+++ b/apps/modeler-plugin/src/infrastructure/DiffPaneStore.spec.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `DiffPaneStore` imports the `Disposable` *type* from vscode; it is erased at
+// runtime, but the module specifier must still resolve under vitest.
+vi.mock("vscode", () => ({}));
+
+import { DiffPaneHandle } from "../domain/DiffSession";
+import { DiffPaneStore } from "./DiffPaneStore";
+
+function fakeHandle(uri: string): DiffPaneHandle {
+    let ready = false;
+    return {
+        uri,
+        isReady: () => ready,
+        setReady: () => {
+            ready = true;
+        },
+        getText: vi.fn(() => ""),
+        postMessage: vi.fn().mockResolvedValue(true),
+        dispose: vi.fn(),
+    };
+}
+
+const LEFT = "git:/repo/diagram.bpmn?ref=HEAD";
+const RIGHT = "file:///repo/diagram.bpmn";
+
+describe("DiffPaneStore", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    // ─── compare-files registration & lookup ────────────────────────────────
+
+    it("registerCompareFiles indexes both URIs to the same session", () => {
+        const store = new DiffPaneStore();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+
+        expect(store.findByUri(LEFT)).toBe(session);
+        expect(store.findByUri(RIGHT)).toBe(session);
+        expect(session.origin).toBe("compare-files");
+    });
+
+    it("findByUri returns undefined for an unknown URI", () => {
+        const store = new DiffPaneStore();
+        expect(store.findByUri("file:///nothing.bpmn")).toBeUndefined();
+    });
+
+    // ─── hasPaneForUri ───────────────────────────────────────────────────────
+
+    it("hasPaneForUri is true once a pane is attached to the session", () => {
+        const store = new DiffPaneStore();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+
+        expect(store.hasPaneForUri(LEFT)).toBe(false); // registered, not attached
+        session.attachPane(fakeHandle(LEFT));
+        expect(store.hasPaneForUri(LEFT)).toBe(true);
+    });
+
+    it("hasPaneForUri is true for a pending SCM pane", () => {
+        const store = new DiffPaneStore();
+        store.addPendingScm("/repo/diagram.bpmn", fakeHandle(RIGHT));
+        expect(store.hasPaneForUri(RIGHT)).toBe(true);
+    });
+
+    // ─── pending SCM panes ────────────────────────────────────────────────────
+
+    it("add/get/delete pending SCM panes by key", () => {
+        const store = new DiffPaneStore();
+        const handle = fakeHandle(RIGHT);
+        const key = "/repo/diagram.bpmn";
+
+        store.addPendingScm(key, handle);
+        expect(store.getPendingScm(key)).toBe(handle);
+
+        store.deletePendingScm(key);
+        expect(store.getPendingScm(key)).toBeUndefined();
+    });
+
+    it("removePendingByHandle drops the matching entry and reports success", () => {
+        const store = new DiffPaneStore();
+        const handle = fakeHandle(RIGHT);
+        store.addPendingScm("/repo/diagram.bpmn", handle);
+
+        expect(store.removePendingByHandle(handle)).toBe(true);
+        expect(store.removePendingByHandle(handle)).toBe(false); // already gone
+        expect(store.hasPaneForUri(RIGHT)).toBe(false);
+    });
+
+    // ─── remove ────────────────────────────────────────────────────────────────
+
+    it("remove clears both index entries", () => {
+        const store = new DiffPaneStore();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+
+        store.remove(session);
+        expect(store.findByUri(LEFT)).toBeUndefined();
+        expect(store.findByUri(RIGHT)).toBeUndefined();
+    });
+
+    // ─── TTL sweeping ────────────────────────────────────────────────────────
+
+    it("sweeps an orphaned compare-files session after the TTL elapses", () => {
+        const store = new DiffPaneStore();
+        store.registerCompareFiles(LEFT, RIGHT);
+
+        vi.advanceTimersByTime(30_000);
+
+        expect(store.findByUri(LEFT)).toBeUndefined();
+        expect(store.findByUri(RIGHT)).toBeUndefined();
+    });
+
+    it("cancelTtl keeps a session alive past the TTL once a pane attaches", () => {
+        const store = new DiffPaneStore();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+
+        session.attachPane(fakeHandle(LEFT));
+        store.cancelTtl(session);
+        vi.advanceTimersByTime(30_000);
+
+        expect(store.findByUri(LEFT)).toBe(session);
+    });
+
+    it("the TTL sweep leaves a session that gained a pane untouched", () => {
+        const store = new DiffPaneStore();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+
+        // A pane attaches but the timer is (deliberately) not cancelled — the
+        // emptiness guard must still spare the session when the sweep fires.
+        session.attachPane(fakeHandle(LEFT));
+        vi.advanceTimersByTime(30_000);
+
+        expect(store.findByUri(LEFT)).toBe(session);
+    });
+
+    it("dispose clears armed TTL timers so they never fire", () => {
+        const store = new DiffPaneStore();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+
+        store.dispose();
+        vi.advanceTimersByTime(30_000);
+
+        // The session is still indexed because the sweep never ran.
+        expect(store.findByUri(LEFT)).toBe(session);
+    });
+});

--- a/apps/modeler-plugin/src/infrastructure/DiffPaneStore.ts
+++ b/apps/modeler-plugin/src/infrastructure/DiffPaneStore.ts
@@ -1,0 +1,190 @@
+import { Disposable } from "vscode";
+
+import { DiffPaneHandle, DiffSession } from "../domain/DiffSession";
+
+/**
+ * Milliseconds a pre-registered `compare-files` session stays alive with no
+ * panes attached before it is swept.  Covers the "user triggered the command
+ * but the diff tab never opened" edge case.  Longer than any realistic
+ * `vscode.diff` → `resolveCustomTextEditor` latency; short enough that
+ * registering the same pair again after a cancel works without collisions.
+ */
+const COMPARE_FILES_TTL_MS = 30_000;
+
+/**
+ * Registry for every live BPMN diff session and the panes attached to them.
+ *
+ * Pure in-memory state with no diff orchestration: it answers "which session
+ * owns this URI?", holds SCM panes waiting for their partner, and arms the
+ * TTL sweeper that drops orphaned `compare-files` sessions. Deciding *when*
+ * to pair, broadcast, or open a diff lives in the controller and service.
+ *
+ * Implements {@link Disposable} so the extension host can clear any armed TTL
+ * timers on deactivate.
+ */
+export class DiffPaneStore implements Disposable {
+    // Every live session, keyed by `${beforeUri}|${afterUri}`.
+    private readonly sessions = new Map<string, DiffSession>();
+
+    /**
+     * Lookup index: URI string → session it belongs to.  Populated as soon as
+     * a session is created, whether pre-registered (`compare-files`) or
+     * lazily formed (`scm`).
+     */
+    private readonly sessionByUri = new Map<string, DiffSession>();
+
+    /**
+     * SCM panes awaiting their partner, keyed by pairing key (the shared
+     * `uri.path`). The Git-provided URI (`git:` in VS Code, `gitfs:` in
+     * Theia) and the working-tree `file:` URI meet here before the controller
+     * promotes them into a session.
+     */
+    private readonly pendingScm = new Map<string, DiffPaneHandle>();
+
+    /**
+     * TTL sweepers for pre-registered `compare-files` sessions.  Cleared
+     * once the first pane attaches.
+     */
+    private readonly ttlTimers = new Map<DiffSession, ReturnType<typeof setTimeout>>();
+
+    /**
+     * Pre-registers a `compare-files` session before `vscode.diff` runs.
+     *
+     * Side assignment is fixed: `beforeUri` is the left pane, `afterUri` the
+     * right — matching the visual order VS Code renders `vscode.diff(a, b)`
+     * in. A TTL sweeper drops the session if no pane attaches within
+     * {@link COMPARE_FILES_TTL_MS}; {@link cancelTtl} disarms it as soon as
+     * the first pane arrives.
+     */
+    registerCompareFiles(beforeUri: string, afterUri: string): DiffSession {
+        const session = DiffSession.forCompareFiles(beforeUri, afterUri);
+        this.index(session);
+        this.ttlTimers.set(
+            session,
+            setTimeout(() => this.sweepOrphan(session), COMPARE_FILES_TTL_MS),
+        );
+        return session;
+    }
+
+    /**
+     * Adds `session` to the `sessions` map and the per-URI lookup index.
+     *
+     * Both session-creation paths (eager `compare-files` and lazy `scm`)
+     * funnel through here so the two maps never drift out of sync.
+     */
+    index(session: DiffSession): void {
+        this.sessions.set(this.sessionIdOf(session), session);
+        this.sessionByUri.set(session.beforeUri, session);
+        this.sessionByUri.set(session.afterUri, session);
+    }
+
+    /**
+     * Returns the session this URI belongs to, or `undefined` when none
+     * exists yet.  Covers both pre-registered `compare-files` sessions and
+     * `scm` sessions that have already been promoted from a pending pane.
+     */
+    findByUri(uri: string): DiffSession | undefined {
+        return this.sessionByUri.get(uri);
+    }
+
+    /**
+     * Removes `session` from both indexes and disarms its TTL timer.
+     */
+    remove(session: DiffSession): void {
+        this.sessions.delete(this.sessionIdOf(session));
+        this.sessionByUri.delete(session.beforeUri);
+        this.sessionByUri.delete(session.afterUri);
+        this.cancelTtl(session);
+    }
+
+    /**
+     * Returns `true` when any pane — attached to a session or still pending
+     * SCM pairing — currently renders `uri`.
+     */
+    hasPaneForUri(uri: string): boolean {
+        const session = this.sessionByUri.get(uri);
+        if (session?.hasPaneFor(uri)) {
+            return true;
+        }
+        for (const handle of this.pendingScm.values()) {
+            if (handle.uri === uri) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Disarms the TTL sweeper for `session`, if one is armed.
+     */
+    cancelTtl(session: DiffSession): void {
+        const timer = this.ttlTimers.get(session);
+        if (timer) {
+            clearTimeout(timer);
+            this.ttlTimers.delete(session);
+        }
+    }
+
+    getPendingScm(key: string): DiffPaneHandle | undefined {
+        return this.pendingScm.get(key);
+    }
+
+    addPendingScm(key: string, handle: DiffPaneHandle): void {
+        this.pendingScm.set(key, handle);
+    }
+
+    deletePendingScm(key: string): void {
+        this.pendingScm.delete(key);
+    }
+
+    /**
+     * Drops a pending SCM pane by identity (used when a pane that never
+     * paired is disposed).
+     *
+     * @returns `true` when a pending entry was found and removed.
+     */
+    removePendingByHandle(handle: DiffPaneHandle): boolean {
+        for (const [key, pending] of this.pendingScm) {
+            if (pending === handle) {
+                this.pendingScm.delete(key);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * All currently-registered sessions — used to fan a language re-broadcast
+     * out to every open diff pane.
+     */
+    allSessions(): Iterable<DiffSession> {
+        return this.sessions.values();
+    }
+
+    dispose(): void {
+        for (const timer of this.ttlTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.ttlTimers.clear();
+    }
+
+    private sessionIdOf(session: DiffSession): string {
+        return `${session.beforeUri}|${session.afterUri}`;
+    }
+
+    /**
+     * TTL expiry: retire the session only if it never gained a pane. A
+     * session that attached a pane (and thus cancelled its timer) should
+     * never reach here, but the emptiness guard keeps the sweep safe against
+     * races.
+     */
+    private sweepOrphan(session: DiffSession): void {
+        this.ttlTimers.delete(session);
+        if (!session.isEmpty()) {
+            return;
+        }
+        this.sessions.delete(this.sessionIdOf(session));
+        this.sessionByUri.delete(session.beforeUri);
+        this.sessionByUri.delete(session.afterUri);
+    }
+}

--- a/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
+++ b/apps/modeler-plugin/src/infrastructure/VsCodeWorkspace.ts
@@ -30,6 +30,40 @@ export class VsCodeWorkspace {
     }
 
     /**
+     * Returns the path of the workspace folder containing `document`, or
+     * `undefined` when the document lies outside every open folder.
+     *
+     * Non-throwing companion to {@link getWorkspaceFolderForDocument}: the
+     * model-navigation search treats "no containing folder" as the signal to
+     * fall back to a loose-file fs walk, so absence is an expected outcome
+     * rather than an error.
+     */
+    findWorkspaceFolderForDocument(document: string): string | undefined {
+        return workspace.getWorkspaceFolder(Uri.file(document))?.uri.path;
+    }
+
+    /**
+     * Lists the open workspace-folder root paths — empty when no folder is
+     * open (the loose-file / single-file-window case).
+     */
+    getWorkspaceFolderPaths(): string[] {
+        return (workspace.workspaceFolders ?? []).map((folder) => folder.uri.path);
+    }
+
+    /**
+     * Returns the directory containing `document` in the `uri.path` form the
+     * rest of this adapter speaks.
+     *
+     * Routing the OS path through `Uri.file(...).path` is what lets callers
+     * pass a raw `uri.fsPath` and stay free of `vscode.Uri`; the normalization
+     * matters on Windows, where `fsPath` (`c:\a\b`) and `uri.path`
+     * (`/c:/a/b`) diverge.
+     */
+    getDocumentDirectory(document: string): string {
+        return posix.dirname(Uri.file(document).path);
+    }
+
+    /**
      * Walks upward from `startDir` looking for a directory containing a `.git`
      * entry, indicating the root of a git repository.
      *

--- a/apps/modeler-plugin/src/infrastructure/WebviewPaneHandle.ts
+++ b/apps/modeler-plugin/src/infrastructure/WebviewPaneHandle.ts
@@ -1,0 +1,44 @@
+import { TextDocument, WebviewPanel } from "vscode";
+
+import { DiffPaneHandle } from "../domain/DiffSession";
+
+/**
+ * Infrastructure adapter that wraps a real `WebviewPanel` + `TextDocument`
+ * pair into the {@link DiffPaneHandle} the diff machinery uses.
+ *
+ * Confining the only `WebviewPanel`/`TextDocument` references to this adapter
+ * is what lets {@link DiffSession}, `DiffPaneStore`, and `BpmnDiffService`
+ * stay vscode-free — they see only the abstract handle.
+ */
+export class WebviewPaneHandle implements DiffPaneHandle {
+    private readyFlag = false;
+
+    constructor(
+        readonly panel: WebviewPanel,
+        readonly document: TextDocument,
+    ) {}
+
+    get uri(): string {
+        return this.document.uri.toString();
+    }
+
+    isReady(): boolean {
+        return this.readyFlag;
+    }
+
+    setReady(): void {
+        this.readyFlag = true;
+    }
+
+    getText(): string {
+        return this.document.getText();
+    }
+
+    postMessage(msg: unknown): Promise<boolean> {
+        return Promise.resolve(this.panel.webview.postMessage(msg));
+    }
+
+    dispose(): void {
+        this.panel.dispose();
+    }
+}

--- a/apps/modeler-plugin/src/main.ts
+++ b/apps/modeler-plugin/src/main.ts
@@ -4,6 +4,7 @@ import { setContext } from "./infrastructure/extensionContext";
 
 import { BpmnScriptFileSystem } from "./infrastructure/BpmnScriptFileSystem";
 import { CompareSelectionStore } from "./infrastructure/CompareSelectionStore";
+import { DiffPaneStore } from "./infrastructure/DiffPaneStore";
 import { EditorStore } from "./infrastructure/EditorStore";
 import { PropertiesPanelStateRepository } from "./infrastructure/PropertiesPanelStateRepository";
 import { VsCodeDocument } from "./infrastructure/VsCodeDocument";
@@ -26,6 +27,7 @@ import { DmnModelerService } from "./service/DmnModelerService";
 import { ModelNavigationService } from "./service/ModelNavigationService";
 import { ReferencedModelLocator } from "./service/modelNavigation/ReferencedModelLocator";
 import { BpmnCompareController } from "./controller/BpmnCompareController";
+import { BpmnDiffController } from "./controller/BpmnDiffController";
 import { CommandController } from "./controller/CommandController";
 import { BpmnEditorController } from "./controller/BpmnEditorController";
 import { DmnEditorController } from "./controller/DmnEditorController";
@@ -99,8 +101,11 @@ export function activate(context: ExtensionContext): void {
     const settingsBroadcaster = new BpmnSettingsBroadcaster(editorStore, vsSettings, notifier);
     const panelSvc = new BpmnPropertiesPanelService(editorStore, panelStateRepo, notifier);
     const dmnService = new DmnModelerService(editorStore, vsDocument, notifier);
-    const diffService = new BpmnDiffService(notifier, vsSettings);
-    context.subscriptions.push(diffService);
+    const diffStore = new DiffPaneStore();
+    context.subscriptions.push(diffStore);
+    const diffService = new BpmnDiffService(notifier, vsSettings, diffStore);
+    const diffController = new BpmnDiffController(diffStore, diffService, notifier);
+    diffController.register(context);
     const deploymentSvc = new DeploymentService(
         vsDocument,
         vsWorkspace,
@@ -146,7 +151,7 @@ export function activate(context: ExtensionContext): void {
         settingsBroadcaster,
         panelSvc,
         clipboardMediator,
-        diffService,
+        diffController,
         artifactSvc,
         scriptTaskSvc,
         notifier,
@@ -155,7 +160,7 @@ export function activate(context: ExtensionContext): void {
         modelNavigationService,
     ).register(context);
     new DmnEditorController(editorStore, dmnService, notifier).register(context);
-    new BpmnCompareController(compareSelection, diffService, notifier).register(context);
+    new BpmnCompareController(compareSelection, diffController, notifier).register(context);
     commandController.register(context);
     new DeploymentController(
         editorStore,

--- a/apps/modeler-plugin/src/service/BpmnDiffService.spec.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.spec.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The service is vscode-free, but `DiffPaneStore` (constructed here as the real
+// backing registry) imports the `Disposable` *type* from vscode — erased at
+// runtime, yet the specifier must resolve under vitest.
+vi.mock("vscode", () => ({}));
+
+import { DiffPaneHandle } from "../domain/DiffSession";
+import { DiffPaneStore } from "../infrastructure/DiffPaneStore";
+import { BpmnDiffService } from "./BpmnDiffService";
+
+// ─── Sample BPMN ──────────────────────────────────────────────────────────────
+
+const beforeBpmn = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+// Adds a task → the differ reports `Task_1` as `_added`.
+const afterBpmn = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Defs_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:task id="Task_1" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+const LEFT = "git:/repo/diagram.bpmn?ref=HEAD";
+const RIGHT = "file:///repo/diagram.bpmn";
+
+// ─── Fakes ──────────────────────────────────────────────────────────────────
+
+function fakeHandle(
+    uri: string,
+    text = "",
+): DiffPaneHandle & { postMessage: ReturnType<typeof vi.fn> } {
+    let ready = false;
+    return {
+        uri,
+        isReady: () => ready,
+        setReady: () => {
+            ready = true;
+        },
+        getText: () => text,
+        postMessage: vi.fn().mockResolvedValue(true),
+        dispose: vi.fn(),
+    };
+}
+
+function createService() {
+    const notifier = {
+        logInfo: vi.fn(),
+        logError: vi.fn(),
+        showError: vi.fn(),
+    };
+    const vsSettings = { getLanguage: vi.fn().mockReturnValue("en") };
+    const store = new DiffPaneStore();
+    const service = new BpmnDiffService(notifier as never, vsSettings as never, store);
+    return { service, notifier, vsSettings, store };
+}
+
+/** Registers a compare-files session with both panes attached. */
+function attachedPair(store: DiffPaneStore, beforeText = "", afterText = "") {
+    const session = store.registerCompareFiles(LEFT, RIGHT);
+    const before = fakeHandle(LEFT, beforeText);
+    const after = fakeHandle(RIGHT, afterText);
+    session.attachPane(before);
+    session.attachPane(after);
+    return { session, before, after };
+}
+
+const messageTypes = (handle: { postMessage: ReturnType<typeof vi.fn> }): string[] =>
+    handle.postMessage.mock.calls.map(([msg]) => (msg as { type: string }).type);
+
+describe("BpmnDiffService", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // ─── Viewer file ──────────────────────────────────────────────────────────
+
+    it("sendViewerFile replies with a viewer-mode BpmnFileQuery", async () => {
+        const { service } = createService();
+        const handle = fakeHandle(RIGHT, beforeBpmn);
+
+        await service.sendViewerFile(handle);
+
+        expect(handle.postMessage).toHaveBeenCalledTimes(1);
+        const msg = handle.postMessage.mock.calls[0][0] as { type: string; viewerMode: string };
+        expect(msg.type).toBe("BpmnFileQuery");
+        expect(msg.viewerMode).toBe("viewer");
+    });
+
+    // ─── Viewport / cursor forwarding ──────────────────────────────────────────
+
+    it("forwardViewport posts a SyncViewportQuery to the partner pane", async () => {
+        const { service, store } = createService();
+        const { before, after } = attachedPair(store);
+
+        await service.forwardViewport(before, { x: 1, y: 2, width: 3, height: 4 });
+
+        expect(messageTypes(after)).toEqual(["SyncViewportQuery"]);
+        expect(before.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("forwardCursor posts a SyncCursorQuery to the partner pane", async () => {
+        const { service, store } = createService();
+        const { before, after } = attachedPair(store);
+
+        await service.forwardCursor(after, 5);
+
+        expect(messageTypes(before)).toEqual(["SyncCursorQuery"]);
+    });
+
+    it("forwarding is a no-op when the session has no partner attached", async () => {
+        const { service, store } = createService();
+        const session = store.registerCompareFiles(LEFT, RIGHT);
+        const before = fakeHandle(LEFT);
+        session.attachPane(before); // after side never attached
+
+        await service.forwardViewport(before, { x: 0, y: 0, width: 0, height: 0 });
+
+        expect(before.postMessage).not.toHaveBeenCalled();
+    });
+
+    // ─── markReady arming ──────────────────────────────────────────────────────
+
+    it("markReady sends language but no highlights while only one side is ready", async () => {
+        const { service, store } = createService();
+        const { before, after } = attachedPair(store, beforeBpmn, afterBpmn);
+
+        await service.markReady(before);
+
+        expect(messageTypes(before)).toEqual(["LanguageQuery"]);
+        expect(messageTypes(after)).toEqual([]);
+    });
+
+    it("markReady runs the differ and broadcasts highlights once both sides are ready", async () => {
+        const { service, store } = createService();
+        const { before, after } = attachedPair(store, beforeBpmn, afterBpmn);
+
+        await service.markReady(before);
+        await service.markReady(after);
+
+        expect(messageTypes(before)).toContain("ApplyDiffHighlightsQuery");
+        expect(messageTypes(after)).toContain("ApplyDiffHighlightsQuery");
+
+        // The added task lands on the after side only.
+        const afterHighlights = after.postMessage.mock.calls
+            .map(([m]) => m as { type: string; added?: string[] })
+            .find((m) => m.type === "ApplyDiffHighlightsQuery");
+        expect(afterHighlights?.added).toContain("Task_1");
+    });
+
+    // ─── Language re-broadcast ──────────────────────────────────────────────────
+
+    it("rebroadcastLanguage posts a LanguageQuery only to ready panes", () => {
+        const { service, store } = createService();
+        const { before, after } = attachedPair(store);
+        before.setReady(); // after stays not-ready
+
+        service.rebroadcastLanguage();
+
+        expect(messageTypes(before)).toEqual(["LanguageQuery"]);
+        expect(after.postMessage).not.toHaveBeenCalled();
+    });
+});

--- a/apps/modeler-plugin/src/service/BpmnDiffService.ts
+++ b/apps/modeler-plugin/src/service/BpmnDiffService.ts
@@ -12,8 +12,6 @@ import { diff } from "bpmn-js-differ";
 import {
     ApplyDiffHighlightsQuery,
     BpmnFileQuery,
-    Command,
-    CursorChangedCommand,
     DiffCounts,
     Engine,
     LanguageQuery,
@@ -25,497 +23,36 @@ import {
     sortIdsByOrder,
 } from "@miragon/bpmn-modeler-shared";
 
-import {
-    commands,
-    ConfigurationChangeEvent,
-    Disposable,
-    TextDocument,
-    Uri,
-    WebviewPanel,
-    window,
-    workspace,
-} from "vscode";
-
-import { bootstrapWebview } from "../infrastructure/bootstrapWebview";
+import { BpmnDocument } from "../domain/BpmnDocument";
+import { DiffPaneHandle, DiffSession, basenameOfUriString } from "../domain/DiffSession";
+import { DiffPaneStore } from "../infrastructure/DiffPaneStore";
 import { VsCodeSettings } from "../infrastructure/VsCodeSettings";
 import { VsCodeNotifier } from "../infrastructure/VsCodeNotifier";
-import { BpmnDocument } from "../domain/BpmnDocument";
-import { DiffPaneHandle, DiffSession } from "./DiffSession";
 
 /**
- * Infrastructure adapter that wraps a real `WebviewPanel` + `TextDocument`
- * pair into the {@link DiffPaneHandle} the session uses. Lives next to the
- * service so the rest of the diff machinery can stay vscode-free.
- */
-class WebviewPaneHandle implements DiffPaneHandle {
-    private readyFlag = false;
-
-    constructor(
-        readonly panel: WebviewPanel,
-        readonly document: TextDocument,
-    ) {}
-
-    get uri(): string {
-        return this.document.uri.toString();
-    }
-
-    isReady(): boolean {
-        return this.readyFlag;
-    }
-
-    setReady(): void {
-        this.readyFlag = true;
-    }
-
-    getText(): string {
-        return this.document.getText();
-    }
-
-    postMessage(msg: unknown): Promise<boolean> {
-        return Promise.resolve(this.panel.webview.postMessage(msg));
-    }
-
-    dispose(): void {
-        this.panel.dispose();
-    }
-}
-
-const BPMN_VIEW_TYPE = "bpmn-modeler.bpmn";
-
-/**
- * URI schemes used by Git-provider extensions to surface ref/index/working-tree
- * documents. VS Code's built-in Git extension uses `git:`; Theia's `@theia/git`
- * (used by the standalone desktop shell) uses `gitfs:`. Both are always
- * readonly and always belong to a diff, so the scheme alone is a sufficient
- * signal for `shouldResolveAsDiff`.
- */
-const GIT_PROVIDED_SCHEMES = new Set<string>(["git", "gitfs"]);
-
-/**
- * Milliseconds a pre-registered `compare-files` session stays alive with no
- * panes attached before it is swept.  Covers the "user triggered the command
- * but the diff tab never opened" edge case.  Longer than any realistic
- * `vscode.diff` → `resolveCustomTextEditor` latency; short enough that
- * registering the same pair again after a cancel works without collisions.
- */
-const COMPARE_FILES_TTL_MS = 30_000;
-
-/**
- * A `"scm"` pane that resolved first and is waiting for its partner.
+ * Drives the diff *content* for already-resolved BPMN diff panes: it answers
+ * the webview's initial file request, runs `bpmn-js-differ` once both sides
+ * report ready, and keeps the two panes in lockstep (viewport, cursor,
+ * language).
  *
- * SCM-initiated diffs don't let us pre-register a session — we learn about
- * each URI only when its pane resolves.  The first pane goes here; when the
- * second pane arrives with a matching `document.uri.path`, we promote both
- * into a full {@link DiffSession} and register it.
- */
-interface PendingScmPane {
-    readonly handle: WebviewPaneHandle;
-}
-
-/**
- * Owns every BPMN diff viewer pane from resolution through disposal.
- *
- * The domain moved from "pair of panes with mutual partner pointers" to
- * {@link DiffSession}: an explicit object with fixed `before` / `after` URIs
- * that any diff origin (SCM, `compare-files`) can register into.  The service
- * is now a registry of sessions plus a per-URI lookup index; pane resolution
- * is a session lookup instead of a scheme-based heuristic.
- *
- * Responsibilities:
- *   1. Register `compare-files` sessions on demand — pre-known URIs, side
- *      fixed at construction, TTL-swept if the tab never opens.
- *   2. Lazily create `scm` sessions when VS Code resolves a diff tab's second
- *      pane — URIs discovered at resolve time, paired by path equality.
- *   3. Bootstrap the webview for each resolved pane, wire up the viewer-mode
- *      message protocol (`GetBpmnFileCommand`, `DiffReadyCommand`,
- *      `ViewportChangedCommand`, `CursorChangedCommand`), and attach the pane
- *      to its session.
- *   4. Once both panes of a session report ready, run `bpmn-js-differ` on the
- *      parsed XMLs and broadcast per-side {@link ApplyDiffHighlightsQuery}.
- *   5. Forward viewport-change and cursor-change messages from one pane to
- *      its partner so panning, zooming, and stepper navigation stay in sync.
+ * Stays free of `vscode` — it works through the abstract {@link DiffPaneHandle}
+ * and reads session state from {@link DiffPaneStore}. Pane lifecycle (creation,
+ * pairing, disposal) and every VS Code call live in `BpmnDiffController`.
  */
 export class BpmnDiffService {
-    // Every live session, keyed by `${beforeUri}|${afterUri}`.
-    private readonly sessions = new Map<string, DiffSession>();
-
-    /**
-     * Lookup index: URI string → session it belongs to.  Populated as soon as
-     * a session is created, whether pre-registered (`compare-files`) or
-     * lazily formed (`scm`).
-     */
-    private readonly sessionByUri = new Map<string, DiffSession>();
-
-    /**
-     * SCM panes awaiting their partner.  Keyed by {@link scmPairingKey} so
-     * the Git-provided URI (`git:` in VS Code, `gitfs:` in Theia) and the
-     * working-tree `file:` URI meet here before being promoted into a session.
-     */
-    private readonly pendingScm = new Map<string, PendingScmPane>();
-
-    /**
-     * TTL sweepers for pre-registered `compare-files` sessions.  Cleared
-     * once the first pane attaches.
-     */
-    private readonly ttlTimers = new Map<DiffSession, ReturnType<typeof setTimeout>>();
-
-    // Dispose handle for the language-setting change subscription.
-    private languageSubscription?: Disposable;
-
     /**
      * @param notifier Logging helper for parse failures and dropped posts.
      * @param vsSettings Settings reader — provides the active UI locale so
      *   each diff pane's legend and chrome render in the user's language from
      *   the moment it opens, and re-renders on setting changes.
+     * @param store Session registry consulted for partner lookups and the
+     *   language re-broadcast fan-out.
      */
     constructor(
         private readonly notifier: VsCodeNotifier,
         private readonly vsSettings: VsCodeSettings,
-    ) {
-        this.languageSubscription = workspace.onDidChangeConfiguration((event) =>
-            this.onConfigurationChanged(event),
-        );
-    }
-
-    /**
-     * Releases the language-setting subscription and any armed TTL timers.
-     */
-    dispose(): void {
-        this.languageSubscription?.dispose();
-        this.languageSubscription = undefined;
-        for (const timer of this.ttlTimers.values()) {
-            clearTimeout(timer);
-        }
-        this.ttlTimers.clear();
-    }
-
-    /**
-     * Pre-registers a `compare-files` session before invoking `vscode.diff`.
-     *
-     * Side assignment is fixed: `leftUri` is `before`, `rightUri` is `after`
-     * — matches the visual order VS Code renders `vscode.diff(a, b)` in.
-     *
-     * A TTL sweeper drops the session if no pane attaches within
-     * {@link COMPARE_FILES_TTL_MS}.  The timer is cleared as soon as the
-     * first pane arrives.
-     *
-     * @returns The created session (useful in tests; production callers can
-     *   ignore the return value).
-     */
-    registerCompareFilesSession(leftUri: Uri, rightUri: Uri): DiffSession {
-        const session = DiffSession.forCompareFiles(leftUri.toString(), rightUri.toString());
-        this.indexSession(session);
-        this.ttlTimers.set(
-            session,
-            setTimeout(() => this.sweepOrphan(session), COMPARE_FILES_TTL_MS),
-        );
-        return session;
-    }
-
-    /**
-     * One-call `compare-files` diff-open: pre-registers the session, invokes
-     * `vscode.diff`, and constructs the tab title.
-     *
-     * Session registration must happen before `vscode.diff` so that when VS
-     * Code immediately resolves each pane through the
-     * `CustomTextEditorProvider`, pane lookup via {@link findSessionFor}
-     * succeeds synchronously — otherwise the panes would fall through to the
-     * SCM label heuristic.
-     *
-     * Errors from `vscode.diff` are surfaced to the user here so both entry
-     * points ({@link BpmnCompareController} and {@link swapCompareFilesSides})
-     * share the same failure UX.
-     */
-    async openCompareFilesDiff(leftUri: Uri, rightUri: Uri): Promise<void> {
-        this.registerCompareFilesSession(leftUri, rightUri);
-        const title = `${this.basenameOfUriString(leftUri.toString())} ↔ ${this.basenameOfUriString(rightUri.toString())}`;
-        try {
-            await commands.executeCommand("vscode.diff", leftUri, rightUri, title, {
-                preview: false,
-            });
-        } catch (error) {
-            this.notifier.logError(error as Error);
-            this.notifier.showError(`Failed to open compare view: ${(error as Error).message}`);
-        }
-    }
-
-    /**
-     * Returns the session this URI belongs to, or `undefined` when none
-     * exists yet.  Covers both pre-registered `compare-files` sessions and
-     * `scm` sessions that have already been promoted from a pending pane.
-     */
-    findSessionFor(uri: Uri): DiffSession | undefined {
-        return this.sessionByUri.get(uri.toString());
-    }
-
-    private basenameOfUriString(uri: string): string {
-        // Trim query/fragment so e.g. `file:///foo.bpmn?ref=HEAD` still
-        // resolves to `foo.bpmn`. `Uri.toString()` keeps `?` / `#` for any
-        // host that uses them; the bare path is what users see in the tab.
-        const noFragment = uri.split("#")[0];
-        const noQuery = noFragment.split("?")[0];
-        const parts = noQuery.split("/");
-        return decodeURIComponent(parts[parts.length - 1] ?? "");
-    }
-
-    /**
-     * Returns `true` when this URI should resolve as a (new) diff pane.
-     *
-     * Decision tree:
-     *   1. A pane (full session or pending SCM entry) already exists for
-     *      this URI → false.  The caller is a *second* resolve, e.g. the
-     *      user opened the working-tree file in a normal editor tab after
-     *      the SCM diff was already open — that second tab is an editable
-     *      modeler, not another diff pane.
-     *   2. A pre-registered `compare-files` session exists → true.
-     *   3. The URI uses a Git-provided scheme (see
-     *      {@link GIT_PROVIDED_SCHEMES}) → true. Covers VS Code's `git:` and
-     *      Theia's `gitfs:` — both are always readonly and always belong to a
-     *      diff.
-     *   4. The URI sits in a diff tab per the label heuristic → true.  This
-     *      is the only signal for SCM diffs when both URIs share the `file:`
-     *      scheme (uncommon but possible for some diff-to-working-tree flows).
-     */
-    shouldResolveAsDiff(uri: Uri): boolean {
-        if (this.hasPaneForUri(uri)) {
-            return false;
-        }
-        if (this.findSessionFor(uri)) {
-            return true;
-        }
-        if (GIT_PROVIDED_SCHEMES.has(uri.scheme)) {
-            return true;
-        }
-        return this.isPartOfDiff(uri);
-    }
-
-    /**
-     * Returns `true` when `uri` belongs to an open BPMN diff tab.
-     *
-     * Label-based heuristic: when a file type has a `CustomTextEditorProvider`
-     * registered as default, VS Code's diff tabs surface as `Tab` objects with
-     * `input === undefined` — there is no `TabInputTextDiff` / `TabInputCustom`
-     * variant to branch on.  The only structural signal left is the label,
-     * which every diff annotates with a parenthetical (e.g.
-     * `"my-bpmn.bpmn (Working Tree)"`, `"… (HEAD)"`, `"… (HEAD~1 ↔ HEAD)"`)
-     * or the `↔` separator used by `vscode.diff(a, b)` when the two basenames
-     * differ.
-     */
-    isPartOfDiff(uri: Uri): boolean {
-        const basename = this.basenameOfUriString(uri.toString());
-        if (!basename.endsWith(".bpmn")) {
-            return false;
-        }
-        for (const group of window.tabGroups.all) {
-            for (const tab of group.tabs) {
-                if (tab.input !== undefined) {
-                    continue;
-                }
-                if (tab.label.startsWith(`${basename} (`) || tab.label.includes(` ↔ `)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Returns `true` when any pane — attached to a session or still pending
-     * SCM pairing — currently renders `uri`.
-     */
-    hasPaneForUri(uri: Uri): boolean {
-        const needle = uri.toString();
-        const session = this.sessionByUri.get(needle);
-        if (session?.hasPaneFor(needle)) {
-            return true;
-        }
-        for (const pending of this.pendingScm.values()) {
-            if (pending.handle.uri === needle) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Bootstraps a freshly-resolved diff pane.
-     *
-     * Resolution paths:
-     *   - Pre-registered `compare-files` session: looked up via
-     *     {@link sessionByUri}, pane attaches immediately, TTL cancels.
-     *   - First `scm` pane: stashed in {@link pendingScm}, waits for partner.
-     *   - Second `scm` pane: paired with the pending entry, session created.
-     *
-     * Nothing about a diff pane flows through `EditorStore`, which keeps the
-     * two "same URI" panels (viewer + editable modeler that a user may open
-     * alongside the diff) from colliding.
-     */
-    resolveDiffPane(panel: WebviewPanel, document: TextDocument): void {
-        // Register listeners *before* we hand HTML to the webview: VS Code
-        // drops webview-originated messages that arrive before the extension
-        // has subscribed, and bootstrapping triggers an immediate
-        // `GetBpmnFileCommand` as soon as the webview's scripts run.
-        const handle = new WebviewPaneHandle(panel, document);
-
-        panel.webview.onDidReceiveMessage((message: Command) => this.onMessage(handle, message));
-        panel.onDidDispose(() => this.disposePane(handle));
-
-        const session = this.findSessionFor(document.uri);
-        if (session) {
-            session.attachPane(handle);
-            this.cancelTtl(session);
-        } else {
-            this.attachOrPendScmPane(handle);
-        }
-
-        bootstrapWebview(BPMN_VIEW_TYPE, panel);
-    }
-
-    /**
-     * Either pairs `entry` with a pending SCM pane that shares its path
-     * (promoting both into a full {@link DiffSession}) or stashes `entry`
-     * as the pending pane for later pairing.
-     *
-     * Side assignment for SCM:
-     *   - If one URI is `file:` it is the working tree → `after`.
-     *   - Otherwise (ref-vs-ref, both `git:`) the first-registered pane is
-     *     `before`, second is `after` — arbitrary but matches the visual
-     *     order VS Code's SCM diff chose.
-     */
-    private attachOrPendScmPane(handle: WebviewPaneHandle): void {
-        const key = this.scmPairingKey(handle.document.uri);
-        const pending = this.pendingScm.get(key);
-
-        if (!pending) {
-            this.pendingScm.set(key, { handle });
-            return;
-        }
-
-        this.pendingScm.delete(key);
-        const { before, after } = resolveScmSides(pending.handle, handle);
-        const session = DiffSession.forScm(before, after);
-        session.attachPane(before);
-        session.attachPane(after);
-        this.indexSession(session);
-    }
-
-    /**
-     * Pairing key for matching the two panes of an SCM diff. Both VS Code
-     * (`git:foo.bpmn` ↔ `file:foo.bpmn`) and Theia (`gitfs:foo.bpmn` ↔
-     * `file:foo.bpmn`) surface the two sides with different schemes but the
-     * same workspace-relative `uri.path`, so the raw path is the pairing key.
-     *
-     * If a future host bakes ref metadata into the path (e.g.
-     * `/foo.bpmn@HEAD`), normalize it here so the two paths still meet.
-     */
-    private scmPairingKey(uri: Uri): string {
-        return uri.path;
-    }
-
-    /**
-     * Adds `session` to the `sessions` map and the per-URI lookup index.
-     *
-     * Both session-creation paths (eager `compare-files` and lazy `scm`)
-     * funnel through here so the two maps never drift out of sync.
-     */
-    private indexSession(session: DiffSession): void {
-        this.sessions.set(this.sessionIdOf(session), session);
-        this.sessionByUri.set(session.beforeUri, session);
-        this.sessionByUri.set(session.afterUri, session);
-    }
-
-    private sessionIdOf(session: DiffSession): string {
-        return `${session.beforeUri}|${session.afterUri}`;
-    }
-
-    private cancelTtl(session: DiffSession): void {
-        const timer = this.ttlTimers.get(session);
-        if (timer) {
-            clearTimeout(timer);
-            this.ttlTimers.delete(session);
-        }
-    }
-
-    private sweepOrphan(session: DiffSession): void {
-        this.ttlTimers.delete(session);
-        if (!session.isEmpty()) {
-            return;
-        }
-        this.sessions.delete(this.sessionIdOf(session));
-        this.sessionByUri.delete(session.beforeUri);
-        this.sessionByUri.delete(session.afterUri);
-    }
-
-    private disposePane(handle: DiffPaneHandle): void {
-        /**
-         * Drop from pending (no session ever formed)
-         */
-        for (const [key, pending] of this.pendingScm) {
-            if (pending.handle === handle) {
-                this.pendingScm.delete(key);
-                return;
-            }
-        }
-
-        // Drop from session; retire the session if both panes are gone.
-        const session = this.sessionByUri.get(handle.uri);
-        if (!session) {
-            return;
-        }
-        session.detachPane(handle);
-        if (session.isEmpty()) {
-            this.sessions.delete(this.sessionIdOf(session));
-            this.sessionByUri.delete(session.beforeUri);
-            this.sessionByUri.delete(session.afterUri);
-            this.cancelTtl(session);
-        }
-    }
-
-    private async onMessage(handle: DiffPaneHandle, message: Command): Promise<void> {
-        switch (message.type) {
-            case "GetBpmnFileCommand":
-                await this.sendViewerFile(handle);
-                break;
-            case "DiffReadyCommand":
-                await this.markReady(handle);
-                break;
-            case "ViewportChangedCommand":
-                await this.forwardViewport(handle, (message as ViewportChangedCommand).viewport);
-                break;
-            case "CursorChangedCommand":
-                await this.forwardCursor(handle, (message as CursorChangedCommand).index);
-                break;
-            case "SwapCompareSidesCommand":
-                await this.swapCompareFilesSides(handle);
-                break;
-        }
-    }
-
-    /**
-     * Closes the current diff tab and reopens it with the two URIs swapped.
-     *
-     * Only applies to `compare-files` sessions: the extension owns both URIs
-     * and the tab title, so it can legitimately retire and recreate the diff.
-     * SCM panes never emit {@link SwapCompareSidesCommand} — the button is
-     * hidden there — but we still guard against misuse since message routing
-     * cannot encode origin at the type level.
-     *
-     * Disposing the webview panels triggers `disposePane` for both sides,
-     * which tears down the old session and removes it from the indexes.  The
-     * subsequent `openCompareFilesDiff` then registers a fresh session with
-     * the reversed before/after assignment.
-     */
-    private async swapCompareFilesSides(handle: DiffPaneHandle): Promise<void> {
-        const session = this.sessionByUri.get(handle.uri);
-        if (!session || session.origin !== "compare-files") {
-            return;
-        }
-        const { beforeUri, afterUri } = session;
-        for (const pane of session.attachedPanes()) {
-            pane.dispose();
-        }
-        await this.openCompareFilesDiff(Uri.parse(afterUri), Uri.parse(beforeUri));
-    }
+        private readonly store: DiffPaneStore,
+    ) {}
 
     /**
      * Replies to the webview's initial `GetBpmnFileCommand` with the pane's
@@ -523,7 +60,7 @@ export class BpmnDiffService {
      * an execution-platform attribute fall back to `"c7"`, since viewer mode
      * does not render engine-specific extensions anyway.
      */
-    private async sendViewerFile(handle: DiffPaneHandle): Promise<void> {
+    async sendViewerFile(handle: DiffPaneHandle): Promise<void> {
         try {
             const content = handle.getText();
             let engine: Engine;
@@ -538,11 +75,15 @@ export class BpmnDiffService {
         }
     }
 
-    private async markReady(handle: DiffPaneHandle): Promise<void> {
+    /**
+     * Marks the pane ready, sends it the current locale, and runs the differ
+     * once both panes of the session report ready.
+     */
+    async markReady(handle: DiffPaneHandle): Promise<void> {
         handle.setReady();
         await this.sendLanguage(handle);
 
-        const session = this.sessionByUri.get(handle.uri);
+        const session = this.store.findByUri(handle.uri);
         if (!session || !session.isArmed()) {
             return;
         }
@@ -554,29 +95,11 @@ export class BpmnDiffService {
     }
 
     /**
-     * Posts the current UI locale to the given pane so its legend and other
-     * non-bpmn-js UI render in the user's language.  Silently drops the post
-     * when the pane is hidden or already disposed — the pane will request the
-     * language again on its next resolve.
+     * Re-posts the current locale to every ready diff pane. Invoked by the
+     * controller when the user changes `miragon.bpmnModeler.language`.
      */
-    private async sendLanguage(handle: DiffPaneHandle): Promise<void> {
-        try {
-            await handle.postMessage(new LanguageQuery(this.vsSettings.getLanguage()));
-        } catch (error) {
-            this.notifier.logInfo(`setLanguage dropped: ${(error as Error).message}`);
-        }
-    }
-
-    /**
-     * Re-posts the current locale to every ready diff pane when the user
-     * changes `miragon.bpmnModeler.language`.  Ignores unrelated setting
-     * changes so panes only churn when the language actually moves.
-     */
-    private onConfigurationChanged(event: ConfigurationChangeEvent): void {
-        if (!event.affectsConfiguration("miragon.bpmnModeler.language")) {
-            return;
-        }
-        for (const session of this.sessions.values()) {
+    rebroadcastLanguage(): void {
+        for (const session of this.store.allSessions()) {
             for (const handle of session.attachedPanes()) {
                 if (handle.isReady()) {
                     void this.sendLanguage(handle);
@@ -589,7 +112,7 @@ export class BpmnDiffService {
      * Posts the partner's viewport change to this pane so panning/zoom stays
      * in lockstep.  Silently drops posts when the partner is hidden or gone.
      */
-    private async forwardViewport(
+    async forwardViewport(
         handle: DiffPaneHandle,
         viewport: ViewportChangedCommand["viewport"],
     ): Promise<void> {
@@ -609,7 +132,7 @@ export class BpmnDiffService {
      * navigation stays in lockstep.  Mirrors {@link forwardViewport} — same
      * partner lookup, same drop-silently-on-failure semantics.
      */
-    private async forwardCursor(handle: DiffPaneHandle, index: number): Promise<void> {
+    async forwardCursor(handle: DiffPaneHandle, index: number): Promise<void> {
         const partner = this.partnerOf(handle);
         if (!partner) {
             return;
@@ -621,8 +144,22 @@ export class BpmnDiffService {
         }
     }
 
+    /**
+     * Posts the current UI locale to the given pane so its legend and other
+     * non-bpmn-js UI render in the user's language.  Silently drops the post
+     * when the pane is hidden or already disposed — the pane will request the
+     * language again on its next resolve.
+     */
+    private async sendLanguage(handle: DiffPaneHandle): Promise<void> {
+        try {
+            await handle.postMessage(new LanguageQuery(this.vsSettings.getLanguage()));
+        } catch (error) {
+            this.notifier.logInfo(`setLanguage dropped: ${(error as Error).message}`);
+        }
+    }
+
     private partnerOf(handle: DiffPaneHandle): DiffPaneHandle | undefined {
-        const session = this.sessionByUri.get(handle.uri);
+        const session = this.store.findByUri(handle.uri);
         return session?.partnerOf(handle);
     }
 
@@ -728,7 +265,7 @@ export class BpmnDiffService {
                 counts,
                 navigationOrder,
                 session.origin,
-                this.basenameOfUriString(before.uri),
+                basenameOfUriString(before.uri),
             ),
         );
         await this.postHighlights(
@@ -742,7 +279,7 @@ export class BpmnDiffService {
                 counts,
                 navigationOrder,
                 session.origin,
-                this.basenameOfUriString(after.uri),
+                basenameOfUriString(after.uri),
             ),
         );
     }
@@ -757,28 +294,4 @@ export class BpmnDiffService {
             this.notifier.logInfo(`ApplyDiffHighlights dropped: ${(error as Error).message}`);
         }
     }
-}
-
-/**
- * SCM-diff side assignment for two panes that share a path.
- *
- * Invariant: `file:` URIs represent the working tree and must be `after`.
- * For ref-vs-ref diffs (both `git:` in VS Code, both `gitfs:` in Theia) side
- * follows resolution order, which mirrors the host's own visual ordering.
- *
- * Lives in the infrastructure-adjacent half of this file because it reads
- * `document.uri.scheme` from the vscode-typed handle; pushing it into the
- * vscode-free {@link DiffSession} would require parsing the string URI.
- */
-function resolveScmSides(
-    first: WebviewPaneHandle,
-    second: WebviewPaneHandle,
-): { before: WebviewPaneHandle; after: WebviewPaneHandle } {
-    if (second.document.uri.scheme === "file") {
-        return { before: first, after: second };
-    }
-    if (first.document.uri.scheme === "file") {
-        return { before: second, after: first };
-    }
-    return { before: first, after: second };
 }

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.spec.ts
@@ -1,9 +1,16 @@
+import { posix } from "path";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReferencedModelLocator } from "./ReferencedModelLocator";
 
 interface FakeWorkspaceFolder {
     uri: { scheme: string; path: string; fsPath: string };
 }
 
+// The locator now reads workspace-folder state through the `VsCodeWorkspace`
+// adapter (mocked below) instead of importing `vscode` directly; this state
+// drives that mock's `findWorkspaceFolderForDocument` / `getWorkspaceFolderPaths`.
 const workspaceState: {
     folders: FakeWorkspaceFolder[];
     folderForUri: (uri: { path: string }) => FakeWorkspaceFolder | undefined;
@@ -11,18 +18,6 @@ const workspaceState: {
     folders: [{ uri: { scheme: "file", path: "/", fsPath: "/" } }],
     folderForUri: () => ({ uri: { scheme: "file", path: "/", fsPath: "/" } }),
 };
-
-vi.mock("vscode", () => ({
-    Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
-    workspace: {
-        get workspaceFolders() {
-            return workspaceState.folders;
-        },
-        getWorkspaceFolder: (uri: { path: string }) => workspaceState.folderForUri(uri),
-    },
-}));
-
-import { ReferencedModelLocator } from "./ReferencedModelLocator";
 
 const bpmnWithProcess = (id: string) =>
     `<?xml version="1.0"?>
@@ -66,6 +61,11 @@ function createLocator(opts: { fileContents: Record<string, string>; tree?: DirT
             if (path in fileContents) return Promise.resolve(fileContents[path]);
             return Promise.reject(new Error("not found"));
         }),
+        findWorkspaceFolderForDocument: vi.fn(
+            (document: string) => workspaceState.folderForUri({ path: document })?.uri.path,
+        ),
+        getWorkspaceFolderPaths: vi.fn(() => workspaceState.folders.map((f) => f.uri.path)),
+        getDocumentDirectory: vi.fn((document: string) => posix.dirname(document)),
     };
     const notifier = { logInfo: vi.fn(), logWarning: vi.fn() };
     const locator = new ReferencedModelLocator(vsWorkspace as never, notifier as never);

--- a/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
+++ b/apps/modeler-plugin/src/service/modelNavigation/ReferencedModelLocator.ts
@@ -1,7 +1,5 @@
 import { posix } from "path";
 
-import { Uri, workspace } from "vscode";
-
 import { VsCodeNotifier } from "../../infrastructure/VsCodeNotifier";
 import { VsCodeWorkspace } from "../../infrastructure/VsCodeWorkspace";
 
@@ -88,20 +86,20 @@ export class ReferencedModelLocator {
         extension: string,
         sourceDocumentPath: string | undefined,
     ): Promise<string[] | undefined> {
-        const sourceDocumentUri =
-            sourceDocumentPath !== undefined ? Uri.file(sourceDocumentPath) : undefined;
-        const looseFile =
-            sourceDocumentUri !== undefined &&
-            workspace.getWorkspaceFolder(sourceDocumentUri) === undefined;
+        const containingFolderPath =
+            sourceDocumentPath !== undefined
+                ? this.vsWorkspace.findWorkspaceFolderForDocument(sourceDocumentPath)
+                : undefined;
+        const looseFile = sourceDocumentPath !== undefined && containingFolderPath === undefined;
 
         if (looseFile) {
             // No workspace folder covers the document → walk from its dir.
-            const rootDir = posix.dirname(sourceDocumentUri!.path);
+            const rootDir = this.vsWorkspace.getDocumentDirectory(sourceDocumentPath!);
             return this.walkWorkspaceTree(rootDir, extension, "walk-primary");
         }
 
-        const folders = workspace.workspaceFolders;
-        if (!folders || folders.length === 0) {
+        const folderPaths = this.vsWorkspace.getWorkspaceFolderPaths();
+        if (folderPaths.length === 0) {
             return undefined;
         }
 
@@ -121,7 +119,7 @@ export class ReferencedModelLocator {
         }
 
         // Fallback: findFiles failed silently (ripgrep missing in packaged .app).
-        const root = this.pickWalkRoot(sourceDocumentUri);
+        const root = this.pickWalkRoot(sourceDocumentPath, containingFolderPath, folderPaths);
         if (!root) return [];
         return this.walkWorkspaceTree(root, extension, "walk-fallback");
     }
@@ -174,16 +172,21 @@ export class ReferencedModelLocator {
     }
 
     /**
-     * Where to root the walk fallback.  Best-effort.
+     * Where to root the walk fallback.  Best-effort: prefer the document's own
+     * workspace folder, else the first open folder, else the document's
+     * directory.  The folder lookups are reused from
+     * {@link collectCandidateFiles} to avoid re-querying the workspace.
      */
-    private pickWalkRoot(sourceDocumentUri: Uri | undefined): string | undefined {
-        if (sourceDocumentUri) {
-            const folder = workspace.getWorkspaceFolder(sourceDocumentUri);
-            if (folder) return folder.uri.path;
+    private pickWalkRoot(
+        sourceDocumentPath: string | undefined,
+        containingFolderPath: string | undefined,
+        folderPaths: string[],
+    ): string | undefined {
+        if (containingFolderPath) return containingFolderPath;
+        if (folderPaths.length > 0) return folderPaths[0];
+        if (sourceDocumentPath !== undefined) {
+            return this.vsWorkspace.getDocumentDirectory(sourceDocumentPath);
         }
-        const folders = workspace.workspaceFolders;
-        if (folders && folders.length > 0) return folders[0].uri.path;
-        if (sourceDocumentUri) return posix.dirname(sourceDocumentUri.path);
         return undefined;
     }
 

--- a/docs/vscode/contributing/architecture/bpmn-diff.md
+++ b/docs/vscode/contributing/architecture/bpmn-diff.md
@@ -29,12 +29,13 @@ diff tab. Sessions come from two origins:
 - **`compare-files`** — the extension opened the diff via its own Explorer
   commands (`bpmn-modeler.compareSelected` or the two-step
   `selectForCompare` / `compareWithSelected`). Both URIs are known up front,
-  so the session is **pre-registered** by `BpmnDiffService.openCompareFilesDiff`
-  (which delegates to `DiffSession.forCompareFiles(…)`) before `vscode.diff`
-  fires, and a 30 s TTL sweeper evicts it if no pane ever attaches.
+  so the session is **pre-registered** by `BpmnDiffController.openCompareFilesDiff`
+  (which delegates to `DiffPaneStore.registerCompareFiles(…)`, in turn calling
+  `DiffSession.forCompareFiles(…)`) before `vscode.diff` fires, and a 30 s TTL
+  sweeper in the store evicts it if no pane ever attaches.
 
 `BpmnEditorController.resolveCustomTextEditor` asks
-`BpmnDiffService.shouldResolveAsDiff(uri)` for each resolving pane. That
+`BpmnDiffController.shouldResolveAsDiff(uri)` for each resolving pane. That
 method runs an ordered decision tree: already-has-a-pane → no (the caller is
 a second resolve for a file already open elsewhere); pre-registered session →
 yes; Git-provided scheme (`git:` or `gitfs:`) → yes; label heuristic matches a
@@ -44,56 +45,67 @@ diff tab → yes; otherwise → no.
 sequenceDiagram
     participant VSCode as VS Code
     participant Ctrl as BpmnCompareController
-    participant Diff as BpmnDiffService
+    participant DiffCtrl as BpmnDiffController
+    participant Store as DiffPaneStore
+    participant Svc as BpmnDiffService
     participant Editor as BpmnEditorController
     participant BeforePane as Before Webview
     participant AfterPane as After Webview
 
-    Note over Ctrl,Diff: compare-files origin (pre-registered)
-    Ctrl->>Diff: registerCompareFilesSession(left, right)
-    Ctrl->>VSCode: executeCommand("vscode.diff", left, right)
+    Note over Ctrl,Store: compare-files origin (pre-registered)
+    Ctrl->>DiffCtrl: openCompareFilesDiff(left, right)
+    DiffCtrl->>Store: registerCompareFiles(left, right)
+    DiffCtrl->>VSCode: executeCommand("vscode.diff", left, right)
 
     Note over VSCode,Editor: scm origin (lazy) skips the two calls above
     VSCode->>Editor: resolveCustomTextEditor (before URI)
-    Editor->>Diff: shouldResolveAsDiff → resolveDiffPane
-    Diff->>Diff: findSessionFor(uri) — attach or stash pending SCM
+    Editor->>DiffCtrl: shouldResolveAsDiff → resolveDiffPane
+    DiffCtrl->>Store: findByUri(uri) — attach or stash pending SCM
 
     VSCode->>Editor: resolveCustomTextEditor (after URI)
-    Editor->>Diff: shouldResolveAsDiff → resolveDiffPane
-    Diff->>Diff: promote pending → DiffSession / attach
+    Editor->>DiffCtrl: shouldResolveAsDiff → resolveDiffPane
+    DiffCtrl->>Store: promote pending → DiffSession / attach
 
-    BeforePane->>Diff: DiffReadyCommand
-    AfterPane->>Diff: DiffReadyCommand
-    Diff->>Diff: session.isArmed() — run bpmn-moddle + bpmn-js-differ
-    Diff->>BeforePane: ApplyDiffHighlightsQuery(removed, changed, moved, counts, origin, paneFilename)
-    Diff->>AfterPane: ApplyDiffHighlightsQuery(added, changed, moved, counts, origin, paneFilename)
+    BeforePane->>DiffCtrl: DiffReadyCommand
+    AfterPane->>DiffCtrl: DiffReadyCommand
+    DiffCtrl->>Svc: markReady(handle)
+    Svc->>Store: session.isArmed() — run bpmn-moddle + bpmn-js-differ
+    Svc->>BeforePane: ApplyDiffHighlightsQuery(removed, changed, moved, counts, origin, paneFilename)
+    Svc->>AfterPane: ApplyDiffHighlightsQuery(added, changed, moved, counts, origin, paneFilename)
 
-    BeforePane->>Diff: ViewportChangedCommand (pan/zoom)
-    Diff->>AfterPane: SyncViewportQuery
-    AfterPane->>Diff: CursorChangedCommand (Next/Prev)
-    Diff->>BeforePane: SyncCursorQuery
+    BeforePane->>DiffCtrl: ViewportChangedCommand (pan/zoom)
+    DiffCtrl->>Svc: forwardViewport → SyncViewportQuery
+    Svc->>AfterPane: SyncViewportQuery
+    AfterPane->>DiffCtrl: CursorChangedCommand (Next/Prev)
+    DiffCtrl->>Svc: forwardCursor → SyncCursorQuery
+    Svc->>BeforePane: SyncCursorQuery
 ```
 
 ## Entry points
 
 - **`BpmnCompareController`** (extension host) — registers the three Explorer
   commands (`selectForCompare`, `compareWithSelected`, `compareSelected`) and
-  dispatches each to `BpmnDiffService.openCompareFilesDiff`, which owns the
+  dispatches each to `BpmnDiffController.openCompareFilesDiff`, which owns the
   session-register + `vscode.diff` + tab-title construction.
 - **`CompareSelectionStore`** (extension host) — ephemeral single-URI store
   that bridges the two-step flow. Toggles the
   `bpmn-modeler.compareSelectionActive` context key so "Compare with Selected"
   only appears in the menu when a pick is pending.
-- **`BpmnDiffService`** (extension host) — owns every session, runs the
-  differ, broadcasts highlights, forwards viewport/cursor sync messages, and
-  handles the compare-files-only swap-sides operation.
+- **`BpmnDiffController`** (extension host) — VS Code-facing surface:
+  `shouldResolveAsDiff`, `resolveDiffPane`, `openCompareFilesDiff`, SCM
+  pairing, webview message routing, the compare-files-only swap-sides
+  operation, and the language-setting subscription.
+- **`BpmnDiffService`** (extension host, vscode-free) — runs the differ,
+  broadcasts highlights, and forwards viewport/cursor/language sync messages.
+- **`DiffPaneStore`** (extension host) — registry of every session, the
+  per-URI lookup index, pending SCM panes, and the compare-files TTL timers.
 - **`DiffSession`** (extension host) — domain object for one diff: `origin`,
   fixed `before`/`after` URIs, attached panes, armed flag. Exposes two
   origin-specific factories (`forCompareFiles`, `forScm`) that each
   encapsulate their own side-assignment rule.
 - **`BpmnEditorController`** (extension host) — branches resolving custom
   editors between editable modeler and readonly viewer via
-  `BpmnDiffService.shouldResolveAsDiff(uri)`.
+  `BpmnDiffController.shouldResolveAsDiff(uri)`.
 - **`DiffMode`** (webview) — webview entry point for viewer mode, wires the
   viewer + legend + message handlers.
 
@@ -101,9 +113,12 @@ sequenceDiagram
 
 | File | Purpose |
 |---|---|
-| `apps/modeler-plugin/src/service/BpmnDiffService.ts` | Session registry, differ runner, highlight broadcaster, viewport/cursor forwarder. Hosts `shouldResolveAsDiff` and `registerCompareFilesSession`. |
-| `apps/modeler-plugin/src/service/DiffSession.ts` | Domain object for one diff: origin, fixed before/after URIs, pane slots, armed flag. |
-| `apps/modeler-plugin/src/controller/BpmnEditorController.ts` | Branches between editable modeler and readonly viewer via `BpmnDiffService.shouldResolveAsDiff`. |
+| `apps/modeler-plugin/src/controller/BpmnDiffController.ts` | VS Code-facing surface: `shouldResolveAsDiff`, `resolveDiffPane`, `openCompareFilesDiff` (`vscode.diff`), SCM pairing, webview message routing, swap-sides, language-setting subscription. |
+| `apps/modeler-plugin/src/service/BpmnDiffService.ts` | vscode-free diff content: differ runner, highlight broadcaster, viewport/cursor forwarder, language broadcast. |
+| `apps/modeler-plugin/src/infrastructure/DiffPaneStore.ts` | Session registry: `sessions`, `sessionByUri`, pending SCM panes, `compare-files` TTL timers. |
+| `apps/modeler-plugin/src/infrastructure/WebviewPaneHandle.ts` | Infra adapter wrapping a `WebviewPanel` + `TextDocument` into the abstract `DiffPaneHandle`. |
+| `apps/modeler-plugin/src/domain/DiffSession.ts` | Domain object for one diff: origin, fixed before/after URIs, pane slots, armed flag. Also exports `basenameOfUriString`. |
+| `apps/modeler-plugin/src/controller/BpmnEditorController.ts` | Branches between editable modeler and readonly viewer via `BpmnDiffController.shouldResolveAsDiff`. |
 | `apps/modeler-plugin/src/controller/BpmnCompareController.ts` | Explorer commands (`selectForCompare`, `compareWithSelected`, `compareSelected`) and the shared `openBpmnDiff` dispatch. |
 | `apps/modeler-plugin/src/infrastructure/CompareSelectionStore.ts` | In-memory store for the pending "Select for Compare" URI; toggles the `bpmn-modeler.compareSelectionActive` context key. |
 | `apps/modeler-plugin/src/types/bpmn-js-differ.d.ts` | Ambient shim for the untyped `bpmn-js-differ` package. |
@@ -171,7 +186,7 @@ echoing back and creating a feedback loop.
 Compare-files diff panes render a swap button on the legend. When clicked, the
 webview posts `SwapCompareSidesCommand` to the host, which looks up the
 sending pane's session, confirms the origin is `compare-files`, disposes both
-webview panels, and re-invokes `BpmnDiffService.openCompareFilesDiff` with the
+webview panels, and re-invokes `BpmnDiffController.openCompareFilesDiff` with the
 two URIs reversed. Disposing the panels cascades through `disposePane` and
 cleans up the old session's index entries before the fresh session registers,
 so the two sessions never collide.
@@ -206,7 +221,7 @@ the differ is upgraded.
   by side without collision.
 - **Dual-host Git scheme handling.** `shouldResolveAsDiff` recognises both
   VS Code's `git:` and Theia's `gitfs:` schemes via the
-  `GIT_PROVIDED_SCHEMES` set in `BpmnDiffService.ts`. Add new schemes there
+  `GIT_PROVIDED_SCHEMES` set in `BpmnDiffController.ts`. Add new schemes there
   if porting to another host; do not branch on a single hardcoded scheme.
 - **SCM pairing is keyed by `uri.path`, not by the full URI.** That is the
   only thing `git:foo.bpmn` / `gitfs:foo.bpmn` and `file:foo.bpmn` share.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7869,7 +7869,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bpmn-moddle@npm:^10.0.0":
+"bpmn-moddle@npm:10.0.0, bpmn-moddle@npm:^10.0.0":
   version: 10.0.0
   resolution: "bpmn-moddle@npm:10.0.0"
   dependencies:
@@ -20164,6 +20164,7 @@ __metadata:
     "@types/vscode": "npm:1.93.0"
     "@vitest/coverage-v8": "npm:4.1.5"
     bpmn-js-differ: "npm:3.2.0"
+    bpmn-moddle: "npm:10.0.0"
     copy-webpack-plugin: "npm:14.0.0"
     lodash: "npm:4.18.1"
     min-dash: "npm:5.0.0"


### PR DESCRIPTION
**Issue**

Closes: #1038

**Description**

Split the monolithic `BpmnDiffService` into three focused components:
- `BpmnDiffController`: VS Code-facing surface owning pane resolution,
  `vscode.diff` invocation, SCM pairing, webview message routing, and
  language-setting subscription.
- `DiffPaneStore`: Pure session registry holding lookups, pending SCM panes,
  and compare-files TTL timers.
- `BpmnDiffService`: vscode-free diff content driver (differ runner, highlight
  broadcaster, sync forwarding).

Extracted `DiffSession` to `domain/` (from `service/`), introduced
`WebviewPaneHandle` adapter in `infrastructure/`, and moved `basenameOfUriString`
into the domain. Updated `BpmnCompareController` and `BpmnEditorController` to
dispatch through `BpmnDiffController` instead.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
