### PR TITLE
fix(bpmn-webview): keep bpmn:Group transparent in dark mode (#1056)

### DIFF
--- a/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
@@ -85,6 +85,16 @@
     stroke: var(--bpmn-shape-stroke-color) !important;
 }
 
+/*
+ * bpmn-js marks deliberately transparent shapes (bpmn:Group, text
+ * annotations) with an inline `fill: none`. The blanket fill override above
+ * would paint them opaque, hiding any elements the group encloses (#1056).
+ * Honor bpmn-js's transparency instead.
+ */
+.djs-shape > .djs-visual > [style*="fill: none"] {
+    fill: none !important;
+}
+
 /* Distinguish bpmn-js throw vs. catch (and other filled) markers in dark mode. */
 .djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"]:not([style*="stroke: white"]) {
     fill: var(--bpmn-shape-stroke-color) !important;


### PR DESCRIPTION
## What

In VS Code dark mode, `bpmn:Group` elements rendered with an opaque dark fill instead of a transparent one. Because a group's rect spans the area around the tasks/events it contains, the opaque fill was painted *over* those contents, hiding any enclosed tasks, gateways and flows. Light mode was unaffected.

Fixes #1056.

## Root cause

bpmn-js renders a group as a dashed rect with `fill: 'none'` (so it stays transparent). The dark theme has a blanket override in `apps/bpmn-webview/src/styles/dark-theme/diagram-js.css`:

```css
.djs-shape > .djs-visual > *:not(text) {
    fill: var(--bpmn-shape-fill-color) !important;  /* opaque #282828 */
    stroke: var(--bpmn-shape-stroke-color) !important;
}
```

The `!important` fill clobbered bpmn-js's deliberate `fill: none`, painting the group opaque over its contents. The light theme has no such override, which is why it was fine.

## Fix

One additive rule that re-asserts transparency for any visual whose inline style declares `fill: none`:

```css
.djs-shape > .djs-visual > [style*="fill: none"] {
    fill: none !important;
}
```

The attribute selector has higher specificity and comes later in source order, so it wins over the blanket rule — without disturbing the existing stroke theming (the group keeps its themed dashed border). This honors bpmn-js's intent generally rather than special-casing groups, so it also covers other transparent-by-design shapes (e.g. text annotations). It follows the same inline-style-matching convention already used in this file for the throw/catch marker rules.

## Verification

- Webview builds cleanly; the rule is present in the bundled `darkTheme.css`.
- Drove a real browser (Chromium over CDP) against a harness reproducing exactly how bpmn-js sets inline styles. Confirmed: the group's serialized style contains `fill: none`, the selector matches it, the group's computed fill is `none` (transparent), and a normal task rect still computes the dark fill — so shapes that should be filled are unaffected.
