### PR TITLE
docs(agent): add commit conventions guide and disable Claude attribution

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -83,6 +83,38 @@ build → package plugin → bundle → start chain.
 
 All VS Code settings use the `miragon.bpmnModeler` namespace (e.g. `miragon.bpmnModeler.alignToOrigin`, `miragon.bpmnModeler.language`). Do **not** use the legacy `miragon.camundaModeler` prefix.
 
+## Commit Conventions
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
+There is no commitlint/husky enforcement — the convention is upheld by
+discipline, so match the existing history. Use `/commit` to generate a
+conforming message.
+
+**Format:** `<type>(<scope>): <subject>`
+
+- **Subject:** imperative present tense, lowercase, no trailing period
+  (e.g. `add`, not `added`/`adds`). Keep the header under ~72 characters.
+- **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`,
+  `build`, `ci`, `perf`, `revert`.
+- **Scope:** the affected workspace or feature, matching existing history —
+  e.g. `bpmn-webview`, `dmn-webview`, `deployment-webview`, `modeler-plugin`,
+  `editor`, `diff`, `domain`, `infrastructure`, `service`, `deps`, `release`.
+  Omit the scope only when a change is genuinely repo-wide.
+- **Body/footer:** optional. Explain the *why* in the body when the subject
+  isn't self-explanatory; reference PRs/issues in the footer as the history
+  does (e.g. `(#1056)`). Mark breaking changes with `!` after the
+  type/scope (`feat(editor)!: …`) or a `BREAKING CHANGE:` footer.
+- **No Claude attribution.** Do not add `Co-Authored-By` or
+  "Generated with Claude Code" trailers (also enforced via `.claude/settings.json`).
+
+Examples (from this repo's history):
+
+```
+fix(bpmn-webview): keep bpmn:Group transparent in dark mode (#1056)
+refactor(editor): introduce EditorHandle port and split EditorStore
+chore(release): bump version to 1.0.1
+```
+
 ## Comment Style
 
 Write comments that explain **why**, not **what**. Identifier names and

--- a/.agent/commands/commit.md
+++ b/.agent/commands/commit.md
@@ -1,0 +1,48 @@
+---
+description: Create a Conventional Commits message for the staged changes and commit
+argument-hint: "[optional scope hint or extra context, e.g. 'editor' or 'fixes flaky test']"
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*)
+---
+
+Create a single git commit for the current changes, following this repo's
+commit convention (see the "Commit Conventions" section in `CLAUDE.md`).
+
+## Gather context
+
+Run these in parallel and read the output:
+
+- `git status --short`
+- `git diff --staged` — the changes that will actually be committed
+- `git log --format='%s' -15` — to mirror the existing type/scope vocabulary
+
+## Decide what to commit
+
+- If there **are** staged changes, commit **only those** — do not `git add`
+  more. The user's staging is the intent.
+- If **nothing is staged**, do not silently commit everything. Show the
+  unstaged/untracked files and ask the user what to stage (or to confirm
+  staging all). Only proceed once they answer.
+
+## Write the message
+
+Format: `<type>(<scope>): <subject>`
+
+- Infer `type` and `scope` from the changed paths and the diff. Scope is the
+  affected workspace/feature (`bpmn-webview`, `modeler-plugin`, `editor`,
+  `diff`, `deployment`, `domain`, `deps`, `release`, …). Omit the scope only
+  for genuinely repo-wide changes.
+- Subject: imperative present tense, lowercase, no trailing period, ≤ ~72 chars.
+- Add a body only when the *why* isn't obvious from the subject. Wrap at ~72.
+- `$ARGUMENTS`, if provided, is a hint — a scope to prefer or extra context to
+  weave into the body. Treat it as guidance, not the literal message.
+- **No attribution trailers** — no `Co-Authored-By`, no "Generated with Claude
+  Code". (Also disabled in `.claude/settings.json`.)
+
+## Commit
+
+- Show the proposed message, then commit with `git commit -m "…"` (use repeated
+  `-m` flags for a body). Pass the message via a file or multiple `-m` flags —
+  never embed unescaped newlines in a single shell string.
+- **Do not push.** Stop after committing and report the new commit subject.
+- If pre-commit hooks modify files or the commit fails, report what happened
+  instead of forcing it through.

--- a/.agent/settings.json
+++ b/.agent/settings.json
@@ -1,5 +1,10 @@
 {
   "plugins": [".claude/plugins/miranum-ide"],
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
+  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
       "mcp__plugin_playwright_playwright__browser_navigate",


### PR DESCRIPTION
**Issue**

_n/a — tooling/config improvement._

**Description**

Documents the Conventional Commits convention the repo already follows (format, type list, scope vocabulary, breaking-change notation) in `AGENT.md`/`CLAUDE.md`, adds a reusable `/commit` slash command that generates a conforming message from the staged diff, and disables Claude's commit/PR attribution in `.claude/settings.json` (`attribution` emptied + `includeCoAuthoredBy: false`) so no `Co-Authored-By` / "Generated with Claude Code" trailers are added. No production code or enforcement tooling (commitlint/husky) is changed.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created