### PR TITLE
feat(codeLink): navigate from BPMN tasks to their source code (#856)

### DIFF
--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -16,6 +16,7 @@
         "@miragon/bpmn-model-navigation": "workspace:*",
         "@miragon/bpmn-modeler-append-menu": "workspace:*",
         "@miragon/bpmn-modeler-clipboard": "workspace:*",
+        "@miragon/bpmn-modeler-code-link": "workspace:*",
         "@miragon/bpmn-modeler-element-template-chooser": "workspace:*",
         "@miragon/bpmn-modeler-i18n": "workspace:*",
         "@miragon/bpmn-modeler-shared": "workspace:*",

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -8,6 +8,7 @@ import TransactionBoundariesModule from "camunda-transaction-boundaries";
 import { CreateAppendElementTemplatesModule } from "bpmn-js-create-append-anything";
 import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
 import { NavigateToReferencedModelModule } from "@miragon/bpmn-model-navigation";
+import { CodeLinkModule, type CodeLinkMapClient } from "@miragon/bpmn-modeler-code-link";
 import { CreateAppendC7ElementTemplatesModule } from "@miragon/create-append-c7";
 import {
     BpmnModelerSetting,
@@ -104,6 +105,7 @@ export class BpmnModeler {
             ElementTemplateChooserModule,
             AppendMenuModule,
             NavigateToReferencedModelModule,
+            CodeLinkModule,
         ];
         const extra = extraModules ?? [];
 
@@ -443,6 +445,18 @@ export class BpmnModeler {
             .on(OPEN_SCRIPT_EDITOR_EVENT, (event: OpenScriptEditorEvent) => {
                 callback(event);
             });
+    }
+
+    /**
+     * Hands the host's per-activity implementation-resolution map to the
+     * code-link DI service, which caches it and refreshes the context pad so the
+     * "Go to implementation" entry hides for tasks whose implementation does not
+     * exist in the workspace.
+     *
+     * @throws {NoModelerError} If the modeler has not been created yet.
+     */
+    applyImplementationStatus(resolved: Record<string, boolean>): void {
+        this.getService<CodeLinkMapClient>("codeLinkMapClient").applyStatus(resolved);
     }
 
     /**

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -18,6 +18,7 @@ import {
     GetElementTemplatesCommand,
     GetPropertiesPanelStateCommand,
     GetTextClipboardCommand,
+    ImplementationStatusQuery,
     LanguageQuery,
     LogErrorCommand,
     LogInfoCommand,
@@ -451,6 +452,15 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     query.listenerIndex,
                     query.scriptFormat,
                 );
+            } catch (error: any) {
+                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+            }
+            break;
+        }
+        case queryOrCommand.type === "ImplementationStatusQuery": {
+            try {
+                const query = message.data as ImplementationStatusQuery;
+                bpmnModeler.applyImplementationStatus(query.resolved);
             } catch (error: any) {
                 vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsConfigurable.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsConfigurable.kt
@@ -32,6 +32,7 @@ class ModelerSettingsConfigurable : Configurable {
         var alignToOrigin: Boolean,
         var showTransactionBoundaries: Boolean,
         var configFolder: String,
+        var persistCodeLinkMap: Boolean,
         var c8ApiVersion: String,
         var colorTheme: String,
         var favouritesText: String,
@@ -63,6 +64,19 @@ class ModelerSettingsConfigurable : Configurable {
                         .comment(
                             "Folder searched at each level from the BPMN file up to the project root. " +
                                 "Element templates live under <code>&lt;config&gt;/element-templates/</code>.",
+                        )
+                }
+                row {
+                    checkBox("Persist activity→code map to disk")
+                        .bindSelected(
+                            { state.persistCodeLinkMap },
+                            { state.persistCodeLinkMap = it },
+                        )
+                        .comment(
+                            "Writes the activity→code map to " +
+                                "<code>&lt;config&gt;/code-link/&lt;file&gt;.json</code> as an opt-in warm " +
+                                "cache (faster re-open) and a machine-readable artifact for external/AI " +
+                                "tooling. The <b>Go to implementation</b> entry works in memory either way.",
                         )
                 }
                 row("Camunda 8 API version:") {
@@ -133,6 +147,7 @@ class ModelerSettingsConfigurable : Configurable {
             alignToOrigin = alignToOrigin,
             showTransactionBoundaries = showTransactionBoundaries,
             configFolder = configFolder.trim(),
+            persistCodeLinkMap = persistCodeLinkMap,
             c8ApiVersion = c8ApiVersion.trim(),
             colorTheme = colorTheme,
             favouriteBpmnElements = parseFavourites(favouritesText),
@@ -143,6 +158,7 @@ class ModelerSettingsConfigurable : Configurable {
         alignToOrigin = other.alignToOrigin
         showTransactionBoundaries = other.showTransactionBoundaries
         configFolder = other.configFolder
+        persistCodeLinkMap = other.persistCodeLinkMap
         c8ApiVersion = other.c8ApiVersion
         colorTheme = other.colorTheme
         favouritesText = other.favouritesText
@@ -155,6 +171,7 @@ class ModelerSettingsConfigurable : Configurable {
             alignToOrigin = settings.alignToOrigin,
             showTransactionBoundaries = settings.showTransactionBoundaries,
             configFolder = settings.configFolder,
+            persistCodeLinkMap = settings.persistCodeLinkMap,
             c8ApiVersion = settings.c8ApiVersion,
             colorTheme = settings.colorTheme,
             favouritesText = settings.favouriteBpmnElements.joinToString("\n"),

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsStore.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsStore.kt
@@ -15,6 +15,7 @@ data class ModelerSettings(
     val alignToOrigin: Boolean,
     val showTransactionBoundaries: Boolean,
     val configFolder: String,
+    val persistCodeLinkMap: Boolean,
     val c8ApiVersion: String,
     val colorTheme: String,
     val favouriteBpmnElements: List<String>,
@@ -41,6 +42,7 @@ class ModelerSettingsStore {
             alignToOrigin = props.getBoolean(ALIGN_TO_ORIGIN, DEFAULT_ALIGN_TO_ORIGIN),
             showTransactionBoundaries = props.getBoolean(SHOW_TX_BOUNDARIES, DEFAULT_SHOW_TX_BOUNDARIES),
             configFolder = props.getValue(CONFIG_FOLDER, DEFAULT_CONFIG_FOLDER),
+            persistCodeLinkMap = props.getBoolean(PERSIST_CODE_LINK_MAP, DEFAULT_PERSIST_CODE_LINK_MAP),
             c8ApiVersion = props.getValue(C8_API_VERSION, DEFAULT_C8_API_VERSION),
             colorTheme = normalizeColorTheme(props.getValue(COLOR_THEME, DEFAULT_COLOR_THEME)),
             favouriteBpmnElements = props.getList(FAVOURITE_ELEMENTS) ?: DEFAULT_FAVOURITE_ELEMENTS,
@@ -53,6 +55,7 @@ class ModelerSettingsStore {
         props.setValue(SHOW_TX_BOUNDARIES, settings.showTransactionBoundaries, DEFAULT_SHOW_TX_BOUNDARIES)
         // An empty config folder would make discovery scan the whole tree; keep the default instead.
         props.setValue(CONFIG_FOLDER, settings.configFolder.ifBlank { DEFAULT_CONFIG_FOLDER }, DEFAULT_CONFIG_FOLDER)
+        props.setValue(PERSIST_CODE_LINK_MAP, settings.persistCodeLinkMap, DEFAULT_PERSIST_CODE_LINK_MAP)
         props.setValue(C8_API_VERSION, settings.c8ApiVersion, DEFAULT_C8_API_VERSION)
         props.setValue(COLOR_THEME, normalizeColorTheme(settings.colorTheme), DEFAULT_COLOR_THEME)
         // Cap matches the webview append-menu palette (max 6 pinned elements).
@@ -71,6 +74,7 @@ class ModelerSettingsStore {
             "alignToOrigin" to current.alignToOrigin,
             "showTransactionBoundaries" to current.showTransactionBoundaries,
             "configFolder" to current.configFolder,
+            "persistCodeLinkMap" to current.persistCodeLinkMap,
             "c8ApiVersion" to current.c8ApiVersion,
             "colorTheme" to current.colorTheme,
             "favouriteBpmnElements" to current.favouriteBpmnElements,
@@ -91,6 +95,7 @@ class ModelerSettingsStore {
         private const val ALIGN_TO_ORIGIN = "miragon.bpmnModeler.alignToOrigin"
         private const val SHOW_TX_BOUNDARIES = "miragon.bpmnModeler.showTransactionBoundaries"
         private const val CONFIG_FOLDER = "miragon.bpmnModeler.configFolder"
+        private const val PERSIST_CODE_LINK_MAP = "miragon.bpmnModeler.persistCodeLinkMap"
         private const val C8_API_VERSION = "miragon.bpmnModeler.c8ApiVersion"
         private const val COLOR_THEME = "miragon.bpmnModeler.colorTheme"
         private const val FAVOURITE_ELEMENTS = "miragon.bpmnModeler.favouriteBpmnElements"
@@ -100,6 +105,7 @@ class ModelerSettingsStore {
         private const val DEFAULT_ALIGN_TO_ORIGIN = false
         private const val DEFAULT_SHOW_TX_BOUNDARIES = true
         private const val DEFAULT_CONFIG_FOLDER = ".camunda"
+        private const val DEFAULT_PERSIST_CODE_LINK_MAP = false
         private const val DEFAULT_C8_API_VERSION = "v2"
         private const val DEFAULT_COLOR_THEME = "automatic"
         private const val DEFAULT_LANGUAGE = "en"

--- a/apps/modeler-bridge/src/bridge.codeLink.spec.ts
+++ b/apps/modeler-bridge/src/bridge.codeLink.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * End-to-end coverage for the code-link RPC paths on the bridge.
+ *
+ * Same harness as `bridge.navigate.spec.ts`: the real bridge (`createBridge`)
+ * runs against a fake transport (a frames array) over a real temp filesystem, so
+ * the `CodeLinkMapService` + `ImplementationLocator` it constructs do an actual
+ * `fs.glob` + path/content match. The tests cover the host-visible behaviour:
+ * `SyncActivitiesCommand` resolving (and not resolving) an entry into an
+ * `ImplementationStatusQuery`, `NavigateToImplementationCommand` opening the
+ * single match, and the unknown-`kind` guard short-circuiting before any search.
+ */
+
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { implementationStatusKey } from "@miragon/bpmn-modeler-shared";
+
+import { createBridge } from "./bridge";
+import { Rpc } from "./rpc";
+
+const C7_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true" />
+</bpmn:definitions>`;
+
+/** A minimal Java class file body; the locator resolves `javaClass` by path alone. */
+function javaClass(packageName: string, className: string): string {
+    return `package ${packageName};\n\npublic class ${className} {}\n`;
+}
+
+async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Waits for a frame matching `predicate`, or rejects after `timeoutMs`. The sync
+ * path chains an async attach → fs.glob → per-file work before the status push,
+ * so polling keeps the test deterministic without counting microtasks.
+ */
+async function waitForFrame(
+    frames: any[],
+    predicate: (frame: any) => boolean,
+    timeoutMs = 2000,
+): Promise<any> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const match = frames.find(predicate);
+        if (match) return match;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("waitForFrame timed out");
+}
+
+function registerParams(editorId: string, root: string, fsPath: string, content: string) {
+    return {
+        editorId,
+        uriString: editorId,
+        path: editorId.replace(/^file:\/\//, ""),
+        fsPath,
+        scheme: "file",
+        workspaceRoot: root,
+        content,
+    };
+}
+
+describe("bridge code link (real core + map/locator over a fake transport)", () => {
+    const cleanups: Array<() => Promise<void> | void> = [];
+
+    afterEach(async () => {
+        for (const cleanup of cleanups.splice(0)) {
+            await cleanup();
+        }
+    });
+
+    async function setup(): Promise<{
+        rpc: Rpc;
+        frames: any[];
+        root: string;
+        editorId: string;
+    }> {
+        const root = await fs.mkdtemp(join(tmpdir(), "modeler-bridge-link-"));
+        const sourcePath = join(root, "process.bpmn");
+        await fs.writeFile(sourcePath, C7_XML, "utf8");
+
+        const frames: any[] = [];
+        const { rpc } = createBridge((line) => frames.push(JSON.parse(line)));
+        const editorId = `file://${sourcePath}`;
+
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "session/register",
+                params: registerParams(editorId, root, sourcePath, C7_XML),
+            }),
+        );
+
+        cleanups.push(() => fs.rm(root, { recursive: true, force: true }));
+        return { rpc, frames, root, editorId };
+    }
+
+    /** Drops a Java class at the conventional `<src>/<pkg path>/<Class>.java` location. */
+    async function writeJava(root: string, fqcn: string): Promise<void> {
+        const segments = fqcn.split(".");
+        const className = segments.pop()!;
+        const packageName = segments.join(".");
+        const dir = join(root, "src", "main", "java", ...segments);
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(
+            join(dir, `${className}.java`),
+            javaClass(packageName, className),
+            "utf8",
+        );
+    }
+
+    it("resolves a javaClass activity to true and an unbacked one to false", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        await writeJava(root, "com.example.OrderDelegate");
+
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "SyncActivitiesCommand",
+                        entries: [
+                            {
+                                activityId: "Task_Resolved",
+                                kind: "javaClass",
+                                reference: "com.example.OrderDelegate",
+                            },
+                            {
+                                activityId: "Task_Missing",
+                                kind: "javaClass",
+                                reference: "com.example.DoesNotExist",
+                            },
+                        ],
+                    },
+                },
+            }),
+        );
+
+        const status = await waitForFrame(
+            frames,
+            (f) =>
+                f.method === "editor/postMessage" &&
+                f.params.message.type === "ImplementationStatusQuery",
+        );
+        const { resolved } = status.params.message;
+        expect(
+            resolved[implementationStatusKey("Task_Resolved", "com.example.OrderDelegate")],
+        ).toBe(true);
+        expect(resolved[implementationStatusKey("Task_Missing", "com.example.DoesNotExist")]).toBe(
+            false,
+        );
+    });
+
+    it("opens the single match on NavigateToImplementationCommand without a picker", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        await writeJava(root, "com.example.PaymentDelegate");
+        const targetPath = join(
+            root,
+            "src",
+            "main",
+            "java",
+            "com",
+            "example",
+            "PaymentDelegate.java",
+        );
+
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "NavigateToImplementationCommand",
+                        reference: "com.example.PaymentDelegate",
+                        kind: "javaClass",
+                    },
+                },
+            }),
+        );
+
+        const open = await waitForFrame(frames, (f) => f.method === "notifier/openDocument");
+        expect(open.params.path).toBe(targetPath);
+        // A single match must short-circuit the picker.
+        expect(frames.find((f) => f.method === "picker/show")).toBeUndefined();
+    });
+
+    it("rejects an unknown implementation kind with a warn log and no search", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        // Seed a real candidate so a fall-through bug would visibly open something.
+        await writeJava(root, "com.example.PaymentDelegate");
+
+        const before = frames.length;
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "NavigateToImplementationCommand",
+                        reference: "com.example.PaymentDelegate",
+                        kind: "sorcery",
+                    },
+                },
+            }),
+        );
+        await settle();
+
+        const newFrames = frames.slice(before);
+        expect(newFrames.find((f) => f.method === "notifier/openDocument")).toBeUndefined();
+        expect(newFrames.find((f) => f.method === "picker/show")).toBeUndefined();
+        // The guard must short-circuit before the locator's progress spinner.
+        expect(newFrames.find((f) => f.method === "notifier/progressStart")).toBeUndefined();
+        const warn = newFrames.find(
+            (f) => f.method === "notifier/log" && f.params.level === "warn",
+        );
+        expect(warn).toBeDefined();
+        expect(String(warn.params.message)).toContain("sorcery");
+    });
+});

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -36,11 +36,14 @@
 import {
     Command,
     DiffOrigin,
+    ImplementationKind,
+    NavigateToImplementationCommand,
     NavigateToReferencedModelCommand,
     OpenScriptEditorCommand,
     Query,
     SetClipboardCommand,
     SetTextClipboardCommand,
+    SyncActivitiesCommand,
     SyncDocumentCommand,
     UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
@@ -55,12 +58,15 @@ import {
     Camunda7RestClient,
     Camunda8RestClient,
     CamundaEngineRouter,
+    CodeLinkMapService,
     DeploymentMessageDispatcher,
     DeploymentService,
     DiffPaneStore,
     DiffSession,
     EditorSessionStore,
     FetchHttpClient,
+    ImplementationLocator,
+    ImplementationNavigationService,
     ModelNavigationService,
     ReferencedModelLocator,
     StartInstanceService,
@@ -89,6 +95,15 @@ import { BridgeScriptEditor } from "./scriptAdapters";
 function query(type: string, fields: Record<string, unknown>): Query {
     return { type, ...fields } as unknown as Query;
 }
+
+/** Implementation kinds the locator can resolve; a guard against a malformed webview message. */
+const KNOWN_IMPLEMENTATION_KINDS: ReadonlySet<ImplementationKind> = new Set<ImplementationKind>([
+    "javaClass",
+    "delegateExpression",
+    "expression",
+    "externalTopic",
+    "jobType",
+]);
 
 interface RegisterParams extends SessionMeta {
     content: string;
@@ -165,6 +180,26 @@ export function createBridge(
         referencedModelLocator,
         notifier,
         picker,
+    );
+
+    // The code-link brain is `vscode`-free too: the locator/navigation service
+    // mirror the model-navigation pair (search via NodeWorkspace, surface via the
+    // RPC notifier/picker), while the always-on map service maintains context-pad
+    // visibility and live linking off the source-file watcher. Mirrors
+    // `composition/codeLinkFeature.ts` — the locator is shared by both consumers.
+    const implementationLocator = new ImplementationLocator(nodeWorkspace, notifier);
+    const implementationNavigationService = new ImplementationNavigationService(
+        implementationLocator,
+        notifier,
+        picker,
+    );
+    const codeLinkMapService = new CodeLinkMapService(
+        store,
+        implementationLocator,
+        artifactSvc,
+        nodeWorkspace,
+        settings,
+        notifier,
     );
 
     // "Edit Script" orchestrator. Unlike the other features this one has no
@@ -291,6 +326,30 @@ export function createBridge(
             const sourceFsPath = store.requireHandle(editorId).documentFsPath();
             await modelNavigationService.navigate(cmd.referenceId, cmd.referenceKind, sourceFsPath);
         })
+        // Mirrors `navigateToImplementationHandler` on the VS Code host: the same
+        // defence-in-depth guard rejects an unknown/empty `kind` so a malformed
+        // message can't be resolved as an arbitrary kind.
+        .on("NavigateToImplementationCommand", async (message: Command, editorId: string) => {
+            const cmd = message as NavigateToImplementationCommand;
+            if (!KNOWN_IMPLEMENTATION_KINDS.has(cmd.kind)) {
+                notifier.logWarning(
+                    `Ignoring NavigateToImplementationCommand with unknown kind: ${String(
+                        cmd.kind,
+                    )}`,
+                );
+                return;
+            }
+            const sourceFsPath = store.requireHandle(editorId).documentFsPath();
+            await implementationNavigationService.navigate(cmd.reference, cmd.kind, sourceFsPath);
+        })
+        // Always-on activity→code reconciliation; the map service filters invalid
+        // entries internally, so this stays a thin pass-through.
+        .on("SyncActivitiesCommand", async (message: Command, editorId: string) => {
+            await codeLinkMapService.syncActivities(
+                editorId,
+                (message as SyncActivitiesCommand).entries,
+            );
+        })
         .on("OpenScriptEditorCommand", (message: Command, editorId: string) => {
             void scriptEditor.open(message as OpenScriptEditorCommand, editorId);
         })
@@ -384,6 +443,9 @@ export function createBridge(
         bpmnService.disposeSession(params.editorId);
         // Close any script tabs this editor opened before its handle is dropped.
         scriptEditor.disposeEditor(params.editorId);
+        // Release this editor's code-link map state + its share of the source
+        // watcher; mirrors `CodeLinkParticipant` (the bridge has no participants).
+        codeLinkMapService.disposeEditor(params.editorId);
         watchers.get(params.editorId)?.forEach((d) => d.dispose());
         watchers.delete(params.editorId);
         // Read the root before removing the mirror entry that holds it.

--- a/apps/modeler-bridge/src/nodeAdapters.spec.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.spec.ts
@@ -149,7 +149,7 @@ describe("NodeWorkspace folder lookups", () => {
  * recursive `fs.watch`.
  */
 
-/** chokidar is ignored by the adapter (`_glob`); any constant documents intent. */
+/** The element-templates glob the adapter compiles to match changed paths against. */
 const PATTERN = "**/.camunda/element-templates/**/*.json";
 
 // chokidar needs a moment to arm its watchers; the adapter debounces ~50ms on
@@ -266,4 +266,79 @@ describe("NodeWorkspace.createWatcher", () => {
         await sleep(SETTLE_MS);
         expect(onCreate).not.toHaveBeenCalled();
     }, 15000);
+
+    // The source glob (extensions `{java,kt,…}`) is the code-link watcher's
+    // pattern. An earlier version hardcoded the template matcher and ignored the
+    // glob, so a saved `.java` file never reached the handler — these pin the fix.
+    const SOURCE_GLOB = "**/*.{java,kt,groovy,scala,js,ts}";
+
+    it("honours the source glob: fires onCreate for a created .java file", async () => {
+        const onCreate = vi.fn();
+        handle = workspace.createWatcher(root, SOURCE_GLOB, { onCreate });
+        await sleep(SETTLE_MS);
+
+        await fs.mkdir(join(root, "src", "main", "java"), { recursive: true });
+        await fs.writeFile(
+            join(root, "src", "main", "java", "Worker.java"),
+            "class Worker {}",
+            "utf8",
+        );
+
+        await waitForCall(onCreate);
+        expect(onCreate).toHaveBeenCalled();
+    }, 15000);
+
+    it("honours the source glob: ignores a non-matching .json file", async () => {
+        const onCreate = vi.fn();
+        handle = workspace.createWatcher(root, SOURCE_GLOB, { onCreate });
+        await sleep(SETTLE_MS);
+
+        await fs.writeFile(join(root, "config.json"), "{}", "utf8");
+
+        await sleep(SETTLE_MS);
+        expect(onCreate).not.toHaveBeenCalled();
+    }, 15000);
+
+    it("still fires for a template under the template glob", async () => {
+        const onCreate = vi.fn();
+        handle = workspace.createWatcher(root, PATTERN, { onCreate });
+        await sleep(SETTLE_MS);
+
+        await fs.mkdir(templatesDir, { recursive: true });
+        await fs.writeFile(join(templatesDir, "task.json"), "[]", "utf8");
+
+        await waitForCall(onCreate);
+        expect(onCreate).toHaveBeenCalled();
+    }, 15000);
+});
+
+/**
+ * `writeFile` backs the code-link artifact persistence. It must mkdirp the
+ * nested `<config>/code-link/…` target — the directory rarely exists yet — which
+ * the prior stub (a hard throw) never did.
+ */
+describe("NodeWorkspace.writeFile", () => {
+    let root: string;
+
+    beforeEach(async () => {
+        root = await fs.mkdtemp(join(tmpdir(), "modeler-write-"));
+    });
+
+    afterEach(async () => {
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    it("creates missing parent directories", async () => {
+        const target = join(root, ".camunda", "code-link", "sub", "order.bpmn.json");
+        await new NodeWorkspace().writeFile(target, '{"ok":true}');
+        expect(await fs.readFile(target, "utf8")).toBe('{"ok":true}');
+    });
+
+    it("overwrites an existing file", async () => {
+        const target = join(root, "out.json");
+        const ws = new NodeWorkspace();
+        await ws.writeFile(target, "first");
+        await ws.writeFile(target, "second");
+        expect(await fs.readFile(target, "utf8")).toBe("second");
+    });
 });

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -333,6 +333,7 @@ export interface SettingsSnapshot {
     alignToOrigin: boolean;
     showTransactionBoundaries: boolean;
     configFolder: string;
+    persistCodeLinkMap: boolean;
     c8ApiVersion: string;
     colorTheme: "automatic" | "light";
     favouriteBpmnElements: string[];
@@ -352,6 +353,7 @@ const DEFAULT_SETTINGS: SettingsSnapshot = {
     alignToOrigin: false,
     showTransactionBoundaries: true,
     configFolder: ".camunda",
+    persistCodeLinkMap: false,
     c8ApiVersion: "v2",
     colorTheme: "automatic",
     favouriteBpmnElements: [
@@ -417,6 +419,9 @@ export class BridgeSettings implements SettingsPort {
 
     getConfigFolder(): string {
         return this.snapshot.configFolder;
+    }
+    getPersistCodeLinkMap(): boolean {
+        return this.snapshot.persistCodeLinkMap;
     }
     getAlignToOrigin(): boolean {
         return this.snapshot.alignToOrigin;

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -46,15 +46,22 @@ function toFsPath(path: string): string {
     return path.replace(/^file:\/\//, "");
 }
 
+/** Backslash-escapes every regex-special character in a literal glob run. */
+function escapeRegExpLiteral(literal: string): string {
+    return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
- * Compiles a glob into a path-matching `RegExp`. Used only to honour the
- * `exclude` argument of {@link NodeWorkspace.findFiles}: Node's `fs.glob`
- * accepts the positive pattern natively, but its `exclude` option shape differs
- * across Node and Bun, so we match excluded paths ourselves to stay portable.
+ * Compiles a glob into a path-matching `RegExp`. Two callers rely on it: the
+ * `exclude` argument of {@link NodeWorkspace.findFiles} (Node's `fs.glob` accepts
+ * the positive pattern natively, but its `exclude` option shape differs across
+ * Node and Bun, so we match excluded paths ourselves to stay portable) and
+ * {@link NodeWorkspace.createWatcher}, which honours its `glob` param this way.
  *
  * Supports the operators the callers use: a double-star (across path segments,
  * with a trailing slash swallowed so a leading double-star also matches at the
- * root), and single `*` / `?` within one segment.
+ * root), single `*` / `?` within one segment, and `{a,b,c}` brace alternation —
+ * the code-link source glob (extensions `{java,kt,…}`) needs the last one.
  */
 function globToRegExp(glob: string): RegExp {
     let re = "";
@@ -68,12 +75,19 @@ function globToRegExp(glob: string): RegExp {
             re += "[^/]*";
         } else if (c === "?") {
             re += "[^/]";
+        } else if (c === "{") {
+            // `{a,b,c}` → `(?:a|b|c)`. An unterminated brace degrades to a literal
+            // so a stray `{` can't produce an invalid regex.
+            const end = glob.indexOf("}", i);
+            if (end === -1) {
+                re += "\\{";
+            } else {
+                const alternatives = glob.slice(i + 1, end).split(",");
+                re += `(?:${alternatives.map(escapeRegExpLiteral).join("|")})`;
+                i = end;
+            }
         } else {
-            // `c` is a single character; backslash-escape it when it carries
-            // regex meaning. (A non-global `.replace` here would only escape the
-            // first match — fine for one char, but the explicit test is clearer
-            // and side-steps the incomplete-sanitization trap.)
-            re += /[.*+?^${}()|[\]\\]/.test(c) ? `\\${c}` : c;
+            re += escapeRegExpLiteral(c);
         }
     }
     return new RegExp(`^${re}$`);
@@ -192,16 +206,22 @@ export class NodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Watches the workspace root for element-template JSON changes via chokidar,
-     * firing the matching handler debounced ~50ms to coalesce the editor's
-     * multi-event save bursts into a single re-load.
+     * Watches the workspace root via chokidar, firing the matching handler for
+     * every changed path that matches `glob`, debounced ~50ms to coalesce an
+     * editor's multi-event save burst into one notification per file.
+     *
+     * Both watch consumers ride this one adapter: `ArtifactService` arms it with
+     * the element-templates glob, and `CodeLinkMapService` with the source glob
+     * (extensions `{java,kt,…}`). The `glob` argument is honoured — an earlier
+     * version hardcoded the template pattern, which silently dropped every
+     * code-link event.
      *
      * chokidar replaces `fs.watch({ recursive: true })`: the latter's recursive
      * mode is unreliable across platforms — under Bun on Linux it only tracks
      * subdirectories that existed when the watch began (fixed only in Bun
-     * ≥1.3.14), so a freshly-created `element-templates/` folder would go
-     * unnoticed. chokidar gives version-independent recursive watching on
-     * macOS/Windows/Linux, matching VS Code's `FileSystemWatcher` behaviour.
+     * ≥1.3.14), so a freshly-created folder would go unnoticed. chokidar gives
+     * version-independent recursive watching on macOS/Windows/Linux, matching
+     * VS Code's `FileSystemWatcher` behaviour.
      *
      * `node_modules`/`.git` are pruned so arming the recursive watch on a large
      * repo stays within the OS watch-descriptor budget (inotify on Linux).
@@ -209,7 +229,7 @@ export class NodeWorkspace implements WorkspacePort {
      */
     createWatcher(
         rootPath: string,
-        _glob: string,
+        glob: string,
         handlers: {
             onChange?: (path: string) => void;
             onCreate?: (path: string) => void;
@@ -217,30 +237,36 @@ export class NodeWorkspace implements WorkspacePort {
         },
     ): { dispose(): void } {
         const root = toFsPath(rootPath);
-        let timer: NodeJS.Timeout | undefined;
+        const matcher = globToRegExp(glob);
 
-        // The glob targets `<configFolder>/element-templates/**/*.json`; match
-        // its intent against the changed path. chokidar emits OS-native paths,
-        // so normalise separators before the substring check.
-        const isTemplate = (changed: string): boolean => {
-            const normalized = changed.replace(/\\/g, "/");
-            return normalized.includes("/element-templates/") && normalized.endsWith(".json");
-        };
+        // chokidar emits OS-native paths; normalise separators before matching
+        // the glob, which is always forward-slash.
+        const matches = (changed: string): boolean => matcher.test(changed.replace(/\\/g, "/"));
 
-        // One shared timer across add/change/unlink: every event resolves to the
-        // same template re-load downstream, so coalescing a burst into the last
-        // event's handler is correct and avoids redundant reloads.
+        // Per-path timers, not one shared timer: the template handler reloads
+        // everything on any event, so coalescing its burst is harmless — but code
+        // link needs every distinct changed file. A single timer would drop all
+        // but the last file of a multi-file burst (e.g. a branch checkout).
+        const timers = new Map<string, NodeJS.Timeout>();
+
         const fireDebounced = (
             handler: ((path: string) => void) | undefined,
             changed: string,
         ): void => {
-            if (!handler || !isTemplate(changed)) {
+            if (!handler || !matches(changed)) {
                 return;
             }
-            if (timer) {
-                clearTimeout(timer);
+            const pending = timers.get(changed);
+            if (pending) {
+                clearTimeout(pending);
             }
-            timer = setTimeout(() => handler(changed), 50);
+            timers.set(
+                changed,
+                setTimeout(() => {
+                    timers.delete(changed);
+                    handler(changed);
+                }, 50),
+            );
         };
 
         const watcher = watch(root, {
@@ -256,9 +282,10 @@ export class NodeWorkspace implements WorkspacePort {
 
         return {
             dispose(): void {
-                if (timer) {
+                for (const timer of timers.values()) {
                     clearTimeout(timer);
                 }
+                timers.clear();
                 // chokidar's close() is async; nothing awaits teardown here.
                 void watcher.close();
             },
@@ -289,8 +316,15 @@ export class NodeWorkspace implements WorkspacePort {
         return hadScheme ? "file://" + parent : parent;
     }
 
-    writeFile(): Promise<void> {
-        throw new Error("not implemented in bridge");
+    /**
+     * Writes `content`, creating missing parent directories first. The mkdirp
+     * mirrors `VsCodeWorkspace.writeFile`: the code-link artifact lands under a
+     * nested `<configFolder>/code-link/<dir>/…` path that need not exist yet.
+     */
+    async writeFile(path: string, content: string): Promise<void> {
+        const fsPath = toFsPath(path);
+        await fs.mkdir(posix.dirname(fsPath), { recursive: true });
+        await fs.writeFile(fsPath, content, "utf8");
     }
 
     /**

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -290,6 +290,11 @@
                     "default": ".camunda",
                     "markdownDescription": "Name of the config folder searched at each directory level from the BPMN file up to the workspace root. **Element templates must be placed under `<config>/element-templates/`** (e.g. `.camunda/element-templates/my-template.json`)."
                 },
+                "miragon.bpmnModeler.persistCodeLinkMap": {
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "Persist the activity→code map to `<configFolder>/code-link/<file>.json` (e.g. `.camunda/code-link/order-process.bpmn.json`). The map drives the **Go to implementation** context-pad entry's visibility and works in memory regardless of this setting; the on-disk file is an opt-in warm cache (faster re-open) and a machine-readable artifact for external/AI tooling. Off by default."
+                },
                 "miragon.bpmnModeler.c8ApiVersion": {
                     "type": "string",
                     "default": "v2",

--- a/apps/vscode-plugin/src/architecture.spec.ts
+++ b/apps/vscode-plugin/src/architecture.spec.ts
@@ -228,7 +228,14 @@ describe("architecture", () => {
         // engine extraction their only plugin-side file is an `index.ts` barrel
         // that re-exports the service from `@miragon/bpmn-modeler-core`, so they
         // have no internals left to protect.
-        const FEATURE_FOLDERS = ["diff", "deployment", "scriptTask", "modeler/bpmn", "modeler/dmn"];
+        const FEATURE_FOLDERS = [
+            "diff",
+            "deployment",
+            "scriptTask",
+            "codeLink",
+            "modeler/bpmn",
+            "modeler/dmn",
+        ];
 
         for (const sourceFeature of FEATURE_FOLDERS) {
             for (const targetFeature of FEATURE_FOLDERS) {

--- a/apps/vscode-plugin/src/codeLink/controller/editor-participants/CodeLinkParticipant.ts
+++ b/apps/vscode-plugin/src/codeLink/controller/editor-participants/CodeLinkParticipant.ts
@@ -1,0 +1,21 @@
+import {
+    EditorSessionContext,
+    EditorSessionParticipant,
+} from "../../../modeler/editor-session/EditorSessionParticipant";
+import { CodeLinkMapService } from "@miragon/bpmn-modeler-core";
+
+/**
+ * Releases a session's slice of the activity→code map (and its share of the
+ * shared source-file watcher) when the editor closes.
+ *
+ * The map itself is built and maintained by the incoming
+ * {@link SyncActivitiesCommand}s, not on resolve — the webview drives it — so
+ * this participant carries only the teardown half of the lifecycle.
+ */
+export class CodeLinkParticipant implements EditorSessionParticipant {
+    constructor(private readonly mapService: CodeLinkMapService) {}
+
+    onResolve(session: EditorSessionContext): void {
+        session.onDispose(() => this.mapService.disposeEditor(session.editorId));
+    }
+}

--- a/apps/vscode-plugin/src/codeLink/index.ts
+++ b/apps/vscode-plugin/src/codeLink/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Public API of the code-link feature. Sibling features resolve
+ * navigate-to-implementation and route activity-sync messages only through this
+ * barrel; reaching into the feature's internals is rejected by the
+ * feature-isolation architecture test.
+ */
+export { ImplementationNavigationService, CodeLinkMapService } from "@miragon/bpmn-modeler-core";

--- a/apps/vscode-plugin/src/composition/codeLinkFeature.ts
+++ b/apps/vscode-plugin/src/composition/codeLinkFeature.ts
@@ -1,0 +1,59 @@
+import { ExtensionContext } from "vscode";
+
+import {
+    CodeLinkMapService,
+    ImplementationLocator,
+    ImplementationNavigationService,
+} from "@miragon/bpmn-modeler-core";
+import { CodeLinkParticipant } from "../codeLink/controller/editor-participants/CodeLinkParticipant";
+import { SharedDeps } from "./sharedDeps";
+
+/**
+ * Collaborators the code-link feature contributes to the BPMN editor: the
+ * navigation service that handles a "Go to implementation" click, the always-on
+ * map service that maintains context-pad visibility + live linking, and the
+ * participant that releases per-editor map/watcher state on close.
+ */
+export interface CodeLinkHandles {
+    implementationNavigation: ImplementationNavigationService;
+    codeLinkMap: CodeLinkMapService;
+    codeLinkParticipant: CodeLinkParticipant;
+}
+
+/**
+ * The code-link feature owns the shared {@link ImplementationLocator} and builds
+ * both consumers on top of it: the on-click navigation service and the
+ * always-on {@link CodeLinkMapService} (which also owns the shared source-file
+ * watcher). They are returned as handles for the editor feature to route the
+ * `NavigateToImplementationCommand` / `SyncActivitiesCommand` messages and the
+ * teardown participant into — only the BPMN router consumes them.
+ *
+ * Constructed here rather than in `editorFeature` so the locator is shared by
+ * both consumers and the watcher's lifetime is owned in one place. As a
+ * `composition/` module it may import code-link internals directly; the
+ * feature-isolation rule applies only between feature folders.
+ */
+export function register(context: ExtensionContext, deps: SharedDeps): CodeLinkHandles {
+    const locator = new ImplementationLocator(deps.vsWorkspace, deps.notifier);
+    const implementationNavigation = new ImplementationNavigationService(
+        locator,
+        deps.notifier,
+        deps.picker,
+    );
+    const codeLinkMap = new CodeLinkMapService(
+        deps.editorStore,
+        locator,
+        deps.artifactSvc,
+        deps.vsWorkspace,
+        deps.vsSettings,
+        deps.notifier,
+    );
+    // Dispose the shared source-file watcher(s) on extension shutdown.
+    context.subscriptions.push({ dispose: () => codeLinkMap.dispose() });
+
+    return {
+        implementationNavigation,
+        codeLinkMap,
+        codeLinkParticipant: new CodeLinkParticipant(codeLinkMap),
+    };
+}

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -32,6 +32,8 @@ import {
     openScriptEditorHandler,
     updateScriptVariablesHandler,
     navigateToReferencedModelHandler,
+    navigateToImplementationHandler,
+    syncActivitiesHandler,
 } from "../modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers";
 import {
     getDmnFileHandler,
@@ -40,33 +42,39 @@ import {
 import { BpmnDiffController } from "../diff/controller/BpmnDiffController";
 import { ScriptTaskService } from "../scriptTask/controller/ScriptTaskService";
 import { BPMN_VIEW_TYPE, DMN_VIEW_TYPE, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
+import { CodeLinkHandles } from "./codeLinkFeature";
 import { SharedDeps } from "./sharedDeps";
 
 /**
  * Lifecycle-bearing collaborators owned by sibling features that the editor
  * routes into: the diff controller decides whether a resolved pane is a diff
  * view, the script-task service handles inline-editor messages and teardown,
- * and the variable store feeds script completion.
+ * the variable store feeds script completion, and the code-link handles carry
+ * go-to-implementation navigation, the always-on activity→code map, and its
+ * teardown participant.
  */
 interface EditorHandles {
     diffController: BpmnDiffController;
     scriptTaskSvc: ScriptTaskService;
     scriptVariableStore: ScriptVariableStore;
+    codeLink: CodeLinkHandles;
 }
 
 /**
  * The editor feature owns both custom-editor controllers (BPMN and DMN) and all
- * the per-document services and message routers behind them. `modelNavigation`
- * and `referencedModelLocator` live here — not in a separate feature — because
- * only the BPMN router consumes them. `bpmnService` is returned because the
- * command feature reuses it for batch operations.
+ * the per-document services and message routers behind them. Model-navigation
+ * is constructed here because only the BPMN router consumes it; go-to-
+ * implementation and the activity→code map arrive as code-link handles so the
+ * locator is shared and the source-file watcher's lifetime is owned in one
+ * place. `bpmnService` is returned because the command feature reuses it for
+ * batch operations.
  */
 export function register(
     context: ExtensionContext,
     deps: SharedDeps,
     handles: EditorHandles,
 ): { bpmnService: BpmnModelerService } {
-    const { diffController, scriptTaskSvc, scriptVariableStore } = handles;
+    const { diffController, scriptTaskSvc, scriptVariableStore, codeLink } = handles;
 
     const panelStateRepo = new PropertiesPanelStateRepository(context);
     const bpmnService = new BpmnModelerService(
@@ -131,7 +139,16 @@ export function register(
                 modelNavigationService,
                 deps.notifier,
             ),
-        );
+        )
+        .on(
+            "NavigateToImplementationCommand",
+            navigateToImplementationHandler(
+                deps.editorStore,
+                codeLink.implementationNavigation,
+                deps.notifier,
+            ),
+        )
+        .on("SyncActivitiesCommand", syncActivitiesHandler(codeLink.codeLinkMap));
     const dmnMessageRouter = new WebviewMessageRouter()
         .on("GetDmnFileCommand", getDmnFileHandler(dmnService, deps.notifier))
         .on("SyncDocumentCommand", syncDmnDocumentHandler(dmnService));
@@ -145,6 +162,7 @@ export function register(
             new SettingsParticipant(settingsBroadcaster),
             new EngineVersionStatusBarParticipant(deps.statusBar, deps.vsDocument),
             new ScriptTaskTeardownParticipant(scriptTaskSvc, scriptVariableStore),
+            codeLink.codeLinkParticipant,
         ],
         // Diff routing: when the URI resolves as a diff pane the diff controller
         // owns it, so signal "handled" and skip editor-session creation.

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -4,6 +4,7 @@ import { setContext } from "./shared/infrastructure/extensionContext";
 import { buildSharedDeps } from "./composition/sharedDeps";
 import * as diffFeature from "./composition/diffFeature";
 import * as scriptFeature from "./composition/scriptFeature";
+import * as codeLinkFeature from "./composition/codeLinkFeature";
 import * as editorFeature from "./composition/editorFeature";
 import * as compareFeature from "./composition/compareFeature";
 import * as commandsFeature from "./composition/commandsFeature";
@@ -16,9 +17,10 @@ import * as deploymentFeature from "./composition/deploymentFeature";
  *
  * The register order is observable (it is the order custom editors, providers,
  * and commands become available) and is preserved exactly: diff → script →
- * editor → compare → commands → deployment. Handles flow forward only:
- * the editor routes into diff's controller and script's service; compare and
- * commands reuse handles the earlier features returned.
+ * codeLink → editor → compare → commands → deployment. Handles flow forward
+ * only: the editor routes into diff's controller, script's service, and
+ * code-link's handles; compare and commands reuse handles the earlier features
+ * returned.
  */
 export function activate(context: ExtensionContext): void {
     notifyIfNewRelease(context);
@@ -28,10 +30,12 @@ export function activate(context: ExtensionContext): void {
     const deps = buildSharedDeps(context);
     const { diffController } = diffFeature.register(context, deps);
     const { scriptTaskSvc, scriptVariableStore } = scriptFeature.register(context, deps);
+    const codeLink = codeLinkFeature.register(context, deps);
     const { bpmnService } = editorFeature.register(context, deps, {
         diffController,
         scriptTaskSvc,
         scriptVariableStore,
+        codeLink,
     });
     compareFeature.register(context, deps, { diffController });
     commandsFeature.register(context, deps, { bpmnService });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.codeLink.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.codeLink.spec.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({
+    Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
+}));
+
+import { NavigateToImplementationCommand } from "@miragon/bpmn-modeler-shared";
+
+import { navigateToImplementationHandler } from "./bpmnMessageHandlers";
+
+function createHandler() {
+    const editorStore = { requireHandle: vi.fn() };
+    const implementationNavigationService = { navigate: vi.fn().mockResolvedValue(undefined) };
+    const notifier = { logWarning: vi.fn() };
+
+    const handler = navigateToImplementationHandler(
+        editorStore as never,
+        implementationNavigationService as never,
+        notifier as never,
+    );
+    return { handler, editorStore, implementationNavigationService, notifier };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("navigateToImplementationHandler", () => {
+    it("forwards a javaClass command to the service with the editor's document path", async () => {
+        const { handler, editorStore, implementationNavigationService } = createHandler();
+        editorStore.requireHandle.mockReturnValue({ documentFsPath: () => "/src/a.bpmn" });
+
+        await handler(
+            new NavigateToImplementationCommand("com.example.MyDelegate", "javaClass"),
+            "file:///src/a.bpmn",
+        );
+
+        expect(editorStore.requireHandle).toHaveBeenCalledWith("file:///src/a.bpmn");
+        expect(implementationNavigationService.navigate).toHaveBeenCalledWith(
+            "com.example.MyDelegate",
+            "javaClass",
+            "/src/a.bpmn",
+        );
+    });
+
+    it("forwards a jobType command unchanged", async () => {
+        const { handler, editorStore, implementationNavigationService } = createHandler();
+        editorStore.requireHandle.mockReturnValue({ documentFsPath: () => "/src/a.bpmn" });
+
+        await handler(
+            new NavigateToImplementationCommand("payment-service", "jobType"),
+            "file:///src/a.bpmn",
+        );
+
+        expect(implementationNavigationService.navigate).toHaveBeenCalledWith(
+            "payment-service",
+            "jobType",
+            "/src/a.bpmn",
+        );
+    });
+
+    it("rejects unknown kind values with a logWarning and no service call", async () => {
+        const { handler, notifier, implementationNavigationService } = createHandler();
+        // Simulate protocol drift / a hostile webview sending an unexpected
+        // discriminant by bypassing the command's compile-time type.
+        const malformed = {
+            type: "NavigateToImplementationCommand",
+            reference: "X",
+            kind: "anything",
+        };
+
+        await handler(malformed as never, "file:///src/a.bpmn");
+
+        expect(notifier.logWarning).toHaveBeenCalledWith(
+            expect.stringContaining("unknown kind: anything"),
+        );
+        expect(implementationNavigationService.navigate).not.toHaveBeenCalled();
+    });
+});

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -1,10 +1,12 @@
 import {
     Command,
     OpenScriptEditorCommand,
+    NavigateToImplementationCommand,
     NavigateToReferencedModelCommand,
     SetClipboardCommand,
     SetPropertiesPanelStateCommand,
     SetTextClipboardCommand,
+    SyncActivitiesCommand,
     SyncDocumentCommand,
     UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
@@ -18,6 +20,7 @@ import { BpmnElementTemplatesService } from "@miragon/bpmn-modeler-core";
 import { BpmnPropertiesPanelService } from "@miragon/bpmn-modeler-core";
 import { BpmnSettingsBroadcaster } from "@miragon/bpmn-modeler-core";
 import { ModelNavigationService } from "../../../../navigation/index";
+import { CodeLinkMapService, ImplementationNavigationService } from "../../../../codeLink/index";
 import { ScriptTaskService } from "../../../../scriptTask/index";
 
 /**
@@ -183,5 +186,54 @@ export function navigateToReferencedModelHandler(
         }
         const sourceFsPath = editorStore.requireHandle(editorId).documentFsPath();
         await modelNavigationService.navigate(cmd.referenceId, cmd.referenceKind, sourceFsPath);
+    };
+}
+
+// The implementation kinds the host knows how to resolve. Used as a runtime
+// guard so a malformed/hostile message can't reach the locator with a bogus kind.
+const KNOWN_IMPLEMENTATION_KINDS = new Set([
+    "javaClass",
+    "delegateExpression",
+    "expression",
+    "externalTopic",
+    "jobType",
+]);
+
+/**
+ * `NavigateToImplementationCommand` → jump to the task's source implementation.
+ *
+ * Defence-in-depth: an unknown/empty `kind` is rejected with a warning rather
+ * than falling through, so a malformed message can't be resolved as an
+ * arbitrary kind by default.
+ */
+export function navigateToImplementationHandler(
+    editorStore: EditorSessionStore,
+    implementationNavigationService: ImplementationNavigationService,
+    notifier: VsCodeNotifier,
+): MessageHandler {
+    return async (message: Command, editorId: string) => {
+        const cmd = message as NavigateToImplementationCommand;
+        if (!KNOWN_IMPLEMENTATION_KINDS.has(cmd.kind)) {
+            notifier.logWarning(
+                `Ignoring NavigateToImplementationCommand with unknown kind: ${String(cmd.kind)}`,
+            );
+            return;
+        }
+        const sourceFsPath = editorStore.requireHandle(editorId).documentFsPath();
+        await implementationNavigationService.navigate(cmd.reference, cmd.kind, sourceFsPath);
+    };
+}
+
+/**
+ * `SyncActivitiesCommand` → reconcile the editor's activity→code map.
+ *
+ * The map service diffs the pushed references against what it holds, does
+ * filesystem work only for the delta, and pushes resolution status back to the
+ * webview for context-pad visibility. Invalid entries are filtered inside the
+ * service, so the handler stays a thin pass-through.
+ */
+export function syncActivitiesHandler(mapService: CodeLinkMapService): MessageHandler {
+    return async (message: Command, editorId: string) => {
+        await mapService.syncActivities(editorId, (message as SyncActivitiesCommand).entries);
     };
 }

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.spec.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.spec.ts
@@ -132,6 +132,22 @@ describe("ModelerEditorController.resolveCustomTextEditor", () => {
         expect(dispatch).toHaveBeenCalledWith({ type: "GetBpmnFileCommand" }, EDITOR_ID);
     });
 
+    it("logs a rejected dispatch instead of leaving it unhandled", async () => {
+        const messageRouter = new WebviewMessageRouter();
+        const error = new Error("handler boom");
+        vi.spyOn(messageRouter, "dispatch").mockRejectedValue(error);
+        const notifier = createNotifier();
+        const { controller, captured } = resolve({ messageRouter }, notifier);
+
+        await controller.resolveCustomTextEditor(document, panel, token);
+        // VS Code does not await this async listener, so the callback itself must
+        // resolve (the rejection is caught) and the error logged, not thrown.
+        await expect(
+            captured.message?.({ type: "SyncActivitiesCommand" }, EDITOR_ID),
+        ).resolves.toBeUndefined();
+        expect(notifier.logError).toHaveBeenCalledWith(error);
+    });
+
     it("aggregates participant teardown into the single dispose subscription", async () => {
         const teardown = vi.fn();
         const participant: EditorSessionParticipant = {

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
@@ -151,8 +151,16 @@ export class ModelerEditorController implements CustomTextEditorProvider {
     private subscribeToMessageEvent(editorId: string): void {
         this.editorStore.subscribeToMessageEvent(editorId, async (message: Command, id: string) => {
             this.notifier.logInfo(`Message received -> ${message.type}`);
-            await this.options.messageRouter.dispatch(message, id);
-            this.notifier.logInfo(`Message processed -> ${message.type}`);
+            try {
+                await this.options.messageRouter.dispatch(message, id);
+                this.notifier.logInfo(`Message processed -> ${message.type}`);
+            } catch (error) {
+                // VS Code's event emitter does not await this async listener, so
+                // a rejected dispatch would otherwise surface as an unhandled
+                // promise rejection. Log it — one handler's failure must never
+                // crash the host.
+                this.notifier.logError(error as Error);
+            }
         });
     }
 }

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
@@ -89,4 +89,19 @@ export class VsCodeSettings implements SettingsPort {
     getLanguage(): string {
         return workspace.getConfiguration("miragon.bpmnModeler").get<string>("language", "en");
     }
+
+    /**
+     * Whether to persist the activity→code map to disk under
+     * `<configFolder>/code-link/`.
+     *
+     * Defaults to `false`: the in-memory map (context-pad visibility + live
+     * linking) works regardless; the on-disk file is an opt-in warm cache and
+     * external-tooling artifact.
+     */
+    getPersistCodeLinkMap(): boolean {
+        return (
+            workspace.getConfiguration("miragon.bpmnModeler").get<boolean>("persistCodeLinkMap") ??
+            false
+        );
+    }
 }

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const findFilesMock = vi.fn();
+const createDirectoryMock = vi.fn();
+const writeFileMock = vi.fn();
 
 vi.mock("vscode", () => ({
     workspace: {
         fs: {
             readDirectory: vi.fn(),
             readFile: vi.fn(),
-            writeFile: vi.fn(),
+            writeFile: (...args: unknown[]) => writeFileMock(...args),
+            createDirectory: (...args: unknown[]) => createDirectoryMock(...args),
         },
         findFiles: (...args: unknown[]) => findFilesMock(...args),
         getWorkspaceFolder: vi.fn(),
@@ -21,6 +24,10 @@ import { VsCodeWorkspace } from "./VsCodeWorkspace";
 beforeEach(() => {
     findFilesMock.mockReset();
     findFilesMock.mockResolvedValue([{ path: "/a.bpmn" }, { path: "/b.bpmn" }]);
+    createDirectoryMock.mockReset();
+    createDirectoryMock.mockResolvedValue(undefined);
+    writeFileMock.mockReset();
+    writeFileMock.mockResolvedValue(undefined);
 });
 
 describe("VsCodeWorkspace.findFiles", () => {
@@ -67,5 +74,25 @@ describe("VsCodeWorkspace.findFiles", () => {
         const result = await sut.findFiles("**/*.bpmn");
 
         expect(result).toEqual(["/x.bpmn", "/nested/y.bpmn"]);
+    });
+});
+
+describe("VsCodeWorkspace.writeFile", () => {
+    it("creates the parent directory before writing (nested artifact paths)", async () => {
+        const sut = new VsCodeWorkspace();
+
+        await sut.writeFile("/work/proj/.camunda/code-link/src/order.bpmn.json", "{}");
+
+        expect(createDirectoryMock).toHaveBeenCalledWith(
+            expect.objectContaining({ path: "/work/proj/.camunda/code-link/src" }),
+        );
+        expect(writeFileMock).toHaveBeenCalledWith(
+            expect.objectContaining({ path: "/work/proj/.camunda/code-link/src/order.bpmn.json" }),
+            expect.anything(),
+        );
+        // The directory must exist before the write is attempted.
+        expect(createDirectoryMock.mock.invocationCallOrder[0]).toBeLessThan(
+            writeFileMock.mock.invocationCallOrder[0],
+        );
     });
 });

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
@@ -149,6 +149,10 @@ export class VsCodeWorkspace implements WorkspacePort {
      * @param content The string content to write.
      */
     async writeFile(path: string, content: string): Promise<void> {
+        // Create the parent directory first (idempotent). `fs.writeFile` already
+        // mkdirps via FileService, so this is platform-proof insurance for the
+        // code-link artifact's nested target paths rather than a hard requirement.
+        await fs.createDirectory(Uri.file(posix.dirname(path)));
         await fs.writeFile(Uri.file(path), Buffer.from(content));
     }
 
@@ -173,7 +177,12 @@ export class VsCodeWorkspace implements WorkspacePort {
      * Creates a workspace-scoped filesystem watcher for `glob` rooted at
      * `rootPath`. Hides `workspace.createFileSystemWatcher` + `RelativePattern`
      * and the `Uri`-typed event payloads so service callers stay free of
-     * `vscode` imports — handlers receive the absolute `uri.fsPath` string.
+     * `vscode` imports.
+     *
+     * Handlers receive the `uri.path` (POSIX) form, deliberately matching what
+     * {@link findFiles} returns: the code-link watcher compares changed-file
+     * paths against locator results, and `fsPath` (back-slashed, drive-prefixed
+     * on Windows) would never compare equal to a `uri.path`-style match.
      *
      * The returned handle disposes the underlying watcher and unsubscribes
      * the wired listeners in one call.
@@ -191,13 +200,13 @@ export class VsCodeWorkspace implements WorkspacePort {
         const subscriptions: { dispose(): void }[] = [watcher];
         const { onCreate, onChange, onDelete } = handlers;
         if (onCreate) {
-            subscriptions.push(watcher.onDidCreate((uri) => onCreate(uri.fsPath)));
+            subscriptions.push(watcher.onDidCreate((uri) => onCreate(uri.path)));
         }
         if (onChange) {
-            subscriptions.push(watcher.onDidChange((uri) => onChange(uri.fsPath)));
+            subscriptions.push(watcher.onDidChange((uri) => onChange(uri.path)));
         }
         if (onDelete) {
-            subscriptions.push(watcher.onDidDelete((uri) => onDelete(uri.fsPath)));
+            subscriptions.push(watcher.onDidDelete((uri) => onDelete(uri.path)));
         }
         return {
             dispose(): void {

--- a/libs/bpmn-i18n/src/languages/de/other.ts
+++ b/libs/bpmn-i18n/src/languages/de/other.ts
@@ -259,6 +259,7 @@ const translations: Record<string, string> = {
     "Variable Listener": "Variablen-Ereignis",
     "Variable Listeners": "Variablen-Ereignisse",
     "Navigate to referenced model": "Zum referenzierten Modell springen",
+    "Go to implementation": "Zur Implementierung springen",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/en/other.ts
+++ b/libs/bpmn-i18n/src/languages/en/other.ts
@@ -98,6 +98,8 @@ const translations: Record<string, string> = {
     "Data Type": "Data Type",
     // Context pad — Navigate to referenced model
     "Navigate to referenced model": "Navigate to referenced model",
+    // Context pad — Go to implementation (code link)
+    "Go to implementation": "Go to implementation",
     // Diff legend (bpmn diff view)
     "Added": "Added",
     "Removed": "Removed",

--- a/libs/bpmn-i18n/src/languages/es/other.ts
+++ b/libs/bpmn-i18n/src/languages/es/other.ts
@@ -247,6 +247,7 @@ const translations: Record<string, string> = {
     "Variable Listener": "Listener de variable",
     "Variable Listeners": "Listeners de variable",
     "Navigate to referenced model": "Ir al modelo referenciado",
+    "Go to implementation": "Ir a la implementación",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/fr/other.ts
+++ b/libs/bpmn-i18n/src/languages/fr/other.ts
@@ -100,6 +100,7 @@ const translations: Record<string, string> = {
     "Output Expression": "Expression de sortie",
     "Data Type": "Type de données",
     "Navigate to referenced model": "Accéder au modèle référencé",
+    "Go to implementation": "Accéder à l'implémentation",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/nl-nl/other.ts
+++ b/libs/bpmn-i18n/src/languages/nl-nl/other.ts
@@ -100,6 +100,7 @@ const translations: Record<string, string> = {
     "Output Expression": "Output-Expression",
     "Data Type": "Data-Type",
     "Navigate to referenced model": "Naar gerefereerd model navigeren",
+    "Go to implementation": "Naar implementatie navigeren",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/pt-br/other.ts
+++ b/libs/bpmn-i18n/src/languages/pt-br/other.ts
@@ -99,6 +99,7 @@ const translations: Record<string, string> = {
     "Output Expression": "Expressão de Saída",
     "Data Type": "Tipo de Dado",
     "Navigate to referenced model": "Navegar para o modelo referenciado",
+    "Go to implementation": "Ir para a implementação",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/ru/other.ts
+++ b/libs/bpmn-i18n/src/languages/ru/other.ts
@@ -98,6 +98,7 @@ const translations: Record<string, string> = {
     "Data Type": "Тип данных",
     "Create new BPMN Diagram (Camunda Platform)": "Создать новую BPMN диграмму (Camunda Platform)",
     "Navigate to referenced model": "Перейти к связанной модели",
+    "Go to implementation": "Перейти к реализации",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hans/other.ts
@@ -101,6 +101,7 @@ const translations: Record<string, string> = {
     "Errors": "错误",
     "No errors defined.": "没有定义错误。",
     "Navigate to referenced model": "跳转到引用的模型",
+    "Go to implementation": "跳转到实现",
 };
 
 export default translations;

--- a/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
+++ b/libs/bpmn-i18n/src/languages/zh-Hant/other.ts
@@ -101,6 +101,7 @@ const translations: Record<string, string> = {
     "Errors": "錯誤",
     "No errors defined.": "沒有定義錯誤。",
     "Navigate to referenced model": "跳轉到引用的模型",
+    "Go to implementation": "跳轉到實作",
 };
 
 export default translations;

--- a/libs/code-link/README.md
+++ b/libs/code-link/README.md
@@ -1,0 +1,59 @@
+# `@miragon/bpmn-modeler-code-link`
+
+Adds a **Go to implementation** action to the bpmn-js context pad so the user
+can jump from a service / send / business-rule task to the workspace source
+file that implements it. The entry **hides automatically** when the task's
+implementation does not exist in the workspace.
+
+## The always-on activity→code map
+
+`CodeLinkMapClient` (a bpmn-js DI service registered by `CodeLinkModule`) keeps
+the host's activity→code map in sync with the live diagram so the context-pad
+entry's visibility is correct without the user clicking:
+
+- On `import.done` and after edits (`commandStack.changed`, debounced and
+  skip-if-unchanged) it ships the diagram's `(activityId, kind, reference)` list
+  to the host via `SyncActivitiesCommand`. **The host never parses the BPMN
+  XML** — bpmn-js already parsed it, so the webview reads the model and sends
+  cheap strings.
+- The host resolves only the delta and pushes back a
+  `key → resolved` lookup (`ImplementationStatusQuery`), which the modeler hands
+  to `applyStatus`. The provider then asks `isResolved(element)` per element:
+  unknown ⇒ shown optimistically (flash-free), cached `false` ⇒ hidden.
+
+The client never mutates bpmn-js model state (forcing a context-pad re-render
+does not run the command stack), so a status push cannot loop back into a
+`commandStack.changed` event.
+
+## Why this lives in its own library
+
+- **Many reference shapes per binding.** Camunda 7 stores the implementation as
+  attributes on the BPMN element (`camunda:class`,
+  `camunda:delegateExpression`, `camunda:expression`, or external
+  `camunda:topic`); Camunda 8 wraps a job type in a `zeebe:taskDefinition`
+  extension element. Classifying them belongs in one helper
+  (`extractImplementation`), not scattered through the modeler.
+- **Resolution is workspace-driven and host-side.** Mapping a reference to a
+  source file (`workspace.findFiles`, content search, `vscode.open`) only makes
+  sense on the extension host. Keeping the click target in a small webview-side
+  library lets the modeler stay agnostic of VS Code APIs — it just posts a
+  `NavigateToImplementationCommand` carrying the reference string and its kind.
+  Workspace paths never leave the host.
+- **Context-pad placement is opinionated.** The bpmn-js context pad wraps
+  entries 3-per-row within each `data-group` div. The icon sits under the
+  existing `connect` group to avoid an orphan row; that choice is documented
+  here so future readers don't move it back. A business-rule task may show both
+  this entry and the model-navigation entry — they never conflict because
+  `extractImplementation` ignores `camunda:decisionRef`.
+
+## Usage
+
+```ts
+import { CodeLinkModule } from "@miragon/bpmn-modeler-code-link";
+
+new BpmnModeler({ additionalModules: [CodeLinkModule] });
+```
+
+The module expects a `vsCodeBridge` DI value with a `postMessage` method so it
+never has to call `acquireVsCodeApi()` directly (which can only be invoked once
+per webview).

--- a/libs/code-link/package.json
+++ b/libs/code-link/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@miragon/bpmn-modeler-code-link",
+    "version": "0.0.1",
+    "private": true,
+    "scripts": {
+        "build": "tsc --noEmit",
+        "test": "vitest run"
+    },
+    "dependencies": {
+        "@miragon/bpmn-modeler-shared": "workspace:*"
+    },
+    "peerDependencies": {
+        "bpmn-js": "18.16.1"
+    },
+    "devDependencies": {
+        "bpmn-js": "18.16.1",
+        "typescript": "6.0.3",
+        "vitest": "4.1.8"
+    }
+}

--- a/libs/code-link/src/CodeLinkContextPadProvider.spec.ts
+++ b/libs/code-link/src/CodeLinkContextPadProvider.spec.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Drives the `is()` import below. Tests set `isMatchers` to control which BPMN
+// types the helper says the current element implements.
+const isMatchers: Set<string> = new Set();
+vi.mock("bpmn-js/lib/util/ModelUtil", () => ({
+    is: (_element: unknown, type: string) => isMatchers.has(type),
+}));
+
+import { NavigateToImplementationCommand } from "@miragon/bpmn-modeler-shared";
+
+import { CodeLinkContextPadProvider } from "./CodeLinkContextPadProvider";
+
+interface MutableElement {
+    businessObject: {
+        get(name: string): unknown;
+        extensionElements?: { values?: unknown[] };
+    };
+}
+
+function build(
+    opts: {
+        types?: string[];
+        initialAttrs?: Record<string, unknown>;
+        resolved?: boolean;
+    } = {},
+) {
+    isMatchers.clear();
+    for (const t of opts.types ?? []) isMatchers.add(t);
+
+    const attrs: Record<string, unknown> = { ...opts.initialAttrs };
+    const element: MutableElement = {
+        businessObject: {
+            get: (name) => attrs[name],
+        },
+    };
+
+    const contextPad = { registerProvider: vi.fn() };
+    const translate = vi.fn((template: string) => `t(${template})`);
+    const vsCodeBridge = { postMessage: vi.fn() };
+    // The map client gates visibility; default to "resolved" so the existing
+    // (pre-map) cases behave exactly as before.
+    const client = { isResolved: vi.fn().mockReturnValue(opts.resolved ?? true) };
+
+    const provider = new CodeLinkContextPadProvider(
+        contextPad as never,
+        translate as never,
+        vsCodeBridge as never,
+        client as never,
+    );
+
+    return { provider, contextPad, translate, vsCodeBridge, client, element, attrs };
+}
+
+beforeEach(() => {
+    isMatchers.clear();
+});
+
+describe("CodeLinkContextPadProvider", () => {
+    it("registers itself with the contextPad on construction", () => {
+        const { provider, contextPad } = build();
+
+        expect(contextPad.registerProvider).toHaveBeenCalledWith(provider);
+        expect(contextPad.registerProvider).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns no entries for an unrelated element type", () => {
+        const { provider, element } = build({
+            types: [],
+            initialAttrs: { "camunda:class": "com.example.X" },
+        });
+
+        expect(provider.getContextPadEntries(element as never)).toEqual({});
+    });
+
+    it("returns no entries when an implementable task has no binding", () => {
+        const { provider, element } = build({ types: ["bpmn:ServiceTask"] });
+
+        expect(provider.getContextPadEntries(element as never)).toEqual({});
+    });
+
+    it("contributes a single entry in the connect group for a service task with a class", () => {
+        const { provider, element } = build({
+            types: ["bpmn:ServiceTask"],
+            initialAttrs: { "camunda:class": "com.example.MyDelegate" },
+        });
+
+        const entries = provider.getContextPadEntries(element as never);
+
+        expect(Object.keys(entries)).toEqual(["go-to-implementation"]);
+        const entry = entries["go-to-implementation"];
+        expect(entry.group).toBe("connect");
+        expect(entry.html).toContain('<div class="entry">');
+        expect(entry.html).toContain("<svg");
+    });
+
+    it("contributes an entry for a send task with a delegate expression", () => {
+        const { provider, element } = build({
+            types: ["bpmn:SendTask"],
+            initialAttrs: { "camunda:delegateExpression": "${myBean}" },
+        });
+
+        expect(
+            provider.getContextPadEntries(element as never)["go-to-implementation"],
+        ).toBeDefined();
+    });
+
+    it("contributes an entry for a business-rule task with a class binding", () => {
+        const { provider, element } = build({
+            types: ["bpmn:BusinessRuleTask"],
+            initialAttrs: { "camunda:class": "com.example.Rules" },
+        });
+
+        expect(
+            provider.getContextPadEntries(element as never)["go-to-implementation"],
+        ).toBeDefined();
+    });
+
+    it("stays out of the way of a business-rule task that only references a decision", () => {
+        const { provider, element } = build({
+            types: ["bpmn:BusinessRuleTask"],
+            initialAttrs: { "camunda:decisionRef": "Decision_1" },
+        });
+
+        expect(provider.getContextPadEntries(element as never)).toEqual({});
+    });
+
+    it("hides the entry when the host has reported the reference as unresolved", () => {
+        const { provider, element, client } = build({
+            types: ["bpmn:ServiceTask"],
+            initialAttrs: { "camunda:class": "com.example.Missing" },
+            resolved: false,
+        });
+
+        expect(provider.getContextPadEntries(element as never)).toEqual({});
+        expect(client.isResolved).toHaveBeenCalledWith(element);
+    });
+
+    it("does not consult the map client for a non-implementable element", () => {
+        // The cheap type/binding checks must short-circuit first so the client
+        // is only asked about elements that could actually carry the entry.
+        const { provider, element, client } = build({
+            types: [],
+            initialAttrs: { "camunda:class": "com.example.X" },
+            resolved: false,
+        });
+
+        expect(provider.getContextPadEntries(element as never)).toEqual({});
+        expect(client.isResolved).not.toHaveBeenCalled();
+    });
+
+    it("shows the entry while resolution is still unknown (optimistic)", () => {
+        // A real client returns true for unknown — assert the provider shows the
+        // entry whenever the client says resolved, the cold-open flash-free path.
+        const { provider, element } = build({
+            types: ["bpmn:ServiceTask"],
+            initialAttrs: { "camunda:class": "com.example.MyDelegate" },
+            resolved: true,
+        });
+
+        expect(
+            provider.getContextPadEntries(element as never)["go-to-implementation"],
+        ).toBeDefined();
+    });
+
+    it("routes the title through the translator", () => {
+        const { provider, translate, element } = build({
+            types: ["bpmn:ServiceTask"],
+            initialAttrs: { "camunda:class": "com.example.MyDelegate" },
+        });
+
+        const entry = provider.getContextPadEntries(element as never)["go-to-implementation"];
+
+        expect(translate).toHaveBeenCalledWith("Go to implementation");
+        expect(entry.title).toBe("t(Go to implementation)");
+    });
+
+    it("re-extracts the reference on click — not the value captured at render time", () => {
+        const { provider, vsCodeBridge, element, attrs } = build({
+            types: ["bpmn:ServiceTask"],
+            initialAttrs: { "camunda:class": "com.example.Original" },
+        });
+        const entry = provider.getContextPadEntries(element as never)["go-to-implementation"];
+
+        attrs["camunda:class"] = "com.example.Updated";
+        entry.action.click({} as never, element as never);
+
+        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+        const posted = vsCodeBridge.postMessage.mock.calls[0][0];
+        expect(posted).toBeInstanceOf(NavigateToImplementationCommand);
+        expect((posted as NavigateToImplementationCommand).reference).toBe("com.example.Updated");
+        expect((posted as NavigateToImplementationCommand).kind).toBe("javaClass");
+    });
+
+    it("does nothing when the binding was cleared between render and click", () => {
+        const { provider, vsCodeBridge, element, attrs } = build({
+            types: ["bpmn:ServiceTask"],
+            initialAttrs: { "camunda:class": "com.example.Original" },
+        });
+        const entry = provider.getContextPadEntries(element as never)["go-to-implementation"];
+
+        attrs["camunda:class"] = "";
+        entry.action.click({} as never, element as never);
+
+        expect(vsCodeBridge.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("posts a jobType command for a C8 task definition", () => {
+        isMatchers.clear();
+        isMatchers.add("bpmn:ServiceTask");
+        const element = {
+            businessObject: {
+                get: () => undefined,
+                extensionElements: {
+                    values: [{ $type: "zeebe:TaskDefinition", type: "payment-service" }],
+                },
+            },
+        };
+        const contextPad = { registerProvider: vi.fn() };
+        const vsCodeBridge = { postMessage: vi.fn() };
+        const client = { isResolved: vi.fn().mockReturnValue(true) };
+        const provider = new CodeLinkContextPadProvider(
+            contextPad as never,
+            ((s: string) => s) as never,
+            vsCodeBridge as never,
+            client as never,
+        );
+
+        const entry = provider.getContextPadEntries(element as never)["go-to-implementation"];
+        entry.action.click({} as never, element as never);
+
+        const posted = vsCodeBridge.postMessage.mock.calls[0][0] as NavigateToImplementationCommand;
+        expect(posted.kind).toBe("jobType");
+        expect(posted.reference).toBe("payment-service");
+    });
+});

--- a/libs/code-link/src/CodeLinkContextPadProvider.ts
+++ b/libs/code-link/src/CodeLinkContextPadProvider.ts
@@ -1,0 +1,146 @@
+/**
+ * bpmn-js context-pad provider that contributes a "Go to implementation"
+ * action.  The action appears on the floating context pad around a selected
+ * service / send / business-rule task that carries a Camunda implementation
+ * reference — `camunda:class` / `camunda:delegateExpression` /
+ * `camunda:expression` / external `camunda:topic` (C7) or a
+ * `zeebe:taskDefinition type` (C8).
+ *
+ * Clicking the entry sends a {@link NavigateToImplementationCommand} to the
+ * extension host, which resolves the reference to a workspace source file and
+ * opens it (or shows a QuickPick / info notification on N / 0 matches).
+ *
+ * The entry mirrors `NavigateContextPadProvider`: an inline `html` fragment
+ * with an embedded SVG, placed in the `connect` group so it shares a row with
+ * the existing connect icon rather than starting an orphan row.  A business-
+ * rule task may show both this entry and the model-navigation entry; they never
+ * conflict because {@link extractImplementation} ignores `camunda:decisionRef`.
+ */
+import { is } from "bpmn-js/lib/util/ModelUtil";
+
+import { NavigateToImplementationCommand } from "@miragon/bpmn-modeler-shared";
+
+import { BusinessObjectLike, extractImplementation } from "./extractImplementation";
+import { IMPLEMENTABLE_TYPES } from "./collectImplementations";
+import type { CodeLinkMapClient } from "./CodeLinkMapClient";
+
+interface ContextPad {
+    registerProvider(provider: CodeLinkContextPadProvider): void;
+}
+
+interface Translate {
+    (template: string): string;
+}
+
+/**
+ * The slice of a bpmn-js element this feature reads. `id` is the activity id the
+ * status map is keyed by; `businessObject` carries the Camunda binding.
+ */
+export interface Element {
+    id?: string;
+    type?: string;
+    businessObject?: BusinessObjectLike;
+}
+
+interface VsCodeBridge {
+    postMessage(message: unknown): void;
+}
+
+interface ContextPadEntry {
+    group: string;
+    html: string;
+    title: string;
+    action: { click: (event: Event, element: Element) => void };
+}
+
+export type ContextPadEntries = Record<string, ContextPadEntry>;
+
+/**
+ * Feather "code" glyph — `< >` chevrons.  Sized 22×22 to match the context
+ * pad's entry box and drawn with `currentColor` so it inherits the theme's
+ * foreground.  Deliberately distinct from the external-link icon used by the
+ * model-navigation entry so the two are tellable apart when both are present.
+ */
+const CODE_ICON_SVG = `<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>`;
+
+/**
+ * Constructor-registered provider.  bpmn-js' `contextPad` collects entries by
+ * calling {@link getContextPadEntries} on every registered provider; this one
+ * contributes only when the selected element is an implementable task with a
+ * resolvable implementation reference.
+ *
+ * The `vsCodeBridge` DI value is supplied by the bpmn-webview during modeler
+ * construction so this library never calls `acquireVsCodeApi` itself (it may
+ * only be invoked once per webview).
+ */
+export class CodeLinkContextPadProvider {
+    static $inject = ["contextPad", "translate", "vsCodeBridge", "codeLinkMapClient"];
+
+    private readonly translate: Translate;
+
+    private readonly vsCodeBridge: VsCodeBridge;
+
+    private readonly client: CodeLinkMapClient;
+
+    constructor(
+        contextPad: ContextPad,
+        translate: Translate,
+        vsCodeBridge: VsCodeBridge,
+        codeLinkMapClient: CodeLinkMapClient,
+    ) {
+        this.translate = translate;
+        this.vsCodeBridge = vsCodeBridge;
+        this.client = codeLinkMapClient;
+        contextPad.registerProvider(this);
+    }
+
+    /**
+     * Called by the context pad for the selected element.  Returns a single
+     * entry when the element is an implementable task with a resolvable
+     * implementation reference that the host has not reported as missing, or an
+     * empty object otherwise.
+     *
+     * @param element The currently selected element.
+     */
+    getContextPadEntries(element: Element): ContextPadEntries {
+        if (!this.isImplementableTask(element)) {
+            return {};
+        }
+        if (!extractImplementation(element.businessObject)) {
+            return {};
+        }
+        // Hide the entry once the host has confirmed the reference resolves to
+        // nothing in the workspace — there is no source file to navigate to.
+        if (!this.client.isResolved(element)) {
+            return {};
+        }
+
+        return {
+            "go-to-implementation": {
+                group: "connect",
+                html: `<div class="entry">${CODE_ICON_SVG}</div>`,
+                title: this.translate("Go to implementation"),
+                action: {
+                    // Re-extract on click so an edit made between pad-render and
+                    // click (e.g. via the properties panel) navigates to the
+                    // current reference, not a stale one.
+                    click: (_event, clickedElement) => {
+                        const current = extractImplementation(clickedElement.businessObject);
+                        if (current) {
+                            this.vsCodeBridge.postMessage(
+                                new NavigateToImplementationCommand(
+                                    current.reference,
+                                    current.kind,
+                                ),
+                            );
+                        }
+                    },
+                },
+            },
+        };
+    }
+
+    private isImplementableTask(element: Element): boolean {
+        return IMPLEMENTABLE_TYPES.some((type) => is(element, type));
+    }
+}

--- a/libs/code-link/src/CodeLinkMapClient.spec.ts
+++ b/libs/code-link/src/CodeLinkMapClient.spec.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("bpmn-js/lib/util/ModelUtil", () => ({
+    is: (element: { type?: string } | undefined, type: string) => element?.type === type,
+}));
+
+import { implementationStatusKey, SyncActivitiesCommand } from "@miragon/bpmn-modeler-shared";
+
+import { CodeLinkMapClient } from "./CodeLinkMapClient";
+
+interface FakeElement {
+    id?: string;
+    type?: string;
+    businessObject?: { get(name: string): unknown };
+}
+
+function serviceTask(id: string, javaClass: string): FakeElement {
+    return {
+        id,
+        type: "bpmn:ServiceTask",
+        businessObject: { get: (name) => (name === "camunda:class" ? javaClass : undefined) },
+    };
+}
+
+function setup(elements: FakeElement[] = []) {
+    const handlers: Record<string, ((event?: unknown) => void)[]> = {};
+    const eventBus = {
+        on: (event: string, callback: (event?: unknown) => void) => {
+            (handlers[event] ??= []).push(callback);
+        },
+    };
+    const fire = (event: string, payload?: unknown) =>
+        (handlers[event] ?? []).forEach((callback) => callback(payload));
+
+    const registryElements = [...elements];
+    const elementRegistry = { getAll: () => registryElements as never };
+    const contextPad = { isOpen: vi.fn().mockReturnValue(false), open: vi.fn() };
+    const vsCodeBridge = { postMessage: vi.fn() };
+
+    const client = new CodeLinkMapClient(
+        eventBus as never,
+        elementRegistry,
+        contextPad as never,
+        vsCodeBridge as never,
+    );
+
+    const lastSentEntries = () => {
+        const calls = vsCodeBridge.postMessage.mock.calls;
+        const command = calls[calls.length - 1][0] as SyncActivitiesCommand;
+        return command.entries;
+    };
+
+    return { client, fire, contextPad, vsCodeBridge, registryElements, lastSentEntries };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("CodeLinkMapClient — syncing", () => {
+    it("posts a SyncActivitiesCommand immediately on import.done", () => {
+        const { fire, vsCodeBridge, lastSentEntries } = setup([
+            serviceTask("Activity_1", "com.example.A"),
+        ]);
+
+        fire("import.done");
+
+        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+        expect(vsCodeBridge.postMessage.mock.calls[0][0]).toBeInstanceOf(SyncActivitiesCommand);
+        expect(lastSentEntries()).toEqual([
+            { activityId: "Activity_1", kind: "javaClass", reference: "com.example.A" },
+        ]);
+    });
+
+    it("debounces a burst of commandStack.changed into a single post", () => {
+        vi.useFakeTimers();
+        const { fire, vsCodeBridge } = setup([serviceTask("Activity_1", "com.example.A")]);
+
+        fire("commandStack.changed");
+        fire("commandStack.changed");
+        fire("commandStack.changed");
+        expect(vsCodeBridge.postMessage).not.toHaveBeenCalled();
+
+        vi.advanceTimersByTime(400);
+        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the post when the implementation list is unchanged", () => {
+        vi.useFakeTimers();
+        const { fire, vsCodeBridge } = setup([serviceTask("Activity_1", "com.example.A")]);
+
+        fire("import.done");
+        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+
+        // An edit that did not touch any implementation binding.
+        fire("commandStack.changed");
+        vi.advanceTimersByTime(400);
+        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(1);
+    });
+
+    it("posts again once a binding actually changes", () => {
+        vi.useFakeTimers();
+        const element = serviceTask("Activity_1", "com.example.A");
+        const { fire, vsCodeBridge, registryElements, lastSentEntries } = setup([element]);
+
+        fire("import.done");
+        registryElements[0] = serviceTask("Activity_1", "com.example.B");
+
+        fire("commandStack.changed");
+        vi.advanceTimersByTime(400);
+
+        expect(vsCodeBridge.postMessage).toHaveBeenCalledTimes(2);
+        expect(lastSentEntries()).toEqual([
+            { activityId: "Activity_1", kind: "javaClass", reference: "com.example.B" },
+        ]);
+    });
+});
+
+describe("CodeLinkMapClient — status", () => {
+    it("treats unknown references as resolved (optimistic) and a cached false as hidden", () => {
+        const element = serviceTask("Activity_1", "com.example.A");
+        const { client } = setup([element]);
+
+        expect(client.isResolved(element)).toBe(true); // unknown
+
+        client.applyStatus({ [implementationStatusKey("Activity_1", "com.example.A")]: false });
+        expect(client.isResolved(element)).toBe(false);
+
+        client.applyStatus({ [implementationStatusKey("Activity_1", "com.example.A")]: true });
+        expect(client.isResolved(element)).toBe(true);
+    });
+
+    it("keys status by reference so a reference edit falls back to optimistic show", () => {
+        const element = serviceTask("Activity_1", "com.example.A");
+        const { client } = setup([element]);
+        client.applyStatus({ [implementationStatusKey("Activity_1", "com.example.A")]: false });
+
+        // The user changes the class; the old false no longer applies.
+        element.businessObject = {
+            get: (name) => (name === "camunda:class" ? "com.example.B" : undefined),
+        };
+        expect(client.isResolved(element)).toBe(true);
+    });
+
+    it("refreshes the open context pad when the shown element's status flips", () => {
+        const element = serviceTask("Activity_1", "com.example.A");
+        const { client, fire, contextPad } = setup([element]);
+        contextPad.isOpen.mockReturnValue(true);
+        fire("contextPad.open", { current: { target: element } });
+
+        client.applyStatus({ [implementationStatusKey("Activity_1", "com.example.A")]: false });
+
+        expect(contextPad.open).toHaveBeenCalledWith(element, true);
+    });
+
+    it("does not refresh the pad when the shown element's status is unchanged", () => {
+        const element = serviceTask("Activity_1", "com.example.A");
+        const { client, fire, contextPad } = setup([element]);
+        contextPad.isOpen.mockReturnValue(true);
+        fire("contextPad.open", { current: { target: element } });
+
+        // unknown → true and the push also says true: no visible change.
+        client.applyStatus({ [implementationStatusKey("Activity_1", "com.example.A")]: true });
+
+        expect(contextPad.open).not.toHaveBeenCalled();
+    });
+
+    it("ignores a multi-selection pad target (the entry never shows for one)", () => {
+        const element = serviceTask("Activity_1", "com.example.A");
+        const { client, fire, contextPad } = setup([element]);
+        contextPad.isOpen.mockReturnValue(true);
+        fire("contextPad.open", { current: { target: [element, element] } });
+
+        client.applyStatus({ [implementationStatusKey("Activity_1", "com.example.A")]: false });
+
+        expect(contextPad.open).not.toHaveBeenCalled();
+    });
+});

--- a/libs/code-link/src/CodeLinkMapClient.ts
+++ b/libs/code-link/src/CodeLinkMapClient.ts
@@ -1,0 +1,156 @@
+/**
+ * bpmn-js DI service that keeps the host's activity→code map in sync with the
+ * live diagram and caches the resolution status the context-pad provider reads
+ * to decide whether to show the "Go to implementation" entry.
+ *
+ * It is the webview half of the always-on map: on import and after edits it
+ * ships the diagram's implementation references to the host
+ * ({@link SyncActivitiesCommand}); the host resolves the delta and pushes back a
+ * `key → resolved` lookup ({@link ImplementationStatusQuery}) consumed by
+ * {@link applyStatus}. The provider then calls {@link isResolved} per element.
+ *
+ * It never mutates bpmn-js model state — forcing the context pad to re-render
+ * does not run the command stack — so a status push can't loop back into a
+ * `commandStack.changed` event and re-trigger a sync.
+ */
+import {
+    ImplementationEntry,
+    implementationStatusKey,
+    SyncActivitiesCommand,
+} from "@miragon/bpmn-modeler-shared";
+
+import { collectImplementations, ElementRegistryLike } from "./collectImplementations";
+import { extractImplementation } from "./extractImplementation";
+import type { Element } from "./CodeLinkContextPadProvider";
+
+interface EventBus {
+    on(event: string, callback: (event?: unknown) => void): void;
+}
+
+interface ContextPad {
+    isOpen(): boolean;
+    open(target: unknown, force?: boolean): void;
+}
+
+interface VsCodeBridge {
+    postMessage(message: unknown): void;
+}
+
+// Coalesce the bursts of `commandStack.changed` a single gesture fires (drag,
+// multi-property edit) into one sync. import.done bypasses this — the first
+// status push should land as fast as possible for a flash-free open.
+const SYNC_DEBOUNCE_MS = 400;
+
+/**
+ * The context pad opens for a single element or a multi-selection array; we only
+ * track single-element targets because the "Go to implementation" entry never
+ * appears for a multi-selection, so there is nothing to refresh for arrays.
+ */
+function singleTarget(current: unknown): Element | undefined {
+    const target = (current as { target?: unknown } | undefined)?.target;
+    if (!target || Array.isArray(target)) {
+        return undefined;
+    }
+    return target as Element;
+}
+
+export class CodeLinkMapClient {
+    static $inject = ["eventBus", "elementRegistry", "contextPad", "vsCodeBridge"];
+
+    private readonly elementRegistry: ElementRegistryLike;
+
+    private readonly contextPad: ContextPad;
+
+    private readonly vsCodeBridge: VsCodeBridge;
+
+    // Resolution status keyed by `${activityId}::${reference}`. Absent key ⇒
+    // unknown ⇒ shown optimistically; explicit `false` ⇒ hidden.
+    private statusByKey: Map<string, boolean> = new Map();
+
+    // Signature of the last entry list sent, so an edit that touches no
+    // implementation binding (moving a shape, renaming a flow) is not re-sent.
+    private lastSentSignature: string | undefined;
+
+    // The element the context pad is currently open for, so a status flip while
+    // it is open can re-render it (drop a now-stale entry / surface a new one).
+    private currentPadTarget: Element | undefined;
+
+    private syncTimer: ReturnType<typeof setTimeout> | undefined;
+
+    constructor(
+        eventBus: EventBus,
+        elementRegistry: ElementRegistryLike,
+        contextPad: ContextPad,
+        vsCodeBridge: VsCodeBridge,
+    ) {
+        this.elementRegistry = elementRegistry;
+        this.contextPad = contextPad;
+        this.vsCodeBridge = vsCodeBridge;
+
+        eventBus.on("import.done", () => this.sendNow());
+        eventBus.on("commandStack.changed", () => this.sendDebounced());
+        eventBus.on("contextPad.open", (event) => {
+            this.currentPadTarget = singleTarget((event as { current?: unknown })?.current);
+        });
+        eventBus.on("contextPad.close", () => {
+            this.currentPadTarget = undefined;
+        });
+    }
+
+    /**
+     * Applies a host status push: replaces the cache with the new snapshot and,
+     * if the context pad is open for an element whose visibility just flipped,
+     * re-renders it so a now-resolved entry appears or a now-broken one hides
+     * without waiting for the user to reselect.
+     */
+    applyStatus(resolved: Record<string, boolean>): void {
+        const previous = this.statusByKey;
+        const next = new Map(Object.entries(resolved));
+        const target = this.currentPadTarget;
+        const flipped =
+            target !== undefined && this.lookup(previous, target) !== this.lookup(next, target);
+
+        this.statusByKey = next;
+
+        if (flipped && target && this.contextPad.isOpen()) {
+            this.contextPad.open(target, true);
+        }
+    }
+
+    /**
+     * Visibility decision for the provider. Unknown (no push seen for this
+     * activity/reference yet) is optimistic `true`; only a cached `false` hides.
+     */
+    isResolved(element: Element): boolean {
+        return this.lookup(this.statusByKey, element);
+    }
+
+    private lookup(status: Map<string, boolean>, element: Element): boolean {
+        const implementation = extractImplementation(element.businessObject);
+        if (!element.id || !implementation) {
+            return true;
+        }
+        const cached = status.get(implementationStatusKey(element.id, implementation.reference));
+        return cached === undefined ? true : cached;
+    }
+
+    private sendDebounced(): void {
+        if (this.syncTimer !== undefined) {
+            clearTimeout(this.syncTimer);
+        }
+        this.syncTimer = setTimeout(() => {
+            this.syncTimer = undefined;
+            this.sendNow();
+        }, SYNC_DEBOUNCE_MS);
+    }
+
+    private sendNow(): void {
+        const entries: ImplementationEntry[] = collectImplementations(this.elementRegistry);
+        const signature = JSON.stringify(entries);
+        if (signature === this.lastSentSignature) {
+            return;
+        }
+        this.lastSentSignature = signature;
+        this.vsCodeBridge.postMessage(new SyncActivitiesCommand(entries));
+    }
+}

--- a/libs/code-link/src/collectImplementations.spec.ts
+++ b/libs/code-link/src/collectImplementations.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+// `is()` is mocked to compare against each element's own `type`, so a single
+// registry can hold elements of mixed BPMN types.
+vi.mock("bpmn-js/lib/util/ModelUtil", () => ({
+    is: (element: { type?: string } | undefined, type: string) => element?.type === type,
+}));
+
+import { collectImplementations, ElementRegistryLike } from "./collectImplementations";
+
+interface FakeElement {
+    id?: string;
+    type?: string;
+    businessObject?: { get(name: string): unknown; extensionElements?: { values?: unknown[] } };
+}
+
+function registry(elements: FakeElement[]): ElementRegistryLike {
+    return { getAll: () => elements as never };
+}
+
+function bo(attrs: Record<string, unknown>): FakeElement["businessObject"] {
+    return {
+        get: (name) => attrs[name],
+        extensionElements: attrs.extensionElements as { values?: unknown[] } | undefined,
+    };
+}
+
+describe("collectImplementations", () => {
+    it("collects one entry per implementable task with a resolvable binding", () => {
+        const entries = collectImplementations(
+            registry([
+                {
+                    id: "Activity_Charge",
+                    type: "bpmn:ServiceTask",
+                    businessObject: bo({ "camunda:class": "com.example.Charge" }),
+                },
+                {
+                    id: "Activity_Mail",
+                    type: "bpmn:SendTask",
+                    businessObject: bo({ "camunda:delegateExpression": "${mailer}" }),
+                },
+            ]),
+        );
+
+        expect(entries).toEqual([
+            { activityId: "Activity_Charge", kind: "javaClass", reference: "com.example.Charge" },
+            { activityId: "Activity_Mail", kind: "delegateExpression", reference: "${mailer}" },
+        ]);
+    });
+
+    it("skips non-implementable element types even when they carry attributes", () => {
+        const entries = collectImplementations(
+            registry([
+                {
+                    id: "Task_User",
+                    type: "bpmn:UserTask",
+                    businessObject: bo({ "camunda:class": "com.example.X" }),
+                },
+                {
+                    id: "Flow_1",
+                    type: "bpmn:SequenceFlow",
+                    businessObject: bo({}),
+                },
+            ]),
+        );
+
+        expect(entries).toEqual([]);
+    });
+
+    it("skips implementable tasks without a binding", () => {
+        const entries = collectImplementations(
+            registry([{ id: "Activity_Empty", type: "bpmn:ServiceTask", businessObject: bo({}) }]),
+        );
+
+        expect(entries).toEqual([]);
+    });
+
+    it("skips elements without an id (the status map is keyed by activity id)", () => {
+        const entries = collectImplementations(
+            registry([
+                {
+                    type: "bpmn:ServiceTask",
+                    businessObject: bo({ "camunda:class": "com.example.NoId" }),
+                },
+            ]),
+        );
+
+        expect(entries).toEqual([]);
+    });
+
+    it("reads a C8 zeebe:taskDefinition job type", () => {
+        const entries = collectImplementations(
+            registry([
+                {
+                    id: "Activity_Pay",
+                    type: "bpmn:ServiceTask",
+                    businessObject: bo({
+                        extensionElements: {
+                            values: [{ $type: "zeebe:TaskDefinition", type: "payment-service" }],
+                        },
+                    }),
+                },
+            ]),
+        );
+
+        expect(entries).toEqual([
+            { activityId: "Activity_Pay", kind: "jobType", reference: "payment-service" },
+        ]);
+    });
+
+    it("sorts entries by activity id so the list is order-stable across calls", () => {
+        const entries = collectImplementations(
+            registry([
+                {
+                    id: "Activity_Z",
+                    type: "bpmn:ServiceTask",
+                    businessObject: bo({ "camunda:class": "com.example.Z" }),
+                },
+                {
+                    id: "Activity_A",
+                    type: "bpmn:ServiceTask",
+                    businessObject: bo({ "camunda:class": "com.example.A" }),
+                },
+            ]),
+        );
+
+        expect(entries.map((entry) => entry.activityId)).toEqual(["Activity_A", "Activity_Z"]);
+    });
+});

--- a/libs/code-link/src/collectImplementations.ts
+++ b/libs/code-link/src/collectImplementations.ts
@@ -1,0 +1,61 @@
+/**
+ * Reads the diagram's implementation bindings straight off the bpmn-js model so
+ * the host never has to parse the BPMN XML. bpmn-js already parsed the
+ * (possibly huge) `.bpmn` to render it; this walks the resulting
+ * `elementRegistry`, keeps the task types that can carry a Camunda
+ * implementation, and turns each one into a cheap `(activityId, kind, reference)`
+ * triple for {@link SyncActivitiesCommand}.
+ */
+import { is } from "bpmn-js/lib/util/ModelUtil";
+
+import type { ImplementationEntry } from "@miragon/bpmn-modeler-shared";
+
+import { BusinessObjectLike, extractImplementation } from "./extractImplementation";
+
+/**
+ * The task types that can carry a Camunda implementation binding worth linking.
+ * The single source of truth for both {@link collectImplementations} and the
+ * context-pad provider, so the two never disagree about what is implementable.
+ */
+export const IMPLEMENTABLE_TYPES = ["bpmn:ServiceTask", "bpmn:SendTask", "bpmn:BusinessRuleTask"];
+
+/** The minimal slice of a bpmn-js element this module reads. */
+interface RegistryElement {
+    id?: string;
+    type?: string;
+    businessObject?: BusinessObjectLike;
+}
+
+/** The slice of bpmn-js' `elementRegistry` this module needs. */
+export interface ElementRegistryLike {
+    getAll(): RegistryElement[];
+}
+
+/**
+ * Collects one {@link ImplementationEntry} per implementable task that carries a
+ * resolvable reference. Entries are sorted by activity id so the resulting list
+ * is order-stable across calls — that lets the client cheaply skip re-sending an
+ * unchanged diagram and gives the persisted artifact a deterministic ordering.
+ *
+ * @param elementRegistry bpmn-js' element registry for the live diagram.
+ */
+export function collectImplementations(
+    elementRegistry: ElementRegistryLike,
+): ImplementationEntry[] {
+    const entries: ImplementationEntry[] = [];
+    for (const element of elementRegistry.getAll()) {
+        if (!element.id || !IMPLEMENTABLE_TYPES.some((type) => is(element, type))) {
+            continue;
+        }
+        const implementation = extractImplementation(element.businessObject);
+        if (!implementation) {
+            continue;
+        }
+        entries.push({
+            activityId: element.id,
+            kind: implementation.kind,
+            reference: implementation.reference,
+        });
+    }
+    return entries.sort((a, b) => a.activityId.localeCompare(b.activityId));
+}

--- a/libs/code-link/src/extractImplementation.spec.ts
+++ b/libs/code-link/src/extractImplementation.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import { BusinessObjectLike, extractImplementation } from "./extractImplementation";
+
+function businessObject(attrs: Record<string, unknown>): BusinessObjectLike {
+    return {
+        get(name: string) {
+            return attrs[name];
+        },
+        extensionElements: attrs.extensionElements as
+            | { values?: { $type?: string; type?: string }[] }
+            | undefined,
+    };
+}
+
+describe("extractImplementation", () => {
+    it("reads C7 camunda:class as javaClass", () => {
+        const subject = businessObject({ "camunda:class": "com.example.MyDelegate" });
+
+        expect(extractImplementation(subject)).toEqual({
+            kind: "javaClass",
+            reference: "com.example.MyDelegate",
+        });
+    });
+
+    it("reads C7 camunda:delegateExpression as delegateExpression", () => {
+        const subject = businessObject({ "camunda:delegateExpression": "${myBean}" });
+
+        expect(extractImplementation(subject)).toEqual({
+            kind: "delegateExpression",
+            reference: "${myBean}",
+        });
+    });
+
+    it("reads C7 camunda:expression as expression", () => {
+        const subject = businessObject({ "camunda:expression": "${svc.run()}" });
+
+        expect(extractImplementation(subject)).toEqual({
+            kind: "expression",
+            reference: "${svc.run()}",
+        });
+    });
+
+    it("reads C7 external topic when type is external", () => {
+        const subject = businessObject({
+            "camunda:type": "external",
+            "camunda:topic": "payment-topic",
+        });
+
+        expect(extractImplementation(subject)).toEqual({
+            kind: "externalTopic",
+            reference: "payment-topic",
+        });
+    });
+
+    it("ignores the topic when the type is not external", () => {
+        // A leftover `camunda:topic` without `camunda:type="external"` is not a
+        // live external-task binding, so it must not be offered.
+        const subject = businessObject({ "camunda:topic": "payment-topic" });
+
+        expect(extractImplementation(subject)).toBeUndefined();
+    });
+
+    it("reads C8 zeebe:TaskDefinition.type as jobType", () => {
+        const subject = businessObject({
+            extensionElements: {
+                values: [{ $type: "zeebe:TaskDefinition", type: "payment-service" }],
+            },
+        });
+
+        expect(extractImplementation(subject)).toEqual({
+            kind: "jobType",
+            reference: "payment-service",
+        });
+    });
+
+    it("returns undefined for a business-rule task with only camunda:decisionRef", () => {
+        // That DMN link is model-navigation's job — code-link must stay out of
+        // the way so the two context-pad entries never collide.
+        const subject = businessObject({ "camunda:decisionRef": "Decision_1" });
+
+        expect(extractImplementation(subject)).toBeUndefined();
+    });
+
+    it("prefers camunda:class over the other C7 bindings", () => {
+        const subject = businessObject({
+            "camunda:class": "com.example.Winner",
+            "camunda:delegateExpression": "${loser}",
+            "camunda:expression": "${alsoLoser}",
+        });
+
+        expect(extractImplementation(subject)).toEqual({
+            kind: "javaClass",
+            reference: "com.example.Winner",
+        });
+    });
+
+    it("prefers a C7 binding over the C8 task definition", () => {
+        const subject = businessObject({
+            "camunda:class": "com.example.MyDelegate",
+            "extensionElements": {
+                values: [{ $type: "zeebe:TaskDefinition", type: "payment-service" }],
+            },
+        });
+
+        expect(extractImplementation(subject)?.kind).toBe("javaClass");
+    });
+
+    it("returns undefined for empty-string bindings", () => {
+        expect(extractImplementation(businessObject({ "camunda:class": "" }))).toBeUndefined();
+        expect(
+            extractImplementation(businessObject({ "camunda:delegateExpression": "" })),
+        ).toBeUndefined();
+    });
+
+    it("returns undefined when no binding is present", () => {
+        expect(extractImplementation(businessObject({}))).toBeUndefined();
+    });
+
+    it("returns undefined when extensionElements has no values array", () => {
+        const subject: BusinessObjectLike = { get: () => undefined, extensionElements: {} };
+
+        expect(extractImplementation(subject)).toBeUndefined();
+    });
+
+    it("returns undefined for a missing business object", () => {
+        expect(extractImplementation(undefined)).toBeUndefined();
+    });
+});

--- a/libs/code-link/src/extractImplementation.ts
+++ b/libs/code-link/src/extractImplementation.ts
@@ -1,0 +1,101 @@
+/**
+ * Extracts the Camunda implementation reference from a service / send /
+ * business-rule task business object so the host can navigate to its source.
+ *
+ * Camunda 7 stores the binding directly as attributes on the BPMN element
+ * (`camunda:class`, `camunda:delegateExpression`, `camunda:expression`, or
+ * `camunda:type="external"` + `camunda:topic`). Camunda 8 wraps it in a
+ * `zeebe:taskDefinition` extension element carrying a `type`. Both shapes are
+ * checked so the caller does not need to know the active engine.
+ *
+ * A business-rule task that only carries `camunda:decisionRef` returns
+ * `undefined` here — that DMN link is model-navigation's job, so the two
+ * context-pad entries never collide.
+ */
+import type { ImplementationKind } from "@miragon/bpmn-modeler-shared";
+
+export type { ImplementationKind };
+
+/**
+ * The shape this module needs from a bpmn-js business object. Kept loose so the
+ * code stays decoupled from bpmn-moddle types — only `get()` and the optional
+ * `extensionElements.values` list matter.
+ */
+export interface BusinessObjectLike {
+    get(attr: string): unknown;
+    extensionElements?: { values?: ExtensionElementLike[] };
+}
+
+export interface ExtensionElementLike {
+    $type?: string;
+    // `zeebe:TaskDefinition` carries the C8 job type here.
+    type?: string;
+}
+
+/**
+ * A resolved implementation reference: the raw reference string plus the
+ * {@link ImplementationKind} that tells the host how to resolve it.
+ */
+export interface ImplementationReference {
+    kind: ImplementationKind;
+    reference: string;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function findExtensionElement(
+    businessObject: BusinessObjectLike,
+    type: string,
+): ExtensionElementLike | undefined {
+    return businessObject.extensionElements?.values?.find((element) => element.$type === type);
+}
+
+/**
+ * Classifies the selected element's implementation binding. C7 attributes are
+ * checked before the C8 extension element; within C7 the order
+ * class → delegate → expression → external matches the mutually-exclusive
+ * "Implementation" dropdown so the first present attribute wins.
+ *
+ * @param businessObject Business object of the selected element.
+ */
+export function extractImplementation(
+    businessObject: BusinessObjectLike | undefined,
+): ImplementationReference | undefined {
+    if (!businessObject) {
+        return undefined;
+    }
+
+    const javaClass = asNonEmptyString(businessObject.get("camunda:class"));
+    if (javaClass) {
+        return { kind: "javaClass", reference: javaClass };
+    }
+
+    const delegateExpression = asNonEmptyString(businessObject.get("camunda:delegateExpression"));
+    if (delegateExpression) {
+        return { kind: "delegateExpression", reference: delegateExpression };
+    }
+
+    const expression = asNonEmptyString(businessObject.get("camunda:expression"));
+    if (expression) {
+        return { kind: "expression", reference: expression };
+    }
+
+    // C7 external task: the topic is meaningful only when the type is external.
+    if (businessObject.get("camunda:type") === "external") {
+        const topic = asNonEmptyString(businessObject.get("camunda:topic"));
+        if (topic) {
+            return { kind: "externalTopic", reference: topic };
+        }
+    }
+
+    // C8: <zeebe:taskDefinition type="…">
+    const taskDefinition = findExtensionElement(businessObject, "zeebe:TaskDefinition");
+    const jobType = asNonEmptyString(taskDefinition?.type);
+    if (jobType) {
+        return { kind: "jobType", reference: jobType };
+    }
+
+    return undefined;
+}

--- a/libs/code-link/src/index.ts
+++ b/libs/code-link/src/index.ts
@@ -1,0 +1,38 @@
+/**
+ * bpmn-js DI module that adds a "Go to implementation" entry to the context
+ * pad around service / send / business-rule tasks carrying a Camunda
+ * implementation reference (C7 `camunda:class` / delegate / expression /
+ * external topic, or C8 `zeebe:taskDefinition` job type).
+ *
+ * Register as an `additionalModule` when creating the bpmn-js modeler:
+ *
+ * ```ts
+ * import { CodeLinkModule } from "@miragon/bpmn-modeler-code-link";
+ *
+ * new BpmnModeler({ additionalModules: [CodeLinkModule] });
+ * ```
+ *
+ * Requires a `vsCodeBridge` DI value with a `postMessage` method (the
+ * bpmn-webview provides this so the existing single VS Code API instance is
+ * reused).
+ *
+ * The module also registers a {@link CodeLinkMapClient}: it keeps the host's
+ * activity→code map in sync (so the context-pad entry can hide when a task's
+ * implementation does not exist) and is the service the bpmn-webview hands the
+ * host's {@link ImplementationStatusQuery} pushes via `applyStatus`.
+ */
+import { CodeLinkContextPadProvider } from "./CodeLinkContextPadProvider";
+import { CodeLinkMapClient } from "./CodeLinkMapClient";
+
+export { extractImplementation } from "./extractImplementation";
+export type { ImplementationKind, ImplementationReference } from "./extractImplementation";
+export { collectImplementations, IMPLEMENTABLE_TYPES } from "./collectImplementations";
+export { CodeLinkMapClient } from "./CodeLinkMapClient";
+
+export const CodeLinkModule = {
+    // `codeLinkMapClient` is listed first so it is constructed (and subscribed
+    // to import/edit events) before the provider that depends on it.
+    __init__: ["codeLinkMapClient", "codeLinkContextPadProvider"],
+    codeLinkMapClient: ["type", CodeLinkMapClient],
+    codeLinkContextPadProvider: ["type", CodeLinkContextPadProvider],
+};

--- a/libs/code-link/tsconfig.json
+++ b/libs/code-link/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "skipLibCheck": true,
+        "allowArbitraryExtensions": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/libs/code-link/vitest.config.ts
+++ b/libs/code-link/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+export default defineConfig({
+    test: {
+        name: "context-pad-code-link",
+        environment: "node",
+        include: ["src/**/*.{spec,test}.ts"],
+        alias: {
+            "@miragon/bpmn-modeler-shared": resolve(__dirname, "../../libs/shared/src/index.ts"),
+        },
+    },
+});

--- a/libs/modeler-core/src/codeLink/domain/CodeLinkMap.spec.ts
+++ b/libs/modeler-core/src/codeLink/domain/CodeLinkMap.spec.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    buildMapJson,
+    CODE_LINK_SCHEMA_VERSION,
+    CodeLinkMapEntry,
+    contentDeclaresBean,
+    contentImplementsLiteral,
+    fileMatchesEntry,
+    matchesBeanClassName,
+    matchesClassPath,
+    parseMapJson,
+    toAbsolute,
+    toAbsoluteEntries,
+    toRelative,
+} from "./CodeLinkMap";
+
+describe("CodeLinkMap — path conversion", () => {
+    it("relativises and re-absolutises a workspace path round-trip", () => {
+        const abs = "/work/proj/src/main/java/com/example/Charge.java";
+        const root = "/work/proj";
+        expect(toRelative(abs, root)).toBe("src/main/java/com/example/Charge.java");
+        expect(toAbsolute(toRelative(abs, root), root)).toBe(abs);
+    });
+});
+
+describe("CodeLinkMap — matchesClassPath", () => {
+    it("matches a FQCN against its class file under any source root", () => {
+        expect(
+            matchesClassPath("com.example.Charge", "/a/src/main/java/com/example/Charge.java"),
+        ).toBe(true);
+        expect(matchesClassPath("com.example.Charge", "/a/com/example/Charge.kt")).toBe(true);
+    });
+
+    it("requires a segment boundary so a no-package class does not match a suffix collision", () => {
+        // `Foo` must not match `MyFoo.java`.
+        expect(matchesClassPath("Foo", "/src/MyFoo.java")).toBe(false);
+        expect(matchesClassPath("Foo", "/src/Foo.java")).toBe(true);
+    });
+
+    it("does not match a different file extension", () => {
+        expect(matchesClassPath("com.example.Charge", "/src/com/example/Charge.txt")).toBe(false);
+    });
+});
+
+describe("CodeLinkMap — matchesBeanClassName", () => {
+    it("matches the conventional capitalised class file for a bean id", () => {
+        expect(matchesBeanClassName("myBean", "/src/MyBean.java")).toBe(true);
+        expect(matchesBeanClassName("myBean", "/src/MyBean.kt")).toBe(true);
+    });
+
+    it("does not match an unrelated file name", () => {
+        expect(matchesBeanClassName("myBean", "/src/OtherBean.java")).toBe(false);
+    });
+});
+
+describe("CodeLinkMap — content matchers", () => {
+    it("finds a quoted literal but ignores one inside an XML comment", () => {
+        expect(contentImplementsLiteral('@JobWorker(type = "pay")', "pay")).toBe(true);
+        expect(contentImplementsLiteral('<!-- "pay" -->', "pay")).toBe(false);
+    });
+
+    it("matches a Spring/CDI bean annotation carrying the exact bean id", () => {
+        expect(contentDeclaresBean('@Service("myBean")', "myBean")).toBe(true);
+        expect(contentDeclaresBean('@Component(value = "myBean")', "myBean")).toBe(true);
+        expect(contentDeclaresBean('@Service("other")', "myBean")).toBe(false);
+    });
+});
+
+describe("CodeLinkMap — fileMatchesEntry", () => {
+    it("decides javaClass by path alone (content ignored)", () => {
+        expect(
+            fileMatchesEntry("javaClass", "com.example.Charge", "/x/com/example/Charge.java"),
+        ).toBe(true);
+    });
+
+    it("decides a bean by class-file name OR annotation content", () => {
+        expect(fileMatchesEntry("delegateExpression", "${myBean}", "/src/MyBean.java")).toBe(true);
+        expect(
+            fileMatchesEntry("expression", "${myBean}", "/src/Renamed.java", '@Service("myBean")'),
+        ).toBe(true);
+        expect(
+            fileMatchesEntry("delegateExpression", "${myBean}", "/src/Renamed.java", "class X {}"),
+        ).toBe(false);
+    });
+
+    it("decides a literal kind only when content is supplied", () => {
+        expect(fileMatchesEntry("jobType", "pay", "/src/W.java", 'type = "pay"')).toBe(true);
+        expect(fileMatchesEntry("jobType", "pay", "/src/W.java")).toBe(false);
+        expect(fileMatchesEntry("externalTopic", "topic", "/src/W.java", '"topic"')).toBe(true);
+    });
+});
+
+describe("CodeLinkMap — JSON artifact", () => {
+    const entries: CodeLinkMapEntry[] = [
+        {
+            activityId: "Activity_Charge",
+            kind: "javaClass",
+            reference: "com.example.Charge",
+            resolved: true,
+            paths: ["/work/proj/src/main/java/com/example/Charge.java"],
+        },
+        {
+            activityId: "Activity_Mail",
+            kind: "jobType",
+            reference: "send-mail",
+            resolved: false,
+            paths: [],
+        },
+    ];
+
+    it("builds a workspace-relative artifact including unresolved entries", () => {
+        const json = buildMapJson({
+            bpmnFile: "src/main/resources/order.bpmn",
+            generatedAt: "2026-06-03T10:15:30.000Z",
+            workspaceRoot: "/work/proj",
+            entries,
+        });
+
+        expect(json).toEqual({
+            schemaVersion: CODE_LINK_SCHEMA_VERSION,
+            bpmnFile: "src/main/resources/order.bpmn",
+            generatedAt: "2026-06-03T10:15:30.000Z",
+            entries: [
+                {
+                    activityId: "Activity_Charge",
+                    kind: "javaClass",
+                    reference: "com.example.Charge",
+                    resolved: true,
+                    paths: ["src/main/java/com/example/Charge.java"],
+                },
+                {
+                    activityId: "Activity_Mail",
+                    kind: "jobType",
+                    reference: "send-mail",
+                    resolved: false,
+                    paths: [],
+                },
+            ],
+        });
+    });
+
+    it("round-trips through parse + toAbsoluteEntries", () => {
+        const json = buildMapJson({
+            bpmnFile: "order.bpmn",
+            generatedAt: "t",
+            workspaceRoot: "/work/proj",
+            entries,
+        });
+        const parsed = parseMapJson(JSON.stringify(json));
+        expect(parsed).toBeDefined();
+        const rehydrated = toAbsoluteEntries(parsed!, "/work/proj");
+        expect(rehydrated).toEqual(entries);
+    });
+
+    it("returns undefined for malformed or wrong-schema input rather than throwing", () => {
+        expect(parseMapJson("not json")).toBeUndefined();
+        expect(parseMapJson(JSON.stringify({ schemaVersion: 999, entries: [] }))).toBeUndefined();
+        expect(
+            parseMapJson(JSON.stringify({ schemaVersion: CODE_LINK_SCHEMA_VERSION })),
+        ).toBeUndefined();
+    });
+
+    it("returns undefined when any entry is malformed (whole file dropped, never throws)", () => {
+        const wrap = (entries: unknown[]) =>
+            JSON.stringify({ schemaVersion: CODE_LINK_SCHEMA_VERSION, entries });
+
+        // A null element — the case that would NPE in toAbsoluteEntries.
+        expect(parseMapJson(wrap([null]))).toBeUndefined();
+        // A missing field (no `paths`).
+        expect(
+            parseMapJson(
+                wrap([{ activityId: "A", kind: "jobType", reference: "pay", resolved: true }]),
+            ),
+        ).toBeUndefined();
+        // `resolved` of the wrong type.
+        expect(
+            parseMapJson(
+                wrap([
+                    {
+                        activityId: "A",
+                        kind: "jobType",
+                        reference: "pay",
+                        resolved: "yes",
+                        paths: [],
+                    },
+                ]),
+            ),
+        ).toBeUndefined();
+        // `paths` not a string array.
+        expect(
+            parseMapJson(
+                wrap([
+                    {
+                        activityId: "A",
+                        kind: "jobType",
+                        reference: "pay",
+                        resolved: true,
+                        paths: [42],
+                    },
+                ]),
+            ),
+        ).toBeUndefined();
+        // One bad entry alongside a valid one still drops the whole file.
+        expect(
+            parseMapJson(
+                wrap([
+                    {
+                        activityId: "A",
+                        kind: "jobType",
+                        reference: "pay",
+                        resolved: true,
+                        paths: ["src/W.java"],
+                    },
+                    null,
+                ]),
+            ),
+        ).toBeUndefined();
+    });
+});

--- a/libs/modeler-core/src/codeLink/domain/CodeLinkMap.ts
+++ b/libs/modeler-core/src/codeLink/domain/CodeLinkMap.ts
@@ -1,0 +1,285 @@
+/**
+ * Pure domain core of the activity→code map: the in-memory entry shape, the
+ * on-disk JSON artifact shape, the relative↔absolute path conversions, and the
+ * single-file matchers that decide whether one source file implements a given
+ * `(kind, reference)`.
+ *
+ * The matchers are the load-bearing piece. They are shared verbatim by the
+ * always-on map's two cheap operations — *verifying* an already-linked file
+ * still implements its activity, and *live-linking* a just-saved file to an
+ * unresolved activity — and by the locator's batched scan, so all three agree on
+ * what "implements" means without re-walking the workspace per reference.
+ *
+ * No `vscode` / Node host modules — only `path` (string math). The matchers
+ * operate on content the caller already read, so this stays unit-testable
+ * against plain strings.
+ */
+import { posix } from "path";
+
+import {
+    beanToClassName,
+    extractBeanName,
+    fqcnToGlobPath,
+    ImplementationKind,
+    JVM_EXTENSIONS,
+} from "./ImplementationReference";
+
+export type { ImplementationKind };
+
+/** Bumped only on a breaking change to {@link CodeLinkMapJson}'s shape. */
+export const CODE_LINK_SCHEMA_VERSION = 1;
+
+/**
+ * One activity's resolution state held in memory while the editor is open.
+ * `paths` are absolute (the `uri.path` form the workspace search speaks) so they
+ * can be read back for verification and compared against watcher events; they
+ * are relativised only when written to the artifact.
+ */
+export interface CodeLinkMapEntry {
+    activityId: string;
+    kind: ImplementationKind;
+    reference: string;
+    resolved: boolean;
+    paths: string[];
+}
+
+/** One entry as persisted: identical to {@link CodeLinkMapEntry} but with workspace-relative paths. */
+export interface CodeLinkMapJsonEntry {
+    activityId: string;
+    kind: ImplementationKind;
+    reference: string;
+    resolved: boolean;
+    paths: string[];
+}
+
+/**
+ * The persisted artifact. A full inventory (unresolved entries included) so
+ * external/AI tooling sees every task, and a warm cache the host reloads on the
+ * next open to skip the cold batched scan.
+ */
+export interface CodeLinkMapJson {
+    schemaVersion: number;
+    bpmnFile: string;
+    generatedAt: string;
+    entries: CodeLinkMapJsonEntry[];
+}
+
+/**
+ * Workspace-relative POSIX path of `absolutePath` under `workspaceRoot`. Both
+ * inputs are `uri.path`-style POSIX strings, so `posix.relative` is exact.
+ */
+export function toRelative(absolutePath: string, workspaceRoot: string): string {
+    return posix.relative(workspaceRoot, absolutePath);
+}
+
+/** Absolute path of a workspace-relative POSIX path — the inverse of {@link toRelative}. */
+export function toAbsolute(relativePath: string, workspaceRoot: string): string {
+    return posix.join(workspaceRoot, relativePath);
+}
+
+/**
+ * Assembles the artifact from the in-memory entries, relativising every path so
+ * the file is workspace-portable. Pure and deterministic given its inputs —
+ * `generatedAt` is passed in rather than read from the clock here so the result
+ * can be asserted in tests.
+ */
+export function buildMapJson(params: {
+    bpmnFile: string;
+    generatedAt: string;
+    workspaceRoot: string;
+    entries: readonly CodeLinkMapEntry[];
+}): CodeLinkMapJson {
+    return {
+        schemaVersion: CODE_LINK_SCHEMA_VERSION,
+        bpmnFile: params.bpmnFile,
+        generatedAt: params.generatedAt,
+        entries: params.entries.map((entry) => ({
+            activityId: entry.activityId,
+            kind: entry.kind,
+            reference: entry.reference,
+            resolved: entry.resolved,
+            paths: entry.paths.map((path) => toRelative(path, params.workspaceRoot)),
+        })),
+    };
+}
+
+/**
+ * Parses the artifact, returning `undefined` (not throwing) on anything that is
+ * not a current-schema map — a hand-edited, truncated, or older file must
+ * degrade to "no warm cache", never crash the open.
+ */
+export function parseMapJson(raw: string): CodeLinkMapJson | undefined {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+    if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        (parsed as CodeLinkMapJson).schemaVersion !== CODE_LINK_SCHEMA_VERSION ||
+        !Array.isArray((parsed as CodeLinkMapJson).entries)
+    ) {
+        return undefined;
+    }
+    // Validate each entry's shape too: an `entries` array alone is not enough.
+    // A hand-edited/truncated file can carry a malformed element (e.g. `[null]`,
+    // a missing field, or a non-string `paths`) that would NPE in
+    // toAbsoluteEntries and crash the open. One bad entry drops the whole file.
+    if (!(parsed as CodeLinkMapJson).entries.every(isValidJsonEntry)) {
+        return undefined;
+    }
+    return parsed as CodeLinkMapJson;
+}
+
+/** Structural guard for one persisted entry — every field present and correctly typed. */
+function isValidJsonEntry(entry: unknown): entry is CodeLinkMapJsonEntry {
+    if (typeof entry !== "object" || entry === null) {
+        return false;
+    }
+    const candidate = entry as Record<string, unknown>;
+    return (
+        typeof candidate.activityId === "string" &&
+        typeof candidate.kind === "string" &&
+        typeof candidate.reference === "string" &&
+        typeof candidate.resolved === "boolean" &&
+        Array.isArray(candidate.paths) &&
+        candidate.paths.every((path) => typeof path === "string")
+    );
+}
+
+/** Re-hydrates persisted entries to the in-memory shape (relative paths → absolute). */
+export function toAbsoluteEntries(
+    json: CodeLinkMapJson,
+    workspaceRoot: string,
+): CodeLinkMapEntry[] {
+    return json.entries.map((entry) => ({
+        activityId: entry.activityId,
+        kind: entry.kind,
+        reference: entry.reference,
+        resolved: entry.resolved,
+        paths: entry.paths.map((path) => toAbsolute(path, workspaceRoot)),
+    }));
+}
+
+/**
+ * `camunda:class` is a fully-qualified name, so the file path *is* the proof —
+ * no content read needed. The package path must sit on a segment boundary
+ * (start of path or after `/`) so a no-package `Foo` does not falsely match
+ * `MyFoo.java`.
+ */
+export function matchesClassPath(fqcn: string, absolutePath: string): boolean {
+    const packagePath = fqcnToGlobPath(fqcn);
+    return JVM_EXTENSIONS.some((ext) => {
+        const suffix = `${packagePath}.${ext}`;
+        return absolutePath === suffix || absolutePath.endsWith(`/${suffix}`);
+    });
+}
+
+/**
+ * Whether the file is the conventional implementing class for a bean id —
+ * `myBean` → `MyBean.java`. The first guess the locator makes for a
+ * delegate/expression binding, matched on the file's basename alone.
+ */
+export function matchesBeanClassName(bean: string, absolutePath: string): boolean {
+    const className = beanToClassName(bean);
+    const base = posix.basename(absolutePath);
+    return JVM_EXTENSIONS.some((ext) => base === `${className}.${ext}`);
+}
+
+/**
+ * Whether `content` declares a worker for a free-form literal (external-task
+ * topic or Zeebe job type) — the literal appears quoted, e.g.
+ * `@JobWorker(type = "payment")` or `taskType: "payment"`.
+ */
+export function contentImplementsLiteral(content: string, literal: string): boolean {
+    return matchesOutsideComments(content, new RegExp(`["']${escapeRegex(literal)}["']`));
+}
+
+/**
+ * Whether `content` declares a Spring/CDI bean carrying the exact bean id, e.g.
+ * `@Service("myBean")` — the fallback when the class file name differs from the
+ * bean (an explicitly named `@Component(value = "myBean")`).
+ */
+export function contentDeclaresBean(content: string, bean: string): boolean {
+    return matchesOutsideComments(
+        content,
+        new RegExp(
+            `@(?:Component|Service|Repository|Named|Bean)\\s*\\(\\s*(?:value\\s*=\\s*)?["']${escapeRegex(
+                bean,
+            )}["']`,
+        ),
+    );
+}
+
+/**
+ * The one decision both verification and live-linking ask: does the file at
+ * `absolutePath` (with already-read `content`) implement `(kind, reference)`?
+ * `content` is optional only for `javaClass`, which is decided by the path
+ * alone; the content-based kinds report `false` when content is unavailable.
+ */
+export function fileMatchesEntry(
+    kind: ImplementationKind,
+    reference: string,
+    absolutePath: string,
+    content?: string,
+): boolean {
+    switch (kind) {
+        case "javaClass":
+            return matchesClassPath(reference, absolutePath);
+        case "delegateExpression":
+        case "expression": {
+            const bean = extractBeanName(reference);
+            if (!bean) {
+                return false;
+            }
+            return (
+                matchesBeanClassName(bean, absolutePath) ||
+                (content !== undefined && contentDeclaresBean(content, bean))
+            );
+        }
+        case "externalTopic":
+        case "jobType":
+            return content !== undefined && contentImplementsLiteral(content, reference);
+    }
+}
+
+/** Escapes regex metacharacters so a user id/literal is matched verbatim. */
+function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True if `pattern` matches at least one position outside an XML comment or
+ * CDATA section — a commented-out declaration is not a real one. Mirrors the
+ * workspace content search so the batched scan and these matchers never
+ * disagree about the same file. For non-XML source the excluded ranges are
+ * empty and matching behaves normally.
+ *
+ * Limitation: only XML comments/CDATA are excluded, not Java/JS line (`//`) or
+ * block comments, so a commented-out annotation in a `.java` file can still
+ * false-match. This is deliberate — a naive comment stripper would truncate on a
+ * `//` inside a string literal and wrongly *hide* a real match (a worse failure
+ * than an extra heuristic link). Revisit only with a real tokenizer if it bites.
+ */
+function matchesOutsideComments(content: string, pattern: RegExp): boolean {
+    const excluded: Array<[number, number]> = [];
+    for (const re of [/<!--[\s\S]*?-->/g, /<!\[CDATA\[[\s\S]*?\]\]>/g]) {
+        let m: RegExpExecArray | null;
+        while ((m = re.exec(content)) !== null) {
+            excluded.push([m.index, m.index + m[0].length]);
+        }
+    }
+    const global = new RegExp(
+        pattern.source,
+        pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+    );
+    let match: RegExpExecArray | null;
+    while ((match = global.exec(content)) !== null) {
+        if (!excluded.some(([start, end]) => match!.index >= start && match!.index < end)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/libs/modeler-core/src/codeLink/domain/ImplementationReference.spec.ts
+++ b/libs/modeler-core/src/codeLink/domain/ImplementationReference.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { beanToClassName, extractBeanName, fqcnToGlobPath } from "./ImplementationReference";
+
+describe("extractBeanName", () => {
+    it("reads a plain ${bean} expression", () => {
+        expect(extractBeanName("${myBean}")).toBe("myBean");
+    });
+
+    it("reads the leading id before a method call", () => {
+        expect(extractBeanName("${svc.run()}")).toBe("svc");
+    });
+
+    it("supports the #{…} EL prefix", () => {
+        expect(extractBeanName("#{myBean}")).toBe("myBean");
+    });
+
+    it("tolerates whitespace inside the braces", () => {
+        expect(extractBeanName("${ myBean }")).toBe("myBean");
+    });
+
+    it("reads a bare identifier with no wrapper", () => {
+        expect(extractBeanName("myBean")).toBe("myBean");
+    });
+
+    it("returns undefined when no identifier leads", () => {
+        expect(extractBeanName("${ 1 + 2 }")).toBeUndefined();
+        expect(extractBeanName("${.foo}")).toBeUndefined();
+    });
+});
+
+describe("beanToClassName", () => {
+    it("capitalises the first letter", () => {
+        expect(beanToClassName("myBean")).toBe("MyBean");
+    });
+
+    it("leaves an already-capitalised name unchanged", () => {
+        expect(beanToClassName("MyBean")).toBe("MyBean");
+    });
+
+    it("handles an empty string", () => {
+        expect(beanToClassName("")).toBe("");
+    });
+});
+
+describe("fqcnToGlobPath", () => {
+    it("converts dots to slashes", () => {
+        expect(fqcnToGlobPath("com.example.MyDelegate")).toBe("com/example/MyDelegate");
+    });
+
+    it("leaves a single-segment name unchanged", () => {
+        expect(fqcnToGlobPath("MyDelegate")).toBe("MyDelegate");
+    });
+});

--- a/libs/modeler-core/src/codeLink/domain/ImplementationReference.ts
+++ b/libs/modeler-core/src/codeLink/domain/ImplementationReference.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure domain helpers for turning a Camunda implementation reference into the
+ * filename / package shapes the workspace search needs. No `vscode` / `node`
+ * dependencies — these are plain string transforms, unit-tested directly.
+ */
+import type { ImplementationKind } from "@miragon/bpmn-modeler-shared";
+
+export type { ImplementationKind };
+
+/**
+ * Source-file extensions a JVM-language Camunda delegate/bean can live in.
+ * Used to build globs and the fs-walk fallback predicate.
+ */
+export const JVM_EXTENSIONS = ["java", "kt", "groovy", "scala"] as const;
+
+/**
+ * Extra extensions a Zeebe job worker can live in (Node workers), searched on
+ * top of {@link JVM_EXTENSIONS} for `jobType` / `externalTopic` content scans.
+ */
+export const SCRIPT_WORKER_EXTENSIONS = ["js", "ts"] as const;
+
+/**
+ * Extracts the leading bean / variable id from a Camunda expression.
+ *
+ * Handles both EL prefixes (`${…}` and `#{…}`) and stops at the first
+ * non-identifier character, so `${myBean}` → `myBean`, `${svc.run()}` → `svc`,
+ * and `#{ beanWithSpaces }` → `beanWithSpaces`. Returns `undefined` when no
+ * identifier can be read (e.g. a literal or a leading operator).
+ */
+export function extractBeanName(expression: string): string | undefined {
+    const inner = expression
+        .trim()
+        .replace(/^[#$]\{/, "")
+        .replace(/\}$/, "")
+        .trim();
+    const match = inner.match(/^[A-Za-z_$][A-Za-z0-9_$]*/);
+    return match ? match[0] : undefined;
+}
+
+/**
+ * Capitalises a bean id to the conventional implementing class name
+ * (`myBean` → `MyBean`). A heuristic: Spring beans default to the
+ * decapitalised class name, so reversing that is the best first guess.
+ */
+export function beanToClassName(bean: string): string {
+    return bean.length === 0 ? bean : bean.charAt(0).toUpperCase() + bean.slice(1);
+}
+
+/**
+ * Converts a fully-qualified class name to its source path segment
+ * (`com.example.Foo` → `com/example/Foo`), so a glob can match the file
+ * regardless of which source root it sits under.
+ */
+export function fqcnToGlobPath(fqcn: string): string {
+    return fqcn.split(".").join("/");
+}

--- a/libs/modeler-core/src/codeLink/service/CodeLinkMapService.spec.ts
+++ b/libs/modeler-core/src/codeLink/service/CodeLinkMapService.spec.ts
@@ -1,0 +1,578 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImplementationEntry, implementationStatusKey } from "@miragon/bpmn-modeler-shared";
+
+import { buildMapJson } from "../domain/CodeLinkMap";
+import { CodeLinkMapService } from "./CodeLinkMapService";
+
+const ROOT = "/work/proj";
+const DOC = "/work/proj/order.bpmn";
+const ARTIFACT = "/work/proj/.camunda/code-link/order.bpmn.json";
+
+interface PushedStatus {
+    editorId: string;
+    resolved: Record<string, boolean>;
+}
+
+/**
+ * Builds the service against in-memory stubs. `resolveMap` keys a reference to
+ * the paths a batched resolve returns; `fileContents` backs both verification
+ * reads and the warm-cache load.
+ */
+function createService(
+    opts: {
+        persist?: boolean;
+        resolveMap?: Record<string, string[]>;
+        fileContents?: Record<string, string>;
+    } = {},
+) {
+    const resolveMap = opts.resolveMap ?? {};
+    const fileContents = { ...(opts.fileContents ?? {}) };
+
+    const pushed: PushedStatus[] = [];
+    const editorStore = {
+        requireHandle: vi.fn(() => ({
+            documentPath: () => DOC,
+            documentFsPath: () => DOC,
+        })),
+        postMessage: vi.fn((editorId: string, message: { resolved: Record<string, boolean> }) => {
+            pushed.push({ editorId, resolved: message.resolved });
+            return Promise.resolve(true);
+        }),
+    };
+
+    const locator = {
+        resolveMany: vi.fn((entries: ImplementationEntry[]) =>
+            Promise.resolve(
+                new Map(
+                    entries.map((entry) => [entry.activityId, resolveMap[entry.reference] ?? []]),
+                ),
+            ),
+        ),
+    };
+
+    const artifactSvc = { getWorkspaceRoot: vi.fn(() => Promise.resolve(ROOT)) };
+
+    const createdWatchers: { dispose: ReturnType<typeof vi.fn> }[] = [];
+    const writes: Record<string, string> = {};
+    const vsWorkspace = {
+        readFile: vi.fn((path: string) =>
+            path in fileContents
+                ? Promise.resolve(fileContents[path])
+                : Promise.reject(new Error("ENOENT")),
+        ),
+        writeFile: vi.fn((path: string, content: string) => {
+            writes[path] = content;
+            return Promise.resolve();
+        }),
+        createWatcher: vi.fn(() => {
+            const handle = { dispose: vi.fn() };
+            createdWatchers.push(handle);
+            return handle;
+        }),
+    };
+
+    const vsSettings = {
+        getPersistCodeLinkMap: vi.fn(() => opts.persist ?? false),
+        getConfigFolder: vi.fn(() => ".camunda"),
+    };
+    const notifier = { logInfo: vi.fn(), logWarning: vi.fn() };
+
+    const service = new CodeLinkMapService(
+        editorStore as never,
+        locator as never,
+        artifactSvc as never,
+        vsWorkspace as never,
+        vsSettings as never,
+        notifier as never,
+        10,
+    );
+
+    const lastStatus = (editorId: string) =>
+        [...pushed].reverse().find((push) => push.editorId === editorId)?.resolved;
+
+    return {
+        service,
+        locator,
+        vsWorkspace,
+        vsSettings,
+        artifactSvc,
+        editorStore,
+        notifier,
+        writes,
+        createdWatchers,
+        lastStatus,
+        pushed,
+        fileContents,
+    };
+}
+
+const entry = (
+    activityId: string,
+    kind: ImplementationEntry["kind"],
+    reference: string,
+): ImplementationEntry => ({ activityId, kind, reference });
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("CodeLinkMapService — sync diff", () => {
+    it("cold-open batch-resolves all activities and pushes their status", async () => {
+        const abs = "/work/proj/src/A.java";
+        const { service, locator, lastStatus } = createService({
+            resolveMap: { "com.example.A": [abs] },
+        });
+
+        await service.syncActivities("editor1", [entry("Act_A", "javaClass", "com.example.A")]);
+
+        expect(locator.resolveMany).toHaveBeenCalledTimes(1);
+        expect(lastStatus("editor1")).toEqual({
+            [implementationStatusKey("Act_A", "com.example.A")]: true,
+        });
+    });
+
+    it("verifies an unchanged resolved entry with a read instead of re-resolving", async () => {
+        const abs = "/work/proj/src/main/java/com/example/A.java";
+        const { service, locator, vsWorkspace } = createService({
+            resolveMap: { "com.example.A": [abs] },
+            fileContents: { [abs]: "class A {}" },
+        });
+        const entries = [entry("Act", "javaClass", "com.example.A")];
+
+        await service.syncActivities("editor1", entries);
+        vsWorkspace.readFile.mockClear();
+        await service.syncActivities("editor1", entries);
+
+        expect(locator.resolveMany).toHaveBeenCalledTimes(1); // not re-resolved
+        expect(vsWorkspace.readFile).toHaveBeenCalledWith(abs); // verified by a single read
+    });
+
+    it("re-resolves when a reference changes", async () => {
+        const { service, locator } = createService({
+            resolveMap: { "com.example.A": ["/p/A.java"], "com.example.B": ["/p/B.java"] },
+        });
+
+        await service.syncActivities("editor1", [entry("Act", "javaClass", "com.example.A")]);
+        await service.syncActivities("editor1", [entry("Act", "javaClass", "com.example.B")]);
+
+        expect(locator.resolveMany).toHaveBeenCalledTimes(2);
+        expect(locator.resolveMany.mock.calls[1][0]).toEqual([
+            entry("Act", "javaClass", "com.example.B"),
+        ]);
+    });
+
+    it("drops a removed activity from the pushed status", async () => {
+        const { service, lastStatus } = createService({
+            resolveMap: { a: ["/p/a"], b: ["/p/b"] },
+        });
+
+        await service.syncActivities("editor1", [
+            entry("A", "jobType", "a"),
+            entry("B", "jobType", "b"),
+        ]);
+        await service.syncActivities("editor1", [entry("A", "jobType", "a")]);
+
+        expect(Object.keys(lastStatus("editor1")!)).toEqual([implementationStatusKey("A", "a")]);
+    });
+
+    it("filters out malformed entries (unknown kind, empty fields)", async () => {
+        const { service, locator, lastStatus } = createService({ resolveMap: { x: ["/p/x"] } });
+
+        await service.syncActivities("editor1", [
+            entry("A", "jobType", "x"),
+            { activityId: "", kind: "jobType", reference: "y" },
+            { activityId: "B", kind: "bogus" as never, reference: "z" },
+        ]);
+
+        expect(locator.resolveMany.mock.calls[0][0]).toEqual([entry("A", "jobType", "x")]);
+        expect(Object.keys(lastStatus("editor1")!)).toEqual([implementationStatusKey("A", "x")]);
+    });
+});
+
+describe("CodeLinkMapService — warm cache", () => {
+    it("loads the artifact and verifies, skipping the batched resolve (persist on)", async () => {
+        const abs = "/work/proj/src/main/java/com/example/A.java";
+        const warm = JSON.stringify(
+            buildMapJson({
+                bpmnFile: "order.bpmn",
+                generatedAt: "t",
+                workspaceRoot: ROOT,
+                entries: [
+                    {
+                        activityId: "Act",
+                        kind: "javaClass",
+                        reference: "com.example.A",
+                        resolved: true,
+                        paths: [abs],
+                    },
+                ],
+            }),
+        );
+        const { service, locator, lastStatus } = createService({
+            persist: true,
+            fileContents: { [ARTIFACT]: warm, [abs]: "class A {}" },
+        });
+
+        await service.syncActivities("editor1", [entry("Act", "javaClass", "com.example.A")]);
+
+        expect(locator.resolveMany).not.toHaveBeenCalled();
+        expect(lastStatus("editor1")).toEqual({
+            [implementationStatusKey("Act", "com.example.A")]: true,
+        });
+    });
+
+    it("loads the warm cache when persistence is toggled on mid-session", async () => {
+        const abs = "/work/proj/src/main/java/com/example/A.java";
+        const warm = JSON.stringify(
+            buildMapJson({
+                bpmnFile: "order.bpmn",
+                generatedAt: "t",
+                workspaceRoot: ROOT,
+                entries: [
+                    {
+                        activityId: "Act",
+                        kind: "javaClass",
+                        reference: "com.example.A",
+                        resolved: true,
+                        paths: [abs],
+                    },
+                ],
+            }),
+        );
+        const { service, vsWorkspace, vsSettings } = createService({
+            persist: false,
+            resolveMap: { "com.example.A": [abs] },
+            fileContents: { [ARTIFACT]: warm, [abs]: "class A {}" },
+        });
+        const entries = [entry("Act", "javaClass", "com.example.A")];
+
+        await service.syncActivities("editor1", entries);
+        // Persist off: the artifact must not have been read as a warm cache.
+        expect(vsWorkspace.readFile).not.toHaveBeenCalledWith(ARTIFACT);
+
+        vsSettings.getPersistCodeLinkMap.mockReturnValue(true);
+        await service.syncActivities("editor1", entries);
+
+        // warmLoaded stayed false while off, so the toggle-on sync loads it now.
+        expect(vsWorkspace.readFile).toHaveBeenCalledWith(ARTIFACT);
+    });
+});
+
+describe("CodeLinkMapService — live linking", () => {
+    it("links a freshly-written worker to an unresolved activity", async () => {
+        const worker = "/work/proj/src/Worker.java";
+        const { service, lastStatus } = createService({
+            resolveMap: {}, // nothing resolves at sync time
+            fileContents: { [worker]: '@JobWorker(type = "pay")' },
+        });
+
+        await service.syncActivities("editor1", [entry("Act", "jobType", "pay")]);
+        expect(lastStatus("editor1")).toEqual({
+            [implementationStatusKey("Act", "pay")]: false,
+        });
+
+        await service.onSourceFileChanged(worker, "created", ROOT);
+        expect(lastStatus("editor1")).toEqual({
+            [implementationStatusKey("Act", "pay")]: true,
+        });
+    });
+
+    it("unlinks a deleted file and marks the activity unresolved", async () => {
+        const worker = "/work/proj/src/Worker.java";
+        const { service, lastStatus } = createService({
+            resolveMap: { pay: [worker] },
+            fileContents: { [worker]: '"pay"' },
+        });
+
+        await service.syncActivities("editor1", [entry("Act", "jobType", "pay")]);
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(true);
+
+        await service.onSourceFileChanged(worker, "deleted", ROOT);
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(false);
+    });
+
+    it("does not push when a changed file is irrelevant to the map", async () => {
+        const { service, pushed } = createService({
+            resolveMap: { "com.example.A": ["/work/proj/src/A.java"] },
+            fileContents: { "/work/proj/src/Unrelated.java": "class Unrelated {}" },
+        });
+        await service.syncActivities("editor1", [entry("Act", "javaClass", "com.example.A")]);
+        const pushesBefore = pushed.length;
+
+        await service.onSourceFileChanged("/work/proj/src/Unrelated.java", "changed", ROOT);
+
+        expect(pushed.length).toBe(pushesBefore);
+    });
+
+    it("unlinks when an edit removes the binding from an already-linked file", async () => {
+        const worker = "/work/proj/src/Worker.java";
+        const { service, lastStatus, fileContents } = createService({
+            resolveMap: { pay: [worker] },
+            fileContents: { [worker]: '@JobWorker(type = "pay")' },
+        });
+        await service.syncActivities("editor1", [entry("Act", "jobType", "pay")]);
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(true);
+
+        // The annotation is edited away — same file, no longer matches.
+        fileContents[worker] = '@JobWorker(type = "other")';
+        await service.onSourceFileChanged(worker, "changed", ROOT);
+
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(false);
+    });
+
+    it("links an additional implementing file to an already-resolved activity", async () => {
+        const first = "/work/proj/src/W1.java";
+        const second = "/work/proj/src/W2.java";
+        const { service, pushed } = createService({
+            resolveMap: { pay: [first] },
+            fileContents: { [first]: '"pay"', [second]: '"pay"' },
+        });
+        await service.syncActivities("editor1", [entry("Act", "jobType", "pay")]);
+        const pushesBefore = pushed.length;
+
+        await service.onSourceFileChanged(second, "created", ROOT);
+
+        // Still resolved, but the second file produced a push (paths changed).
+        expect(pushed.length).toBe(pushesBefore + 1);
+        expect(pushed[pushed.length - 1].resolved[implementationStatusKey("Act", "pay")]).toBe(
+            true,
+        );
+    });
+
+    it("only touches editors rooted at the changed file's root", async () => {
+        const { service, pushed } = createService({ resolveMap: { a: ["/p/a"] } });
+        await service.syncActivities("editor1", [entry("A", "jobType", "a")]);
+        const pushesBefore = pushed.length;
+
+        await service.onSourceFileChanged("/elsewhere/x.java", "changed", "/other-root");
+
+        expect(pushed.length).toBe(pushesBefore);
+    });
+
+    it("ignores a source change inside an excluded directory", async () => {
+        const excluded = "/work/proj/target/generated/Worker.java";
+        const { service, lastStatus, pushed } = createService({
+            resolveMap: {}, // unresolved at sync time
+            fileContents: { [excluded]: '@JobWorker(type = "pay")' },
+        });
+        await service.syncActivities("editor1", [entry("Act", "jobType", "pay")]);
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(false);
+        const pushesBefore = pushed.length;
+
+        // Were the excluded dir not filtered, this match would link and push.
+        await service.onSourceFileChanged(excluded, "created", ROOT);
+
+        expect(pushed.length).toBe(pushesBefore);
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(false);
+    });
+
+    it("reads at apply time so the last event's content wins when reads resolve out of order", async () => {
+        const worker = "/work/proj/src/Worker.java";
+        const { service, lastStatus, vsWorkspace } = createService({
+            resolveMap: { pay: [worker] },
+            fileContents: { [worker]: '@JobWorker(type = "pay")' },
+        });
+        await service.syncActivities("editor1", [entry("Act", "jobType", "pay")]);
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(true);
+
+        // A burst of two saves. Event #1 still matches but its read is made slow;
+        // event #2 removed the binding and reads fast. Reading before queuing
+        // (the old bug) would let the slow #1 apply last and wrongly re-link.
+        // Reading inside the per-editor tail serializes by event order, so #2's
+        // "no match" wins.
+        const reads = [
+            { content: '@JobWorker(type = "pay")', delay: 50 }, // event #1
+            { content: "class Worker {}", delay: 10 }, // event #2
+        ];
+        let call = 0;
+        vsWorkspace.readFile.mockImplementation(
+            () =>
+                new Promise<string>((resolve) => {
+                    const { content, delay } = reads[Math.min(call++, reads.length - 1)];
+                    setTimeout(() => resolve(content), delay);
+                }),
+        );
+
+        const first = service.onSourceFileChanged(worker, "changed", ROOT);
+        const second = service.onSourceFileChanged(worker, "changed", ROOT);
+        await vi.advanceTimersByTimeAsync(200);
+        await Promise.all([first, second]);
+
+        expect(lastStatus("editor1")![implementationStatusKey("Act", "pay")]).toBe(false);
+    });
+});
+
+describe("CodeLinkMapService — persistence", () => {
+    it("writes the artifact to the mirrored path with relative paths when enabled", async () => {
+        const abs = "/work/proj/src/main/java/com/example/A.java";
+        const { service, vsWorkspace, writes } = createService({
+            persist: true,
+            resolveMap: { "com.example.A": [abs] },
+        });
+
+        await service.syncActivities("editor1", [entry("Act", "javaClass", "com.example.A")]);
+        await service.writeArtifact("editor1");
+
+        expect(vsWorkspace.writeFile).toHaveBeenCalled();
+        const written = JSON.parse(writes[ARTIFACT]);
+        expect(written.bpmnFile).toBe("order.bpmn");
+        expect(written.entries[0].paths).toEqual(["src/main/java/com/example/A.java"]);
+    });
+
+    it("does not persist when the setting is off", async () => {
+        const { service, vsWorkspace } = createService({
+            persist: false,
+            resolveMap: { x: ["/p/x"] },
+        });
+
+        await service.syncActivities("editor1", [entry("A", "jobType", "x")]);
+        await vi.advanceTimersByTimeAsync(50);
+
+        expect(vsWorkspace.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("skips rewriting the artifact when the map content is unchanged", async () => {
+        const abs = "/work/proj/src/main/java/com/example/A.java";
+        const { service, vsWorkspace } = createService({
+            persist: true,
+            resolveMap: { "com.example.A": [abs] },
+            fileContents: { [abs]: "class A {}" },
+        });
+        const entries = [entry("Act", "javaClass", "com.example.A")];
+
+        await service.syncActivities("editor1", entries);
+        await service.writeArtifact("editor1");
+        await service.syncActivities("editor1", entries);
+        await service.writeArtifact("editor1");
+
+        expect(vsWorkspace.writeFile).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores an unreadable warm cache and resolves cold instead (persist on)", async () => {
+        const { service, locator } = createService({
+            persist: true,
+            resolveMap: { "com.example.A": ["/work/proj/src/A.java"] },
+            fileContents: { [ARTIFACT]: "{ this is not valid json" },
+        });
+
+        await service.syncActivities("editor1", [entry("Act", "javaClass", "com.example.A")]);
+
+        // Bad cache ⇒ empty map ⇒ everything is "new" ⇒ a normal batched resolve.
+        expect(locator.resolveMany).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows a write failure (never rejects the persist path)", async () => {
+        const { service, vsWorkspace } = createService({
+            persist: true,
+            resolveMap: { x: ["/p/x"] },
+        });
+        vsWorkspace.writeFile.mockRejectedValueOnce(new Error("EACCES"));
+
+        await service.syncActivities("editor1", [entry("A", "jobType", "x")]);
+        await expect(service.writeArtifact("editor1")).resolves.toBeUndefined();
+    });
+});
+
+describe("CodeLinkMapService — lifecycle", () => {
+    it("keeps each editor's map independent", async () => {
+        const { service, lastStatus } = createService({
+            resolveMap: { a: ["/p/a"], b: ["/p/b"] },
+        });
+
+        await service.syncActivities("editor1", [entry("A", "jobType", "a")]);
+        await service.syncActivities("editor2", [entry("B", "jobType", "b")]);
+        await service.syncActivities("editor1", []); // clear editor1
+
+        expect(lastStatus("editor1")).toEqual({});
+        expect(lastStatus("editor2")).toEqual({ [implementationStatusKey("B", "b")]: true });
+    });
+
+    it("shares one watcher per root and disposes it when the last editor closes", async () => {
+        const { service, vsWorkspace, createdWatchers } = createService({
+            resolveMap: { a: ["/p/a"] },
+        });
+
+        await service.syncActivities("editor1", [entry("A", "jobType", "a")]);
+        await service.syncActivities("editor2", [entry("A", "jobType", "a")]);
+
+        expect(vsWorkspace.createWatcher).toHaveBeenCalledTimes(1);
+
+        service.disposeEditor("editor1");
+        expect(createdWatchers[0].dispose).not.toHaveBeenCalled();
+
+        service.disposeEditor("editor2");
+        expect(createdWatchers[0].dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("disposeEditor on an unknown editor is a no-op", () => {
+        const { service } = createService();
+        expect(() => service.disposeEditor("never-opened")).not.toThrow();
+    });
+
+    it("dispose() tears down every outstanding watcher", async () => {
+        const { service, createdWatchers } = createService({ resolveMap: { a: ["/p/a"] } });
+        await service.syncActivities("editor1", [entry("A", "jobType", "a")]);
+
+        service.dispose();
+
+        expect(createdWatchers[0].dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it("logs and continues when a status push fails (hidden editor)", async () => {
+        const { service, editorStore, notifier } = createService({ resolveMap: { a: ["/p/a"] } });
+        editorStore.postMessage.mockRejectedValueOnce(new Error("The active editor is hidden."));
+
+        await expect(
+            service.syncActivities("editor1", [entry("A", "jobType", "a")]),
+        ).resolves.toBeUndefined();
+        expect(notifier.logInfo).toHaveBeenCalledWith(
+            expect.stringContaining("status push skipped"),
+        );
+    });
+
+    it("abandons a sync gracefully when the editor is disposed before it runs", async () => {
+        const { service, editorStore, locator, notifier, createdWatchers } = createService({
+            resolveMap: { a: ["/p/a"] },
+        });
+        // The editor is torn down between the sync being queued and runSync
+        // reaching attach: requireHandle now throws.
+        editorStore.requireHandle.mockImplementation(() => {
+            throw new Error("No editor found for id: editor1");
+        });
+
+        await expect(
+            service.syncActivities("editor1", [entry("A", "jobType", "a")]),
+        ).resolves.toBeUndefined();
+
+        // Attach bailed before acquiring a watcher or resolving anything, and the
+        // orphan state was dropped — nothing leaks.
+        expect(createdWatchers.length).toBe(0);
+        expect(locator.resolveMany).not.toHaveBeenCalled();
+        expect(notifier.logInfo).toHaveBeenCalledWith(
+            expect.stringContaining("disposed before attach"),
+        );
+    });
+
+    it("clears a rejected attach so a later sync retries instead of staying wedged", async () => {
+        const { service, artifactSvc, createdWatchers } = createService({
+            resolveMap: { a: ["/p/a"] },
+        });
+        // First attach rejects (e.g. a transient workspace-root lookup failure).
+        artifactSvc.getWorkspaceRoot.mockRejectedValueOnce(new Error("transient"));
+
+        await expect(
+            service.syncActivities("editor1", [entry("A", "jobType", "a")]),
+        ).rejects.toThrow("transient");
+
+        // The cached attachPromise was cleared, so the next sync re-attaches.
+        await expect(
+            service.syncActivities("editor1", [entry("A", "jobType", "a")]),
+        ).resolves.toBeUndefined();
+        expect(createdWatchers.length).toBe(1);
+    });
+});

--- a/libs/modeler-core/src/codeLink/service/CodeLinkMapService.ts
+++ b/libs/modeler-core/src/codeLink/service/CodeLinkMapService.ts
@@ -1,0 +1,574 @@
+import { posix } from "path";
+
+import {
+    asyncDebounce,
+    ImplementationEntry,
+    ImplementationKind,
+    ImplementationStatusQuery,
+    implementationStatusKey,
+} from "@miragon/bpmn-modeler-shared";
+
+import { EditorHandle } from "../../shared/domain/EditorSession";
+import { pathIsInsideExcludedDir } from "../../shared/domain/excludedDirs";
+import { NotifierPort, SettingsPort, WorkspacePort } from "../../shared/domain/hostPorts";
+import { EditorSessionStore } from "../../shared/infrastructure/EditorSessionStore";
+import { ArtifactService } from "../../shared/service/ArtifactService";
+import {
+    buildMapJson,
+    CodeLinkMapEntry,
+    fileMatchesEntry,
+    parseMapJson,
+    toAbsoluteEntries,
+    toRelative,
+} from "../domain/CodeLinkMap";
+import { JVM_EXTENSIONS, SCRIPT_WORKER_EXTENSIONS } from "../domain/ImplementationReference";
+import { ImplementationLocator } from "./ImplementationLocator";
+
+/** How a watched source file changed, as reported by the workspace watcher. */
+type SourceChangeKind = "created" | "changed" | "deleted";
+
+/** The implementation kinds the host knows how to resolve — a guard against a malformed message. */
+const KNOWN_KINDS: ReadonlySet<ImplementationKind> = new Set<ImplementationKind>([
+    "javaClass",
+    "delegateExpression",
+    "expression",
+    "externalTopic",
+    "jobType",
+]);
+
+// One watcher per workspace root covers every source language a worker/delegate
+// can live in — the same extension set the locator scans.
+const SOURCE_GLOB = `**/*.{${[...JVM_EXTENSIONS, ...SCRIPT_WORKER_EXTENSIONS].join(",")}}`;
+
+// Subfolder of `<configFolder>` the artifact is written under.
+const CODE_LINK_DIR = "code-link";
+
+// Long enough that a burst of saves collapses into one write, short enough that
+// the artifact is fresh by the time anyone reads it.
+const PERSIST_DEBOUNCE_MS = 2000;
+
+/** Per-open-editor state: the map plus the bookkeeping that keeps writes and syncs serial. */
+interface EditorState {
+    map: Map<string, CodeLinkMapEntry>;
+    documentPath: string | undefined;
+    documentFsPath: string | undefined;
+    workspaceRoot: string | undefined;
+    attachedRoot: string | undefined;
+    attachPromise: Promise<void> | undefined;
+    warmLoaded: boolean;
+    // Substantive (timestamp-free) signature of the last artifact written, so an
+    // unchanged map does not rewrite the file and churn `generatedAt`.
+    lastWrittenSignature: string | undefined;
+    // Per-editor debounced writer: a shared one would let two editors' resolve
+    // sets cross-corrupt each other's files.
+    persistDebounced: () => Promise<void>;
+    // Serialises this editor's sync/watcher work so interleaved awaits can't
+    // corrupt the map (two syncs, or a sync racing a file-change handler).
+    tail: Promise<void>;
+}
+
+/** A workspace-root watcher shared by every diagram rooted there, ref-counted by editor. */
+interface SourceWatcher {
+    handle: { dispose(): void };
+    refCount: number;
+}
+
+/**
+ * Owns the always-on activity→code map for every open BPMN editor.
+ *
+ * Driven by the webview: each {@link syncActivities} carries the diagram's
+ * implementation references, which are diffed against the held map so only the
+ * delta touches the filesystem — unchanged-and-resolved entries are verified
+ * with a single read, new/changed ones are batch-resolved in one scan, removed
+ * ones are dropped. The resolution status is pushed back for the context pad.
+ *
+ * A single ref-counted source-file watcher per workspace root keeps the map live
+ * as code is written: a saved file is tested only against this map's entries
+ * ({@link onSourceFileChanged}), linking an unresolved activity or unlinking a
+ * broken one without re-scanning the workspace.
+ *
+ * Disk persistence is opt-in (`miragon.bpmnModeler.persistCodeLinkMap`): when on,
+ * the map is loaded as a warm cache on first sync and written (debounced) after
+ * changes; when off, everything above still works purely in memory.
+ *
+ * `service` layer — no `vscode`; host facilities arrive through ports.
+ */
+export class CodeLinkMapService {
+    private readonly states = new Map<string, EditorState>();
+
+    private readonly watchers = new Map<string, SourceWatcher>();
+
+    constructor(
+        private readonly editorStore: EditorSessionStore,
+        private readonly locator: ImplementationLocator,
+        private readonly artifactSvc: ArtifactService,
+        private readonly vsWorkspace: WorkspacePort,
+        private readonly vsSettings: SettingsPort,
+        private readonly notifier: NotifierPort,
+        private readonly persistDebounceMs: number = PERSIST_DEBOUNCE_MS,
+    ) {}
+
+    /**
+     * Reconciles the held map with the diagram's current implementation
+     * references. Serialised per editor so concurrent posts can't interleave.
+     */
+    syncActivities(editorId: string, entries: readonly ImplementationEntry[]): Promise<void> {
+        const valid = entries.filter((entry) => this.isValidEntry(entry));
+        const state = this.getOrCreateState(editorId);
+        const run = () => this.runSync(editorId, state, valid);
+        // `.then(run, run)` so a rejected predecessor still lets this one run.
+        state.tail = state.tail.then(run, run);
+        return state.tail;
+    }
+
+    /**
+     * Tests one changed source file against every open map rooted at `root`,
+     * linking newly-implementing files and unlinking broken ones. O(changed
+     * file): no workspace scan, just one (OS-cached) read of the file per
+     * affected editor, taken inside each editor's serialized tail.
+     */
+    async onSourceFileChanged(
+        path: string,
+        changeKind: SourceChangeKind,
+        root: string,
+    ): Promise<void> {
+        // The watcher glob carries no exclude, so a save under build output
+        // (`target/`, `build/`, `dist/`, generated sources) still reaches here.
+        // Skip it to match the batched scan, which already filters EXCLUDED_DIRS.
+        if (pathIsInsideExcludedDir(path)) {
+            return;
+        }
+
+        const affected = [...this.states.entries()].filter(
+            ([, state]) => state.attachedRoot === root,
+        );
+        if (affected.length === 0) {
+            return;
+        }
+
+        // Queue synchronously and read fresh *inside* each editor's serialized
+        // tail. Reading here (before queuing) let two rapid saves' reads resolve
+        // out of order, so the apply that ran last could carry the older content
+        // and wedge the map at a stale state. Reading at apply time keeps every
+        // apply on current on-disk content, in event order.
+        for (const [editorId, state] of affected) {
+            const apply = () => this.applyFileChange(editorId, state, path, changeKind);
+            state.tail = state.tail.then(apply, apply);
+        }
+        await Promise.all(affected.map(([, state]) => state.tail));
+    }
+
+    /** Drops an editor's state and releases its share of the workspace-root watcher. */
+    disposeEditor(editorId: string): void {
+        const state = this.states.get(editorId);
+        if (!state) {
+            return;
+        }
+        this.states.delete(editorId);
+        if (state.attachedRoot) {
+            this.releaseWatcher(state.attachedRoot);
+        }
+    }
+
+    /** Disposes every watcher and clears all state — called once on feature shutdown. */
+    dispose(): void {
+        for (const watcher of this.watchers.values()) {
+            watcher.handle.dispose();
+        }
+        this.watchers.clear();
+        this.states.clear();
+    }
+
+    private async runSync(
+        editorId: string,
+        state: EditorState,
+        entries: ImplementationEntry[],
+    ): Promise<void> {
+        await this.attachToRoot(editorId, state);
+        // Attach is a no-op-and-bail when the editor was disposed before this
+        // sync ran (`attachedRoot` left unset). Continuing would resolve against
+        // an undefined document path and push to a gone webview — abandon it.
+        if (!state.attachedRoot) {
+            return;
+        }
+
+        // Mark loaded only once the persist-on path has actually run. Setting it
+        // unconditionally meant toggling `persistCodeLinkMap` on mid-session
+        // never loaded the artifact; leaving the flag false while persist is off
+        // costs only a cheap `persistEnabled()` check per sync.
+        if (!state.warmLoaded && this.persistEnabled()) {
+            await this.loadWarmCache(state);
+            state.warmLoaded = true;
+        }
+
+        const incoming = new Map(entries.map((entry) => [entry.activityId, entry]));
+        for (const activityId of [...state.map.keys()]) {
+            if (!incoming.has(activityId)) {
+                state.map.delete(activityId);
+            }
+        }
+
+        const toResolve: ImplementationEntry[] = [];
+        for (const entry of entries) {
+            const existing = state.map.get(entry.activityId);
+            const unchanged =
+                existing && existing.kind === entry.kind && existing.reference === entry.reference;
+            if (!unchanged) {
+                toResolve.push(entry);
+                continue;
+            }
+            // Unchanged + previously unresolved → leave it for the watcher to
+            // link rather than re-scanning the workspace on every edit.
+            if (!existing!.resolved) {
+                continue;
+            }
+            const stillMatching = await this.verifyEntry(existing!);
+            if (stillMatching.length > 0) {
+                existing!.paths = stillMatching;
+            } else {
+                existing!.resolved = false;
+                existing!.paths = [];
+                toResolve.push(entry);
+            }
+        }
+
+        if (toResolve.length > 0) {
+            const resolved = await this.locator.resolveMany(toResolve, state.documentFsPath);
+            for (const entry of toResolve) {
+                const paths = resolved.get(entry.activityId) ?? [];
+                state.map.set(entry.activityId, {
+                    activityId: entry.activityId,
+                    kind: entry.kind,
+                    reference: entry.reference,
+                    resolved: paths.length > 0,
+                    paths,
+                });
+            }
+        }
+
+        await this.pushStatus(editorId, state);
+        if (this.persistEnabled()) {
+            void state.persistDebounced();
+        }
+    }
+
+    private async applyFileChange(
+        editorId: string,
+        state: EditorState,
+        path: string,
+        changeKind: SourceChangeKind,
+    ): Promise<void> {
+        // Read at execution time (within the per-editor tail) so the content
+        // reflects the file as of *this* event's turn — see onSourceFileChanged.
+        // A delete carries no content. The read is OS-cached and cheap.
+        let content: string | undefined;
+        if (changeKind !== "deleted") {
+            try {
+                content = await this.vsWorkspace.readFile(path);
+            } catch {
+                content = undefined;
+            }
+        }
+
+        let dirty = false;
+        for (const entry of state.map.values()) {
+            if (this.updateEntryForFileChange(entry, path, changeKind, content)) {
+                dirty = true;
+            }
+        }
+        if (!dirty) {
+            return;
+        }
+        await this.pushStatus(editorId, state);
+        if (this.persistEnabled()) {
+            void state.persistDebounced();
+        }
+    }
+
+    /**
+     * Reconciles a single entry with one changed file. Returns whether the
+     * entry's resolution or paths changed (so the caller knows to push/persist).
+     */
+    private updateEntryForFileChange(
+        entry: CodeLinkMapEntry,
+        path: string,
+        changeKind: SourceChangeKind,
+        content: string | undefined,
+    ): boolean {
+        if (changeKind === "deleted") {
+            if (!entry.paths.includes(path)) {
+                return false;
+            }
+            entry.paths = entry.paths.filter((existing) => existing !== path);
+            if (entry.paths.length === 0) {
+                entry.resolved = false;
+            }
+            return true;
+        }
+
+        const matches = fileMatchesEntry(entry.kind, entry.reference, path, content);
+        const alreadyLinked = entry.paths.includes(path);
+
+        if (entry.resolved) {
+            if (alreadyLinked && !matches) {
+                // The edit removed the binding (deleted annotation, renamed class).
+                entry.paths = entry.paths.filter((existing) => existing !== path);
+                if (entry.paths.length === 0) {
+                    entry.resolved = false;
+                }
+                return true;
+            }
+            if (!alreadyLinked && matches) {
+                entry.paths.push(path);
+                return true;
+            }
+            return false;
+        }
+
+        // Unresolved activity, freshly-written implementation → link it (Case 2).
+        if (matches) {
+            entry.paths = [path];
+            entry.resolved = true;
+            return true;
+        }
+        return false;
+    }
+
+    /** Confirms an entry's linked files still implement it; returns the survivors. */
+    private async verifyEntry(entry: CodeLinkMapEntry): Promise<string[]> {
+        const stillMatching: string[] = [];
+        for (const path of entry.paths) {
+            let content: string;
+            try {
+                content = await this.vsWorkspace.readFile(path);
+            } catch {
+                // Linked file gone or unreadable → drop it; re-resolution decides.
+                continue;
+            }
+            if (fileMatchesEntry(entry.kind, entry.reference, path, content)) {
+                stillMatching.push(path);
+            }
+        }
+        return stillMatching;
+    }
+
+    private async pushStatus(editorId: string, state: EditorState): Promise<void> {
+        const resolved: Record<string, boolean> = {};
+        for (const entry of state.map.values()) {
+            resolved[implementationStatusKey(entry.activityId, entry.reference)] = entry.resolved;
+        }
+        try {
+            await this.editorStore.postMessage(editorId, new ImplementationStatusQuery(resolved));
+        } catch (error) {
+            // Expected when the editor is hidden (no retainContextWhenHidden):
+            // the webview re-syncs on reload, so a dropped push is harmless.
+            this.notifier.logInfo(`[code-link] status push skipped: ${(error as Error).message}`);
+        }
+    }
+
+    private attachToRoot(editorId: string, state: EditorState): Promise<void> {
+        if (state.attachedRoot) {
+            return Promise.resolve();
+        }
+        // Dedupe concurrent first syncs so the watcher is ref-counted once.
+        if (!state.attachPromise) {
+            // Never leave a rejected attach cached: clear it so a re-queued sync
+            // retries instead of re-awaiting a permanently-rejected promise.
+            state.attachPromise = this.doAttachToRoot(editorId, state).catch((error) => {
+                state.attachPromise = undefined;
+                throw error;
+            });
+        }
+        return state.attachPromise;
+    }
+
+    private async doAttachToRoot(editorId: string, state: EditorState): Promise<void> {
+        const handle = this.tryRequireHandle(editorId);
+        if (!handle) {
+            // The editor was disposed between this sync being queued and runSync
+            // reaching attach (tail-chaining can delay it past the close).
+            // Abandoning a sync for an editor being torn down is correct — drop
+            // the orphan state so nothing stays wedged, and return without
+            // throwing (an unawaited handler rejection would go unhandled).
+            this.notifier.logInfo(
+                `[code-link] editor ${editorId} disposed before attach; skipping sync`,
+            );
+            this.disposeEditor(editorId);
+            return;
+        }
+        // Capture document paths now so persistence keeps working even if the
+        // debounced write fires after the editor (and its handle) is gone.
+        state.documentPath = handle.documentPath();
+        state.documentFsPath = handle.documentFsPath();
+        const root = await this.artifactSvc.getWorkspaceRoot(posix.dirname(state.documentPath));
+        state.workspaceRoot = root;
+        state.attachedRoot = root;
+        this.acquireWatcher(root);
+    }
+
+    /** {@link EditorSessionStore.requireHandle} that yields `undefined` instead of throwing when the editor is gone. */
+    private tryRequireHandle(editorId: string): EditorHandle | undefined {
+        try {
+            return this.editorStore.requireHandle(editorId);
+        } catch {
+            return undefined;
+        }
+    }
+
+    private acquireWatcher(root: string): void {
+        let watcher = this.watchers.get(root);
+        if (!watcher) {
+            const handle = this.vsWorkspace.createWatcher(root, SOURCE_GLOB, {
+                onCreate: (path) => void this.onSourceFileChanged(path, "created", root),
+                onChange: (path) => void this.onSourceFileChanged(path, "changed", root),
+                onDelete: (path) => void this.onSourceFileChanged(path, "deleted", root),
+            });
+            watcher = { handle, refCount: 0 };
+            this.watchers.set(root, watcher);
+        }
+        watcher.refCount += 1;
+    }
+
+    private releaseWatcher(root: string): void {
+        const watcher = this.watchers.get(root);
+        if (!watcher) {
+            return;
+        }
+        watcher.refCount -= 1;
+        if (watcher.refCount <= 0) {
+            watcher.handle.dispose();
+            this.watchers.delete(root);
+        }
+    }
+
+    private async loadWarmCache(state: EditorState): Promise<void> {
+        const artifactPath = this.artifactPath(state);
+        if (!artifactPath) {
+            return;
+        }
+        let raw: string;
+        try {
+            raw = await this.vsWorkspace.readFile(artifactPath);
+        } catch {
+            return; // No prior artifact — cold open, the diff resolves everything.
+        }
+        const json = parseMapJson(raw);
+        if (!json) {
+            this.notifier.logWarning(
+                `[code-link] ignoring unreadable warm cache at ${artifactPath}`,
+            );
+            return;
+        }
+        // Belt-and-suspenders: parseMapJson already rejects malformed entries, so
+        // the build should never throw — but a warm cache must never crash the
+        // open, so degrade to "no warm cache" (clean map) if it somehow does.
+        try {
+            for (const entry of toAbsoluteEntries(json, state.workspaceRoot!)) {
+                state.map.set(entry.activityId, entry);
+            }
+        } catch (error) {
+            state.map.clear();
+            this.notifier.logWarning(
+                `[code-link] discarding malformed warm cache at ${artifactPath}: ${(error as Error).message}`,
+            );
+            return;
+        }
+        this.notifier.logInfo(
+            `[code-link] warm cache: loaded ${state.map.size} entr(y/ies) from ${artifactPath}`,
+        );
+    }
+
+    /**
+     * Writes the artifact, skipping the write when the map's substantive content
+     * is unchanged. Public so persistence can be asserted directly without
+     * waiting on the debounce; production calls it through `persistDebounced`.
+     */
+    async writeArtifact(editorId: string): Promise<void> {
+        try {
+            const state = this.states.get(editorId);
+            if (!state || !state.workspaceRoot || !state.documentPath) {
+                return; // Editor disposed before the debounced write fired.
+            }
+            const artifactPath = this.artifactPath(state);
+            if (!artifactPath) {
+                return;
+            }
+            const entries = [...state.map.values()];
+            const json = buildMapJson({
+                bpmnFile: toRelative(state.documentPath, state.workspaceRoot),
+                generatedAt: "",
+                workspaceRoot: state.workspaceRoot,
+                entries,
+            });
+            // Compare everything but the timestamp so an unchanged map is a no-op.
+            const signature = JSON.stringify({ bpmnFile: json.bpmnFile, entries: json.entries });
+            if (signature === state.lastWrittenSignature) {
+                return;
+            }
+            state.lastWrittenSignature = signature;
+            json.generatedAt = new Date().toISOString();
+            await this.vsWorkspace.writeFile(artifactPath, JSON.stringify(json, null, 2));
+        } catch (error) {
+            this.notifier.logWarning(
+                `[code-link] failed to persist map: ${(error as Error).message}`,
+            );
+        }
+    }
+
+    /**
+     * Artifact path mirrors the diagram's workspace-relative location under
+     * `<configFolder>/code-link/` (e.g. `…/order.bpmn` →
+     * `.camunda/code-link/…/order.bpmn.json`). Mirroring the path — rather than
+     * using the bare basename — keeps two same-named diagrams in different
+     * folders from clobbering one file.
+     */
+    private artifactPath(state: EditorState): string | undefined {
+        if (!state.workspaceRoot || !state.documentPath) {
+            return undefined;
+        }
+        const relBpmn = toRelative(state.documentPath, state.workspaceRoot);
+        return posix.join(
+            state.workspaceRoot,
+            this.vsSettings.getConfigFolder(),
+            CODE_LINK_DIR,
+            `${relBpmn}.json`,
+        );
+    }
+
+    private getOrCreateState(editorId: string): EditorState {
+        let state = this.states.get(editorId);
+        if (!state) {
+            state = {
+                map: new Map(),
+                documentPath: undefined,
+                documentFsPath: undefined,
+                workspaceRoot: undefined,
+                attachedRoot: undefined,
+                attachPromise: undefined,
+                warmLoaded: false,
+                lastWrittenSignature: undefined,
+                persistDebounced: asyncDebounce(
+                    () => this.writeArtifact(editorId),
+                    this.persistDebounceMs,
+                ),
+                tail: Promise.resolve(),
+            };
+            this.states.set(editorId, state);
+        }
+        return state;
+    }
+
+    private persistEnabled(): boolean {
+        return this.vsSettings.getPersistCodeLinkMap();
+    }
+
+    private isValidEntry(entry: ImplementationEntry): boolean {
+        return (
+            typeof entry.activityId === "string" &&
+            entry.activityId.length > 0 &&
+            typeof entry.reference === "string" &&
+            entry.reference.length > 0 &&
+            KNOWN_KINDS.has(entry.kind)
+        );
+    }
+}

--- a/libs/modeler-core/src/codeLink/service/ImplementationLocator.spec.ts
+++ b/libs/modeler-core/src/codeLink/service/ImplementationLocator.spec.ts
@@ -1,0 +1,360 @@
+import { posix } from "path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ImplementationLocator } from "./ImplementationLocator";
+
+/**
+ * `findFiles` is driven per test by a `glob → paths` function so each test
+ * controls exactly what the (mocked) workspace search returns for the
+ * filename/source globs the locator builds. `readFile` reads from a content map.
+ */
+function createLocator(opts: {
+    findFiles?: (glob: string) => string[];
+    fileContents?: Record<string, string>;
+    folders?: string[];
+}) {
+    const fileContents = opts.fileContents ?? {};
+    const folders = opts.folders ?? ["/"];
+    const vsWorkspace = {
+        findFiles: vi
+            .fn()
+            .mockImplementation((glob: string) =>
+                Promise.resolve(opts.findFiles ? opts.findFiles(glob) : []),
+            ),
+        readFile: vi
+            .fn()
+            .mockImplementation((path: string) =>
+                path in fileContents
+                    ? Promise.resolve(fileContents[path])
+                    : Promise.reject(new Error("not found")),
+            ),
+        readDirectory: vi.fn().mockRejectedValue(new Error("ENOENT")),
+        findWorkspaceFolderForDocument: vi.fn(() => folders[0]),
+        getWorkspaceFolderPaths: vi.fn(() => folders),
+        getDocumentDirectory: vi.fn((document: string) => posix.dirname(document)),
+    };
+    const notifier = { logInfo: vi.fn(), logWarning: vi.fn() };
+    const locator = new ImplementationLocator(vsWorkspace as never, notifier as never);
+    return { locator, vsWorkspace, notifier };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("ImplementationLocator — javaClass", () => {
+    it("resolves the FQCN to the matching class file without reading content", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => ["/src/main/java/com/example/MyDelegate.java"],
+        });
+
+        const result = await locator.resolve("com.example.MyDelegate", "javaClass");
+
+        expect(result).toEqual({
+            kind: "matches",
+            paths: ["/src/main/java/com/example/MyDelegate.java"],
+            readFailures: [],
+        });
+        // The path is the answer; the file content is irrelevant.
+        expect(vsWorkspace.readFile).not.toHaveBeenCalled();
+    });
+
+    it("builds a package-path glob across the JVM source extensions", async () => {
+        const { locator, vsWorkspace } = createLocator({ findFiles: () => [] });
+
+        await locator.resolve("com.example.MyDelegate", "javaClass");
+
+        expect(vsWorkspace.findFiles).toHaveBeenCalledWith(
+            "**/com/example/MyDelegate.{java,kt,groovy,scala}",
+        );
+    });
+
+    it("returns empty matches when no class file is found", async () => {
+        const { locator } = createLocator({ findFiles: () => [] });
+
+        const result = await locator.resolve("com.example.Missing", "javaClass");
+
+        expect(result).toEqual({ kind: "matches", paths: [], readFailures: [] });
+    });
+
+    it("returns multiple matches when the class exists under several roots", async () => {
+        const { locator } = createLocator({
+            findFiles: () => ["/a/com/example/X.java", "/b/com/example/X.kt"],
+        });
+
+        const result = await locator.resolve("com.example.X", "javaClass");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/a/com/example/X.java", "/b/com/example/X.kt"]);
+        }
+    });
+});
+
+describe("ImplementationLocator — delegateExpression / expression", () => {
+    it("finds the implementing class by capitalised bean name", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: (glob) => (glob.includes("MyBean") ? ["/src/MyBean.java"] : []),
+        });
+
+        const result = await locator.resolve("${myBean}", "delegateExpression");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/src/MyBean.java"]);
+        }
+        expect(vsWorkspace.findFiles).toHaveBeenCalledWith("**/MyBean.{java,kt,groovy,scala}");
+    });
+
+    it("derives the class from the leading id of an expression", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: (glob) => (glob.includes("Svc") ? ["/src/Svc.java"] : []),
+        });
+
+        const result = await locator.resolve("${svc.run()}", "expression");
+
+        expect(result.kind).toBe("matches");
+        expect(vsWorkspace.findFiles).toHaveBeenCalledWith("**/Svc.{java,kt,groovy,scala}");
+    });
+
+    it("falls back to a bean-annotation content search when no class file matches", async () => {
+        const { locator } = createLocator({
+            // Filename glob (contains "MyBean") finds nothing; the source scan does.
+            findFiles: (glob) => (glob.includes("MyBean") ? [] : ["/src/CustomName.java"]),
+            fileContents: {
+                "/src/CustomName.java": '@Service("myBean")\nclass CustomName {}',
+            },
+        });
+
+        const result = await locator.resolve("${myBean}", "delegateExpression");
+
+        expect(result).toEqual({
+            kind: "matches",
+            paths: ["/src/CustomName.java"],
+            readFailures: [],
+        });
+    });
+
+    it("returns empty matches when the expression has no leading bean id", async () => {
+        const { locator, vsWorkspace } = createLocator({ findFiles: () => [] });
+
+        const result = await locator.resolve("${ 1 + 2 }", "expression");
+
+        expect(result).toEqual({ kind: "matches", paths: [], readFailures: [] });
+        // No bean id → nothing to search for.
+        expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
+    });
+});
+
+describe("ImplementationLocator — externalTopic / jobType", () => {
+    it("finds a job worker by the quoted job type literal", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => ["/src/Worker.java", "/src/Other.java"],
+            fileContents: {
+                "/src/Worker.java": '@JobWorker(type = "payment-service")\nvoid handle() {}',
+                "/src/Other.java": "class Other {}",
+            },
+        });
+
+        const result = await locator.resolve("payment-service", "jobType");
+
+        expect(result).toEqual({
+            kind: "matches",
+            paths: ["/src/Worker.java"],
+            readFailures: [],
+        });
+        // Source scan spans JVM + JS/TS worker extensions.
+        expect(vsWorkspace.findFiles).toHaveBeenCalledWith("**/*.{java,kt,groovy,scala,js,ts}");
+    });
+
+    it("finds a JS/TS worker by its taskType literal", async () => {
+        const { locator } = createLocator({
+            findFiles: () => ["/src/worker.ts"],
+            fileContents: { "/src/worker.ts": 'createWorker({ taskType: "payment-service" })' },
+        });
+
+        const result = await locator.resolve("payment-service", "jobType");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/src/worker.ts"]);
+        }
+    });
+
+    it("finds an external-task subscription by topic literal", async () => {
+        const { locator } = createLocator({
+            findFiles: () => ["/src/Sub.java"],
+            fileContents: {
+                "/src/Sub.java": '@ExternalTaskSubscription("payment-topic")\nclass Sub {}',
+            },
+        });
+
+        const result = await locator.resolve("payment-topic", "externalTopic");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/src/Sub.java"]);
+        }
+    });
+
+    it("returns multiple matches when several files declare the literal", async () => {
+        const { locator } = createLocator({
+            findFiles: () => ["/src/A.java", "/src/B.java"],
+            fileContents: {
+                "/src/A.java": '@JobWorker(type="t")',
+                "/src/B.java": 'taskType: "t"',
+            },
+        });
+
+        const result = await locator.resolve("t", "jobType");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/src/A.java", "/src/B.java"]);
+        }
+    });
+
+    it("reports all-unreadable when every candidate read fails", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => ["/src/A.java"],
+        });
+        vsWorkspace.readFile.mockRejectedValue(new Error("EACCES"));
+
+        const result = await locator.resolve("t", "jobType");
+
+        expect(result.kind).toBe("all-unreadable");
+        if (result.kind === "all-unreadable") {
+            expect(result.attempted).toBe(1);
+            expect(result.failures[0]).toContain("EACCES");
+        }
+    });
+
+    it("includes partial read failures alongside a successful match", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => ["/src/bad.java", "/src/good.java"],
+            fileContents: { "/src/good.java": 'type = "t"' },
+        });
+        vsWorkspace.readFile.mockImplementationOnce(() => Promise.reject(new Error("EACCES")));
+
+        const result = await locator.resolve("t", "jobType");
+
+        expect(result.kind).toBe("matches");
+        if (result.kind === "matches") {
+            expect(result.paths).toEqual(["/src/good.java"]);
+            expect(result.readFailures).toHaveLength(1);
+        }
+    });
+});
+
+describe("ImplementationLocator — no search scope", () => {
+    it("returns no-search-scope when no folder is open and no source uri given", async () => {
+        const { locator, vsWorkspace } = createLocator({ folders: [], findFiles: () => [] });
+
+        const result = await locator.resolve("com.example.X", "javaClass");
+
+        expect(result).toEqual({ kind: "no-search-scope" });
+        expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
+    });
+});
+
+describe("ImplementationLocator — resolveMany", () => {
+    it("returns an empty map and does no search for an empty entry list", async () => {
+        const { locator, vsWorkspace } = createLocator({ findFiles: () => [] });
+
+        const result = await locator.resolveMany([]);
+
+        expect(result.size).toBe(0);
+        expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
+    });
+
+    it("maps every input id, with unresolved references mapping to []", async () => {
+        const { locator } = createLocator({
+            findFiles: () => ["/src/com/example/Charge.java"],
+        });
+
+        const result = await locator.resolveMany([
+            { activityId: "A", kind: "javaClass", reference: "com.example.Charge" },
+            { activityId: "B", kind: "javaClass", reference: "com.example.Missing" },
+        ]);
+
+        expect(result.get("A")).toEqual(["/src/com/example/Charge.java"]);
+        expect(result.get("B")).toEqual([]);
+    });
+
+    it("settles javaClass by path alone — no file reads", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => ["/src/com/example/Charge.java", "/src/Other.java"],
+        });
+
+        await locator.resolveMany([
+            { activityId: "A", kind: "javaClass", reference: "com.example.Charge" },
+        ]);
+
+        expect(vsWorkspace.readFile).not.toHaveBeenCalled();
+    });
+
+    it("resolves all kinds in a single candidate scan", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => [
+                "/src/com/example/Charge.java",
+                "/src/MyBean.java",
+                "/src/Worker.java",
+            ],
+            fileContents: {
+                "/src/com/example/Charge.java": "class Charge {}",
+                "/src/MyBean.java": "class MyBean {}",
+                "/src/Worker.java": '@JobWorker(type = "pay")',
+            },
+        });
+
+        const result = await locator.resolveMany([
+            { activityId: "A", kind: "javaClass", reference: "com.example.Charge" },
+            { activityId: "B", kind: "delegateExpression", reference: "${myBean}" },
+            { activityId: "C", kind: "jobType", reference: "pay" },
+        ]);
+
+        expect(result.get("A")).toEqual(["/src/com/example/Charge.java"]);
+        expect(result.get("B")).toEqual(["/src/MyBean.java"]);
+        expect(result.get("C")).toEqual(["/src/Worker.java"]);
+        // One candidate scan, not one per entry.
+        expect(vsWorkspace.findFiles).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to a bean annotation when the class file name differs", async () => {
+        const { locator } = createLocator({
+            findFiles: () => ["/src/Renamed.java"],
+            fileContents: { "/src/Renamed.java": '@Service("myBean")\nclass Renamed {}' },
+        });
+
+        const result = await locator.resolveMany([
+            { activityId: "A", kind: "delegateExpression", reference: "${myBean}" },
+        ]);
+
+        expect(result.get("A")).toEqual(["/src/Renamed.java"]);
+    });
+
+    it("reads no files when only path-decidable entries are present", async () => {
+        const { locator, vsWorkspace } = createLocator({
+            findFiles: () => ["/src/MyBean.java"],
+        });
+
+        await locator.resolveMany([
+            { activityId: "A", kind: "delegateExpression", reference: "${myBean}" },
+        ]);
+
+        // MyBean matches by file name, so the content pass is skipped entirely.
+        expect(vsWorkspace.readFile).not.toHaveBeenCalled();
+    });
+
+    it("returns all-empty when there is no search scope", async () => {
+        const { locator, vsWorkspace } = createLocator({ folders: [], findFiles: () => [] });
+
+        const result = await locator.resolveMany([
+            { activityId: "A", kind: "javaClass", reference: "com.example.X" },
+        ]);
+
+        expect(result.get("A")).toEqual([]);
+        expect(vsWorkspace.findFiles).not.toHaveBeenCalled();
+    });
+});

--- a/libs/modeler-core/src/codeLink/service/ImplementationLocator.ts
+++ b/libs/modeler-core/src/codeLink/service/ImplementationLocator.ts
@@ -1,0 +1,322 @@
+import { posix } from "path";
+
+import { ImplementationEntry } from "@miragon/bpmn-modeler-shared";
+
+import { NotifierPort, WorkspacePort } from "../../shared/domain/hostPorts";
+import {
+    ContentSearchResult,
+    escapeRegex,
+    findFilesExcluding,
+    searchFilesContent,
+} from "../../shared/service/workspaceFileSearch";
+import {
+    contentDeclaresBean,
+    contentImplementsLiteral,
+    matchesBeanClassName,
+    matchesClassPath,
+} from "../domain/CodeLinkMap";
+import {
+    beanToClassName,
+    extractBeanName,
+    fqcnToGlobPath,
+    ImplementationKind,
+    JVM_EXTENSIONS,
+    SCRIPT_WORKER_EXTENSIONS,
+} from "../domain/ImplementationReference";
+
+// Max length of a reference echoed back into a user-facing log line.
+const REFERENCE_DISPLAY_LIMIT = 120;
+
+// Brace-expansion glob fragments. VS Code's `findFiles` expands `{a,b}`.
+const JVM_GLOB_EXT = `{${JVM_EXTENSIONS.join(",")}}`;
+const ALL_SOURCE_EXTENSIONS = [...JVM_EXTENSIONS, ...SCRIPT_WORKER_EXTENSIONS];
+const SOURCE_GLOB_EXT = `{${ALL_SOURCE_EXTENSIONS.join(",")}}`;
+
+/**
+ * Outcome of locating the source file(s) implementing a task reference.
+ * Mirrors `navigation`'s `LocateResult` so the navigation service can be a
+ * near-clone.
+ *
+ * - `no-search-scope` — nothing to search (no folder open, no source URI).
+ * - `all-unreadable` — candidates were found but every read failed.
+ * - `matches` — `paths` may be empty (nothing matched) or hold one/many hits.
+ */
+export type LocateImplementationResult =
+    | { kind: "no-search-scope" }
+    | { kind: "all-unreadable"; attempted: number; failures: string[] }
+    | { kind: "matches"; paths: string[]; readFailures: string[] };
+
+/**
+ * Resolves a Camunda implementation reference to workspace source file(s),
+ * picking a per-kind strategy and building on the shared workspace-search
+ * primitives ({@link findFilesExcluding} / {@link searchFilesContent}).
+ *
+ * Deterministic for `javaClass` (FQCN → exact class-file glob); heuristic for
+ * the rest. Heuristics are safe because a wrong/missing guess surfaces as an
+ * info notification or a QuickPick — never a bad silent jump — handled by the
+ * {@link ImplementationNavigationService} that consumes this result.
+ */
+export class ImplementationLocator {
+    constructor(
+        private readonly vsWorkspace: WorkspacePort,
+        private readonly notifier: NotifierPort,
+    ) {}
+
+    async resolve(
+        reference: string,
+        kind: ImplementationKind,
+        sourceDocumentPath?: string,
+    ): Promise<LocateImplementationResult> {
+        this.notifier.logInfo(
+            `[code-link] resolving ${kind} reference="${truncate(reference)}" ` +
+                `sourceUri=${sourceDocumentPath ?? "<none>"}`,
+        );
+
+        if (kind === "javaClass") {
+            return this.resolveJavaClass(reference, sourceDocumentPath);
+        }
+        if (kind === "delegateExpression" || kind === "expression") {
+            return this.resolveBean(reference, sourceDocumentPath);
+        }
+        // externalTopic | jobType — both resolve by searching for the literal.
+        return this.resolveLiteral(reference, sourceDocumentPath);
+    }
+
+    /**
+     * Resolves many references in a single workspace pass — the batched
+     * counterpart to {@link resolve}, built for the always-on map where
+     * resolving the drift per entry would re-walk the tree N times.
+     *
+     * One candidate scan; then a content-free pass settles `javaClass` and
+     * filename-matched beans by path alone, and the remaining content-based
+     * references (literals, and beans whose class file is named differently)
+     * are decided by reading each candidate at most once and testing every
+     * outstanding pattern against it.
+     *
+     * @returns activity id → matched absolute paths. Every input id is present;
+     *   an unresolved reference (or no search scope) maps to an empty array.
+     */
+    async resolveMany(
+        entries: readonly ImplementationEntry[],
+        sourceDocumentPath?: string,
+    ): Promise<Map<string, string[]>> {
+        const result = new Map<string, string[]>(entries.map((entry) => [entry.activityId, []]));
+        if (entries.length === 0) {
+            return result;
+        }
+
+        this.notifier.logInfo(`[code-link] batch-resolving ${entries.length} reference(s)`);
+        const sources = await this.collectSources(
+            SOURCE_GLOB_EXT,
+            ALL_SOURCE_EXTENSIONS,
+            sourceDocumentPath,
+        );
+        if (sources === undefined || sources.length === 0) {
+            return result;
+        }
+
+        // Path-only pass: anything decidable without reading a file. Whatever is
+        // left (literals, and beans with no matching class-file name) needs a
+        // content scan and is queued with the bean id it should look for.
+        const contentTargets: { activityId: string; reference: string; bean?: string }[] = [];
+        for (const entry of entries) {
+            if (entry.kind === "javaClass") {
+                result.set(
+                    entry.activityId,
+                    sources.filter((path) => matchesClassPath(entry.reference, path)),
+                );
+                continue;
+            }
+            if (entry.kind === "delegateExpression" || entry.kind === "expression") {
+                const bean = extractBeanName(entry.reference);
+                if (!bean) {
+                    continue;
+                }
+                const byName = sources.filter((path) => matchesBeanClassName(bean, path));
+                if (byName.length > 0) {
+                    result.set(entry.activityId, byName);
+                } else {
+                    contentTargets.push({
+                        activityId: entry.activityId,
+                        reference: entry.reference,
+                        bean,
+                    });
+                }
+                continue;
+            }
+            // externalTopic | jobType — literal content search only.
+            contentTargets.push({ activityId: entry.activityId, reference: entry.reference });
+        }
+
+        if (contentTargets.length === 0) {
+            return result;
+        }
+
+        // Single read per candidate, every outstanding pattern tested against it.
+        await Promise.all(
+            sources.map(async (path) => {
+                let content: string;
+                try {
+                    content = await this.vsWorkspace.readFile(path);
+                } catch {
+                    return;
+                }
+                for (const target of contentTargets) {
+                    const matched =
+                        target.bean !== undefined
+                            ? contentDeclaresBean(content, target.bean)
+                            : contentImplementsLiteral(content, target.reference);
+                    if (matched) {
+                        result.get(target.activityId)!.push(path);
+                    }
+                }
+            }),
+        );
+        return result;
+    }
+
+    /**
+     * `camunda:class` is a fully-qualified class name, so the file path itself
+     * is the answer — no content check needed. The package path is matched as a
+     * suffix so the class is found under any source root (`src/main/java`, …).
+     */
+    private async resolveJavaClass(
+        fqcn: string,
+        sourceDocumentPath: string | undefined,
+    ): Promise<LocateImplementationResult> {
+        const packagePath = fqcnToGlobPath(fqcn);
+        const paths = await findFilesExcluding(
+            this.vsWorkspace,
+            `**/${packagePath}.${JVM_GLOB_EXT}`,
+            {
+                sourceDocumentPath,
+                logger: this.notifier,
+                matchesWalkedFile: (path) =>
+                    JVM_EXTENSIONS.some((ext) => path.endsWith(`${packagePath}.${ext}`)),
+            },
+        );
+        if (paths === undefined) {
+            return { kind: "no-search-scope" };
+        }
+        return { kind: "matches", paths, readFailures: [] };
+    }
+
+    /**
+     * Delegate / expression bindings name a bean, not a file. First guess the
+     * implementing class by capitalising the bean id and searching by filename;
+     * if that finds nothing, fall back to a content search for a Spring/CDI
+     * bean-naming annotation carrying the exact bean id.
+     */
+    private async resolveBean(
+        expression: string,
+        sourceDocumentPath: string | undefined,
+    ): Promise<LocateImplementationResult> {
+        const bean = extractBeanName(expression);
+        if (!bean) {
+            this.notifier.logInfo(
+                `[code-link] no bean id found in expression "${truncate(expression)}"`,
+            );
+            return { kind: "matches", paths: [], readFailures: [] };
+        }
+
+        const className = beanToClassName(bean);
+        const byName = await findFilesExcluding(
+            this.vsWorkspace,
+            `**/${className}.${JVM_GLOB_EXT}`,
+            {
+                sourceDocumentPath,
+                logger: this.notifier,
+                matchesWalkedFile: (path) =>
+                    JVM_EXTENSIONS.some((ext) => posix.basename(path) === `${className}.${ext}`),
+            },
+        );
+        if (byName === undefined) {
+            return { kind: "no-search-scope" };
+        }
+        if (byName.length > 0) {
+            return { kind: "matches", paths: byName, readFailures: [] };
+        }
+
+        // Fallback: the class file name differs from the bean (e.g. an
+        // explicitly named `@Service("myBean")`), so scan source content.
+        const sources = await this.collectSources(JVM_GLOB_EXT, JVM_EXTENSIONS, sourceDocumentPath);
+        if (sources === undefined) {
+            return { kind: "no-search-scope" };
+        }
+        const pattern = beanAnnotationPattern(bean);
+        return toResult(
+            sources,
+            await searchFilesContent(this.vsWorkspace, sources, pattern, this.notifier),
+        );
+    }
+
+    /**
+     * External-task topics and Zeebe job types are free-form literals declared
+     * on the worker side, so the only reliable signal is the quoted literal in
+     * source — e.g. `@ExternalTaskSubscription("payment-topic")`,
+     * `@JobWorker(type = "payment-service")`, or `taskType: "payment-service"`.
+     */
+    private async resolveLiteral(
+        literal: string,
+        sourceDocumentPath: string | undefined,
+    ): Promise<LocateImplementationResult> {
+        const sources = await this.collectSources(
+            SOURCE_GLOB_EXT,
+            ALL_SOURCE_EXTENSIONS,
+            sourceDocumentPath,
+        );
+        if (sources === undefined) {
+            return { kind: "no-search-scope" };
+        }
+        const pattern = new RegExp(`["']${escapeRegex(literal)}["']`);
+        return toResult(
+            sources,
+            await searchFilesContent(this.vsWorkspace, sources, pattern, this.notifier),
+        );
+    }
+
+    /**
+     * Lists candidate source files for a content scan, with the same
+     * findFiles → fs-walk fallback the deterministic paths use.
+     */
+    private collectSources(
+        globExt: string,
+        extensions: readonly string[],
+        sourceDocumentPath: string | undefined,
+    ): Promise<string[] | undefined> {
+        return findFilesExcluding(this.vsWorkspace, `**/*.${globExt}`, {
+            sourceDocumentPath,
+            logger: this.notifier,
+            matchesWalkedFile: (path) => extensions.some((ext) => path.endsWith(`.${ext}`)),
+        });
+    }
+}
+
+/**
+ * Matches a Spring/CDI bean-naming annotation that carries the exact bean id,
+ * e.g. `@Service("myBean")` or `@Component(value = "myBean")`.
+ */
+function beanAnnotationPattern(bean: string): RegExp {
+    return new RegExp(
+        `@(?:Component|Service|Repository|Named|Bean)\\s*\\(\\s*(?:value\\s*=\\s*)?["']${escapeRegex(
+            bean,
+        )}["']`,
+    );
+}
+
+function toResult(candidates: string[], search: ContentSearchResult): LocateImplementationResult {
+    if (search.allUnreadable) {
+        return {
+            kind: "all-unreadable",
+            attempted: candidates.length,
+            failures: search.readFailures,
+        };
+    }
+    return { kind: "matches", paths: search.matches, readFailures: search.readFailures };
+}
+
+function truncate(value: string): string {
+    return value.length <= REFERENCE_DISPLAY_LIMIT
+        ? value
+        : `${value.slice(0, REFERENCE_DISPLAY_LIMIT - 1)}…`;
+}

--- a/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.spec.ts
+++ b/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.spec.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { LocateImplementationResult } from "./ImplementationLocator";
+import { ImplementationNavigationService } from "./ImplementationNavigationService";
+
+function createService(result: LocateImplementationResult) {
+    const locator = {
+        resolve: vi.fn().mockResolvedValue(result),
+    };
+    const notifier = {
+        showInfo: vi.fn(),
+        showError: vi.fn(),
+        logInfo: vi.fn(),
+        logWarning: vi.fn(),
+        logError: vi.fn(),
+        withProgress: vi.fn(<T>(_title: string, task: () => Promise<T>): Promise<T> => task()),
+        openDocument: vi.fn().mockResolvedValue(undefined),
+    };
+    const picker = {
+        pickReferencedModel: vi.fn(),
+    };
+    const service = new ImplementationNavigationService(
+        locator as never,
+        notifier as never,
+        picker as never,
+    );
+    return { service, locator, notifier, picker };
+}
+
+describe("ImplementationNavigationService.navigate", () => {
+    it("wraps the search in a status-bar progress indicator", async () => {
+        const { service, notifier } = createService({
+            kind: "matches",
+            paths: ["/src/MyDelegate.java"],
+            readFailures: [],
+        });
+
+        await service.navigate("com.example.MyDelegate", "javaClass");
+
+        expect(notifier.withProgress).toHaveBeenCalledTimes(1);
+        const [title] = notifier.withProgress.mock.calls[0];
+        expect(title).toContain("com.example.MyDelegate");
+        expect(title).toContain("class");
+    });
+
+    it("delegates to the locator with the same arguments", async () => {
+        const { service, locator } = createService({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
+        });
+
+        await service.navigate("payment-service", "jobType", "/x.bpmn");
+
+        expect(locator.resolve).toHaveBeenCalledWith("payment-service", "jobType", "/x.bpmn");
+    });
+
+    it("opens the file directly when the locator returns a single match", async () => {
+        const { service, picker, notifier } = createService({
+            kind: "matches",
+            paths: ["/src/MyDelegate.java"],
+            readFailures: [],
+        });
+
+        await service.navigate("com.example.MyDelegate", "javaClass");
+
+        expect(picker.pickReferencedModel).not.toHaveBeenCalled();
+        expect(notifier.openDocument).toHaveBeenCalledWith("/src/MyDelegate.java");
+    });
+
+    it("opens the QuickPick selection when the locator returns multiple matches", async () => {
+        const { service, picker, notifier } = createService({
+            kind: "matches",
+            paths: ["/src/A.java", "/src/B.java"],
+            readFailures: [],
+        });
+        picker.pickReferencedModel.mockResolvedValue("/src/B.java");
+
+        await service.navigate("t", "jobType");
+
+        expect(picker.pickReferencedModel).toHaveBeenCalledWith(["/src/A.java", "/src/B.java"]);
+        expect(notifier.openDocument).toHaveBeenCalledWith("/src/B.java");
+    });
+
+    it("does not open anything when the user cancels the QuickPick", async () => {
+        const { service, picker, notifier } = createService({
+            kind: "matches",
+            paths: ["/src/A.java", "/src/B.java"],
+            readFailures: [],
+        });
+        picker.pickReferencedModel.mockResolvedValue(undefined);
+
+        await service.navigate("t", "jobType");
+
+        expect(notifier.openDocument).not.toHaveBeenCalled();
+    });
+
+    it("shows an info notification when matches is empty", async () => {
+        const { service, notifier } = createService({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
+        });
+
+        await service.navigate("payment-topic", "externalTopic");
+
+        expect(notifier.showInfo).toHaveBeenCalledWith(expect.stringContaining("payment-topic"));
+        expect(notifier.openDocument).not.toHaveBeenCalled();
+    });
+
+    it("shows the 'open a folder' hint when the locator reports no-search-scope", async () => {
+        const { service, notifier } = createService({ kind: "no-search-scope" });
+
+        await service.navigate("com.example.X", "javaClass");
+
+        expect(notifier.showInfo).toHaveBeenCalledWith(expect.stringContaining("Open a folder"));
+        expect(notifier.openDocument).not.toHaveBeenCalled();
+    });
+
+    it("logs each failure and shows an error when the locator reports all-unreadable", async () => {
+        const { service, notifier } = createService({
+            kind: "all-unreadable",
+            attempted: 2,
+            failures: ["read /bad1 failed: EACCES", "read /bad2 failed: EACCES"],
+        });
+
+        await service.navigate("t", "jobType");
+
+        expect(notifier.logWarning).toHaveBeenCalledTimes(2);
+        expect(notifier.showError).toHaveBeenCalledWith(
+            expect.stringContaining("none of the candidate files were readable"),
+        );
+        expect(notifier.openDocument).not.toHaveBeenCalled();
+    });
+
+    it("logs partial read failures alongside a successful match", async () => {
+        const { service, notifier } = createService({
+            kind: "matches",
+            paths: ["/src/good.java"],
+            readFailures: ["read /bad failed: EACCES"],
+        });
+
+        await service.navigate("t", "jobType");
+
+        expect(notifier.logWarning).toHaveBeenCalledWith(expect.stringContaining("EACCES"));
+        expect(notifier.openDocument).toHaveBeenCalledWith("/src/good.java");
+    });
+
+    it("surfaces an error when openDocument rejects", async () => {
+        const { service, notifier } = createService({
+            kind: "matches",
+            paths: ["/src/MyDelegate.java"],
+            readFailures: [],
+        });
+        notifier.openDocument.mockRejectedValueOnce(new Error("File not found"));
+
+        await service.navigate("com.example.MyDelegate", "javaClass");
+
+        expect(notifier.showError).toHaveBeenCalledWith(expect.stringContaining("File not found"));
+        expect(notifier.logError).toHaveBeenCalled();
+    });
+
+    it("truncates very long references in user-facing notifications", async () => {
+        const huge = "x".repeat(500);
+        const { service, notifier } = createService({
+            kind: "matches",
+            paths: [],
+            readFailures: [],
+        });
+
+        await service.navigate(huge, "jobType");
+
+        const message = notifier.showInfo.mock.calls[0][0] as string;
+        expect(message).not.toContain(huge);
+        expect(message).toContain("…");
+    });
+});

--- a/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.ts
+++ b/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.ts
@@ -1,0 +1,97 @@
+import { NotifierPort, PickerPort } from "../../shared/domain/hostPorts";
+import { ImplementationKind } from "../domain/ImplementationReference";
+
+import { ImplementationLocator } from "./ImplementationLocator";
+
+// Maximum length of a reference echoed back into a user-facing notification.
+const REFERENCE_DISPLAY_LIMIT = 100;
+
+// Tighter cap for the status-bar progress label — it's space-constrained.
+const PROGRESS_LABEL_LIMIT = 40;
+
+// Human-readable labels for the progress / not-found messages, per kind.
+const KIND_LABELS: Record<ImplementationKind, string> = {
+    javaClass: "class",
+    delegateExpression: "delegate",
+    expression: "expression",
+    externalTopic: "external task topic",
+    jobType: "job type",
+};
+
+/**
+ * Resolves a Camunda implementation reference to a workspace source file and
+ * opens it. Triggered by `NavigateToImplementationCommand` from the BPMN
+ * webview.
+ *
+ * A thin orchestrator: it delegates the search to {@link ImplementationLocator}
+ * and maps the structured result to user-facing notifications, a QuickPick (for
+ * multi-match), and `vscode.open` — the exact 0/1/N flow of
+ * `ModelNavigationService`.
+ */
+export class ImplementationNavigationService {
+    constructor(
+        private readonly locator: ImplementationLocator,
+        private readonly notifier: NotifierPort,
+        private readonly picker: PickerPort,
+    ) {}
+
+    async navigate(
+        reference: string,
+        kind: ImplementationKind,
+        sourceDocumentPath?: string,
+    ): Promise<void> {
+        const label = KIND_LABELS[kind];
+        const display = truncate(reference, REFERENCE_DISPLAY_LIMIT);
+        // Only the search is wrapped — the QuickPick (multi-match) and
+        // openDocument are user-driven and must not keep a spinner visible.
+        const result = await this.notifier.withProgress(
+            `Searching for ${label} "${truncate(reference, PROGRESS_LABEL_LIMIT)}"…`,
+            () => this.locator.resolve(reference, kind, sourceDocumentPath),
+        );
+
+        if (result.kind === "no-search-scope") {
+            this.notifier.showInfo(
+                `No implementation for "${display}" was found. Open a folder to enable code navigation.`,
+            );
+            return;
+        }
+
+        if (result.kind === "all-unreadable") {
+            result.failures.forEach((message) => this.notifier.logWarning(message));
+            this.notifier.showError(
+                `Could not search for "${display}" — none of the candidate files were readable.`,
+            );
+            return;
+        }
+
+        result.readFailures.forEach((message) => this.notifier.logWarning(message));
+
+        let chosen: string | undefined;
+        if (result.paths.length === 0) {
+            this.notifier.showInfo(
+                `No implementation for ${label} "${display}" was found in the workspace. ` +
+                    `(See Output → bpmn.modeler for what was searched.)`,
+            );
+            return;
+        } else if (result.paths.length === 1) {
+            chosen = result.paths[0];
+        } else {
+            chosen = await this.picker.pickReferencedModel(result.paths);
+        }
+
+        if (!chosen) {
+            return;
+        }
+
+        try {
+            await this.notifier.openDocument(chosen);
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            this.notifier.showError(`Could not open ${chosen}: ${(error as Error).message}`);
+        }
+    }
+}
+
+function truncate(value: string, max: number): string {
+    return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -40,6 +40,11 @@ export * from "./diff/infrastructure/DiffPaneStore";
 export * from "./navigation/service/ModelNavigationService";
 export * from "./navigation/service/ReferencedModelLocator";
 
+// ── codeLink ─────────────────────────────────────────────────────────────────
+export * from "./codeLink/service/ImplementationLocator";
+export * from "./codeLink/service/ImplementationNavigationService";
+export * from "./codeLink/service/CodeLinkMapService";
+
 // ── migration ────────────────────────────────────────────────────────────────
 export * from "./migration/domain/MigrationPlan";
 export * from "./migration/service/BpmnMigrationService";

--- a/libs/modeler-core/src/navigation/service/ReferencedModelLocator.ts
+++ b/libs/modeler-core/src/navigation/service/ReferencedModelLocator.ts
@@ -1,26 +1,9 @@
-import { posix } from "path";
-
 import { NotifierPort, WorkspacePort } from "../../shared/domain/hostPorts";
-
-/**
- * Directory names that never contain user-authored process/decision sources.
- * Applied uniformly to both code paths: as a post-filter on the
- * `workspace.findFiles` result, and per-directory during the fs-walk
- * fallback.  VS Code's default `files.exclude` / `search.exclude` only
- * cover a subset of these (notably `**\/node_modules`), so we cannot rely
- * on the platform defaults alone.
- */
-const EXCLUDED_DIRS: ReadonlySet<string> = new Set([
-    "node_modules",
-    "dist",
-    "build",
-    "out",
-    "target",
-    "coverage",
-    ".git",
-    ".svn",
-    ".hg",
-]);
+import {
+    escapeRegex,
+    findFilesExcluding,
+    searchFilesContent,
+} from "../../shared/service/workspaceFileSearch";
 
 // Max length of a reference id echoed back into a user-facing log line.
 const ID_DISPLAY_LIMIT = 100;
@@ -43,14 +26,9 @@ export type LocateResult =
  * Locates BPMN/DMN files that declare a given `<process id="…">` or
  * `<decision id="…">`.
  *
- * Strategy, in order:
- *   1. `workspace.findFiles("**\/*.bpmn"|.dmn)` — fast (ripgrep-backed in
- *      Theia/VS Code) and respects the user's `files.exclude` setting.
- *   2. fs-walk fallback — kicks in when (1) returns `[]` despite a workspace
- *      folder being open, which happens in the unsigned electron-builder
- *      package where the bundled ripgrep is missing or unexecutable.  No
- *      ripgrep dependency.
- *   3. fs-walk primary — for loose-file scenarios (no workspace folder).
+ * The workspace search itself (findFiles + fs-walk fallback, parallel content
+ * search) lives in {@link findFilesExcluding} / {@link searchFilesContent}
+ * under `shared/`; this class only owns the BPMN/DMN-specific glob and id regex.
  */
 export class ReferencedModelLocator {
     constructor(
@@ -69,164 +47,27 @@ export class ReferencedModelLocator {
             `[nav] resolving ${kind} id="${id}" sourceUri=${sourceDocumentPath ?? "<none>"}`,
         );
 
-        const paths = await this.collectCandidateFiles(extension, sourceDocumentPath);
+        const paths = await findFilesExcluding(this.vsWorkspace, `**/*${extension}`, {
+            sourceDocumentPath,
+            logger: this.notifier,
+            matchesWalkedFile: (path) => path.endsWith(extension),
+        });
         if (paths === undefined) {
             this.notifier.logInfo(`[nav] no search scope (no folder, no source uri)`);
             return { kind: "no-search-scope" };
         }
-        return this.filterByIdDeclaration(paths, referenceId, kind);
-    }
 
-    /**
-     * Phase 1.  Returns `undefined` when nothing can be searched (no source
-     * path and no workspace folder).  Otherwise returns the candidate paths.
-     */
-    private async collectCandidateFiles(
-        extension: string,
-        sourceDocumentPath: string | undefined,
-    ): Promise<string[] | undefined> {
-        const containingFolderPath =
-            sourceDocumentPath !== undefined
-                ? this.vsWorkspace.findWorkspaceFolderForDocument(sourceDocumentPath)
-                : undefined;
-        const looseFile = sourceDocumentPath !== undefined && containingFolderPath === undefined;
-
-        if (looseFile) {
-            // No workspace folder covers the document → walk from its dir.
-            const rootDir = this.vsWorkspace.getDocumentDirectory(sourceDocumentPath!);
-            return this.walkWorkspaceTree(rootDir, extension, "walk-primary");
-        }
-
-        const folderPaths = this.vsWorkspace.getWorkspaceFolderPaths();
-        if (folderPaths.length === 0) {
-            return undefined;
-        }
-
-        // Pass undefined for excludes — VS Code layers user's `files.exclude`
-        // and `search.exclude` on top.  We then post-filter with
-        // `EXCLUDED_DIRS` because the VS Code defaults do not cover all of
-        // them (e.g. `dist`, `build`, `out`, `target`, `coverage`).
-        const startedAt = Date.now();
-        const found = await this.vsWorkspace.findFiles(`**/*${extension}`);
-        const filtered = found.filter((path) => !pathIsInsideExcludedDir(path));
-        this.notifier.logInfo(
-            `[nav] findFiles returned ${found.length} path(s) ` +
-                `(${filtered.length} after exclude filter) in ${Date.now() - startedAt}ms`,
-        );
-        if (filtered.length > 0) {
-            return filtered;
-        }
-
-        // Fallback: findFiles failed silently (ripgrep missing in packaged .app).
-        const root = this.pickWalkRoot(sourceDocumentPath, containingFolderPath, folderPaths);
-        if (!root) return [];
-        return this.walkWorkspaceTree(root, extension, "walk-fallback");
-    }
-
-    /**
-     * Parallel BFS.  All directories at the same depth are read concurrently
-     * via `Promise.all` — sequential per-directory awaits cost several
-     * seconds on deep workspaces.  Unreadable subdirectories are swallowed.
-     */
-    private async walkWorkspaceTree(
-        rootDir: string,
-        extension: string,
-        reason: "walk-primary" | "walk-fallback",
-    ): Promise<string[]> {
-        this.notifier.logInfo(`[nav] ${reason}: walking ${rootDir} for ${extension}`);
-        const startedAt = Date.now();
-
-        const out: string[] = [];
-        let level: string[] = [rootDir];
-        while (level.length > 0) {
-            const reads = await Promise.all(
-                level.map((dir) =>
-                    this.vsWorkspace
-                        .readDirectory(dir)
-                        .then(
-                            (entries) =>
-                                [dir, entries] as [string, Array<[string, "file" | "directory"]>],
-                        )
-                        .catch(() => [dir, []] as [string, Array<[string, "file" | "directory"]>]),
-                ),
-            );
-            const nextLevel: string[] = [];
-            for (const [dir, entries] of reads) {
-                for (const [name, type] of entries) {
-                    const full = posix.join(dir, name);
-                    if (type === "directory") {
-                        if (!EXCLUDED_DIRS.has(name)) nextLevel.push(full);
-                    } else if (name.endsWith(extension)) {
-                        out.push(full);
-                    }
-                }
-            }
-            level = nextLevel;
-        }
-
-        this.notifier.logInfo(
-            `[nav] ${reason} returned ${out.length} path(s) in ${Date.now() - startedAt}ms`,
-        );
-        return out;
-    }
-
-    /**
-     * Where to root the walk fallback.  Best-effort: prefer the document's own
-     * workspace folder, else the first open folder, else the document's
-     * directory.  The folder lookups are reused from
-     * {@link collectCandidateFiles} to avoid re-querying the workspace.
-     */
-    private pickWalkRoot(
-        sourceDocumentPath: string | undefined,
-        containingFolderPath: string | undefined,
-        folderPaths: string[],
-    ): string | undefined {
-        if (containingFolderPath) return containingFolderPath;
-        if (folderPaths.length > 0) return folderPaths[0];
-        if (sourceDocumentPath !== undefined) {
-            return this.vsWorkspace.getDocumentDirectory(sourceDocumentPath);
-        }
-        return undefined;
-    }
-
-    /**
-     * Phase 2.  Reads each candidate file in parallel and tests the id regex
-     * against its content (ignoring XML comments and CDATA sections).
-     */
-    private async filterByIdDeclaration(
-        paths: string[],
-        referenceId: string,
-        kind: "process" | "decision",
-    ): Promise<LocateResult> {
         const pattern = this.buildIdPattern(referenceId, kind);
-        const startedAt = Date.now();
-
-        const failures: string[] = [];
-        const results = await Promise.all(
-            paths.map(async (path) => {
-                try {
-                    const xml = await this.vsWorkspace.readFile(path);
-                    return this.matchesDeclaration(xml, pattern) ? path : undefined;
-                } catch (error) {
-                    failures.push(
-                        `Could not read ${path} while resolving reference "${referenceId}": ${
-                            (error as Error).message
-                        }`,
-                    );
-                    return undefined;
-                }
-            }),
+        const { matches, readFailures, allUnreadable } = await searchFilesContent(
+            this.vsWorkspace,
+            paths,
+            pattern,
+            this.notifier,
         );
-        const matches = results.filter((path): path is string => path !== undefined);
-
-        this.notifier.logInfo(
-            `[nav] candidates=${paths.length} matches=${matches.length} readFailures=${failures.length} reads-took=${Date.now() - startedAt}ms`,
-        );
-
-        if (paths.length > 0 && failures.length === paths.length) {
-            return { kind: "all-unreadable", attempted: paths.length, failures };
+        if (allUnreadable) {
+            return { kind: "all-unreadable", attempted: paths.length, failures: readFailures };
         }
-        return { kind: "matches", paths: matches, readFailures: failures };
+        return { kind: "matches", paths: matches, readFailures };
     }
 
     /**
@@ -246,48 +87,6 @@ export class ReferencedModelLocator {
             `<(?:[\\w-]+:)?${tag}\\b[^>]*\\bid\\s*=\\s*["']${escapeRegex(referenceId)}["']`,
         );
     }
-
-    /**
-     * Returns true if `pattern` matches at least one position in `xml` that
-     * is not inside an XML comment or CDATA section — a commented-out
-     * `<!-- <bpmn:process id="X"/> -->` is not a real declaration.
-     *
-     * We enumerate comment/CDATA ranges via regex rather than `.replace()`
-     * them away to avoid CodeQL's `js/incomplete-multi-character-sanitization`
-     * rule (this is filtering, not sanitisation, so the lint is a false
-     * positive but easier to dodge than appease).
-     */
-    private matchesDeclaration(xml: string, pattern: RegExp): boolean {
-        const excluded: Array<[number, number]> = [];
-        for (const re of [/<!--[\s\S]*?-->/g, /<!\[CDATA\[[\s\S]*?\]\]>/g]) {
-            let m;
-            while ((m = re.exec(xml)) !== null) {
-                excluded.push([m.index, m.index + m[0].length]);
-            }
-        }
-        const global = new RegExp(
-            pattern.source,
-            pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
-        );
-        let match;
-        while ((match = global.exec(xml)) !== null) {
-            if (!excluded.some(([s, e]) => match!.index >= s && match!.index < e)) {
-                return true;
-            }
-        }
-        return false;
-    }
-}
-
-function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function pathIsInsideExcludedDir(path: string): boolean {
-    for (const segment of path.split("/")) {
-        if (segment !== "" && EXCLUDED_DIRS.has(segment)) return true;
-    }
-    return false;
 }
 
 function truncate(value: string, max: number): string {

--- a/libs/modeler-core/src/shared/domain/excludedDirs.ts
+++ b/libs/modeler-core/src/shared/domain/excludedDirs.ts
@@ -1,0 +1,34 @@
+/**
+ * Directory names that never contain user-authored sources worth searching
+ * (process/decision models or implementation code).
+ *
+ * Applied uniformly to both workspace-search code paths: as a post-filter on
+ * the `workspace.findFiles` result, and per-directory during the fs-walk
+ * fallback. VS Code's default `files.exclude` / `search.exclude` only cover a
+ * subset of these (notably `**\/node_modules`), so the platform defaults alone
+ * are not enough.
+ */
+export const EXCLUDED_DIRS: ReadonlySet<string> = new Set([
+    "node_modules",
+    "dist",
+    "build",
+    "out",
+    "target",
+    "coverage",
+    ".git",
+    ".svn",
+    ".hg",
+]);
+
+/**
+ * True when any path segment is an {@link EXCLUDED_DIRS} entry — used to drop
+ * `findFiles` hits buried in build/output trees the VS Code defaults miss.
+ */
+export function pathIsInsideExcludedDir(path: string): boolean {
+    for (const segment of path.split("/")) {
+        if (segment !== "" && EXCLUDED_DIRS.has(segment)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -85,6 +85,8 @@ export interface SettingsPort {
     getColorTheme(): "automatic" | "light";
     getFavouriteBpmnElements(): string[];
     getLanguage(): string;
+    /** Whether the activity→code map is persisted under `<configFolder>/code-link/`. */
+    getPersistCodeLinkMap(): boolean;
 }
 
 /**

--- a/libs/modeler-core/src/shared/service/workspaceFileSearch.ts
+++ b/libs/modeler-core/src/shared/service/workspaceFileSearch.ts
@@ -1,0 +1,254 @@
+import { posix } from "path";
+
+import { EXCLUDED_DIRS, pathIsInsideExcludedDir } from "../domain/excludedDirs";
+import { WorkspacePort } from "../domain/hostPorts";
+
+/**
+ * Reusable workspace-search primitives shared by the navigation and code-link
+ * features. Kept in `shared/` (exempt from feature isolation) so both features
+ * build on one implementation of the find-files-with-fallback and parallel
+ * content-search logic instead of duplicating ~80 lines each.
+ *
+ * `WorkspacePort` is an interface, so this module never imports `vscode` and
+ * the layer-purity arch test (service must not import host modules) stays green.
+ */
+
+// Minimal logging surface — both `NotifierPort` and a bare stub satisfy it.
+export interface SearchLogger {
+    logInfo(message: string): void;
+}
+
+/**
+ * Outcome of reading and matching a set of candidate files.
+ *
+ * `allUnreadable` is `true` only when at least one file was attempted and every
+ * read failed, letting callers distinguish "searched, found nothing" from
+ * "could not search because nothing was readable".
+ */
+export interface ContentSearchResult {
+    matches: string[];
+    readFailures: string[];
+    allUnreadable: boolean;
+}
+
+/**
+ * Escapes regex metacharacters so a user-supplied id / literal is matched
+ * verbatim rather than interpreted as a pattern.
+ */
+export function escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Finds workspace files matching `glob`, excluding build/output dirs, with an
+ * fs-walk fallback for hosts where the bundled ripgrep is missing.
+ *
+ * Strategy, in order:
+ *   1. `workspace.findFiles(glob)` — fast (ripgrep-backed) and respects the
+ *      user's `files.exclude` setting; results post-filtered by {@link EXCLUDED_DIRS}.
+ *   2. fs-walk fallback — when (1) returns `[]` despite an open folder, which
+ *      happens in the unsigned electron-builder package where ripgrep is
+ *      missing/unexecutable.
+ *   3. fs-walk primary — for loose-file scenarios (document outside every folder).
+ *
+ * @returns the candidate absolute paths (possibly empty), or `undefined` when
+ *   there is nothing to search (no workspace folder and no source document to
+ *   anchor a walk).
+ */
+export async function findFilesExcluding(
+    ws: WorkspacePort,
+    glob: string,
+    options: {
+        sourceDocumentPath?: string;
+        logger?: SearchLogger;
+        /**
+         * Decides whether a file encountered during the fs-walk fallback is a
+         * candidate. The `findFiles` path already filters by `glob`, so this is
+         * only consulted on the walk paths (which enumerate every file).
+         */
+        matchesWalkedFile: (absolutePath: string) => boolean;
+    },
+): Promise<string[] | undefined> {
+    const { sourceDocumentPath, logger, matchesWalkedFile } = options;
+
+    const containingFolderPath =
+        sourceDocumentPath !== undefined
+            ? ws.findWorkspaceFolderForDocument(sourceDocumentPath)
+            : undefined;
+    const looseFile = sourceDocumentPath !== undefined && containingFolderPath === undefined;
+
+    if (looseFile) {
+        // No workspace folder covers the document → walk from its directory.
+        const rootDir = ws.getDocumentDirectory(sourceDocumentPath!);
+        return walkWorkspaceTree(ws, rootDir, matchesWalkedFile, logger, "walk-primary");
+    }
+
+    const folderPaths = ws.getWorkspaceFolderPaths();
+    if (folderPaths.length === 0) {
+        return undefined;
+    }
+
+    // Pass no excludes — VS Code layers the user's `files.exclude` and
+    // `search.exclude` on top — then post-filter with EXCLUDED_DIRS because the
+    // VS Code defaults do not cover all of them (dist, build, out, target, …).
+    const startedAt = Date.now();
+    const found = await ws.findFiles(glob);
+    const filtered = found.filter((path) => !pathIsInsideExcludedDir(path));
+    logger?.logInfo(
+        `[search] findFiles("${glob}") returned ${found.length} path(s) ` +
+            `(${filtered.length} after exclude filter) in ${Date.now() - startedAt}ms`,
+    );
+    if (filtered.length > 0) {
+        return filtered;
+    }
+
+    // Fallback: findFiles failed silently (ripgrep missing in packaged .app).
+    const root = pickWalkRoot(ws, sourceDocumentPath, containingFolderPath, folderPaths);
+    if (!root) {
+        return [];
+    }
+    return walkWorkspaceTree(ws, root, matchesWalkedFile, logger, "walk-fallback");
+}
+
+/**
+ * Parallel BFS over the directory tree. All directories at one depth are read
+ * concurrently via `Promise.all` — sequential per-directory awaits cost several
+ * seconds on deep workspaces. Unreadable subdirectories are swallowed.
+ */
+async function walkWorkspaceTree(
+    ws: WorkspacePort,
+    rootDir: string,
+    matchesWalkedFile: (absolutePath: string) => boolean,
+    logger: SearchLogger | undefined,
+    reason: "walk-primary" | "walk-fallback",
+): Promise<string[]> {
+    logger?.logInfo(`[search] ${reason}: walking ${rootDir}`);
+    const startedAt = Date.now();
+
+    const out: string[] = [];
+    let level: string[] = [rootDir];
+    while (level.length > 0) {
+        const reads = await Promise.all(
+            level.map((dir) =>
+                ws
+                    .readDirectory(dir)
+                    .then(
+                        (entries) =>
+                            [dir, entries] as [string, Array<[string, "file" | "directory"]>],
+                    )
+                    .catch(() => [dir, []] as [string, Array<[string, "file" | "directory"]>]),
+            ),
+        );
+        const nextLevel: string[] = [];
+        for (const [dir, entries] of reads) {
+            for (const [name, type] of entries) {
+                const full = posix.join(dir, name);
+                if (type === "directory") {
+                    if (!EXCLUDED_DIRS.has(name)) {
+                        nextLevel.push(full);
+                    }
+                } else if (matchesWalkedFile(full)) {
+                    out.push(full);
+                }
+            }
+        }
+        level = nextLevel;
+    }
+
+    logger?.logInfo(
+        `[search] ${reason} returned ${out.length} path(s) in ${Date.now() - startedAt}ms`,
+    );
+    return out;
+}
+
+/**
+ * Where to root the walk fallback. Best-effort: prefer the document's own
+ * workspace folder, else the first open folder, else the document's directory.
+ */
+function pickWalkRoot(
+    ws: WorkspacePort,
+    sourceDocumentPath: string | undefined,
+    containingFolderPath: string | undefined,
+    folderPaths: string[],
+): string | undefined {
+    if (containingFolderPath) {
+        return containingFolderPath;
+    }
+    if (folderPaths.length > 0) {
+        return folderPaths[0];
+    }
+    if (sourceDocumentPath !== undefined) {
+        return ws.getDocumentDirectory(sourceDocumentPath);
+    }
+    return undefined;
+}
+
+/**
+ * Reads each candidate file in parallel and tests `pattern` against its content
+ * (ignoring XML comments and CDATA sections). Read failures are collected
+ * rather than thrown so a single unreadable file does not abort the search.
+ */
+export async function searchFilesContent(
+    ws: WorkspacePort,
+    paths: string[],
+    pattern: RegExp,
+    logger?: SearchLogger,
+): Promise<ContentSearchResult> {
+    const startedAt = Date.now();
+    const failures: string[] = [];
+    const results = await Promise.all(
+        paths.map(async (path) => {
+            try {
+                const content = await ws.readFile(path);
+                return matchesOutsideCommentsAndCdata(content, pattern) ? path : undefined;
+            } catch (error) {
+                failures.push(`Could not read ${path}: ${(error as Error).message}`);
+                return undefined;
+            }
+        }),
+    );
+    const matches = results.filter((path): path is string => path !== undefined);
+
+    logger?.logInfo(
+        `[search] content: candidates=${paths.length} matches=${matches.length} ` +
+            `readFailures=${failures.length} reads-took=${Date.now() - startedAt}ms`,
+    );
+
+    return {
+        matches,
+        readFailures: failures,
+        allUnreadable: paths.length > 0 && failures.length === paths.length,
+    };
+}
+
+/**
+ * Returns true if `pattern` matches at least one position in `content` that is
+ * not inside an XML comment or CDATA section — a commented-out declaration is
+ * not a real one. For non-XML source files the comment/CDATA ranges are simply
+ * empty, so matching behaves normally.
+ *
+ * Comment/CDATA ranges are enumerated via regex rather than stripped with
+ * `.replace()` to avoid CodeQL's `js/incomplete-multi-character-sanitization`
+ * rule (this is filtering, not sanitisation, so the lint is a false positive
+ * but easier to dodge than appease).
+ */
+function matchesOutsideCommentsAndCdata(content: string, pattern: RegExp): boolean {
+    const excluded: Array<[number, number]> = [];
+    for (const re of [/<!--[\s\S]*?-->/g, /<!\[CDATA\[[\s\S]*?\]\]>/g]) {
+        let m;
+        while ((m = re.exec(content)) !== null) {
+            excluded.push([m.index, m.index + m[0].length]);
+        }
+    }
+    const global = new RegExp(
+        pattern.source,
+        pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`,
+    );
+    let match;
+    while ((match = global.exec(content)) !== null) {
+        if (!excluded.some(([s, e]) => match!.index >= s && match!.index < e)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -13,6 +13,7 @@
  * - {@link ClipboardQuery}                — deliver clipboard text (host mediates sandboxed reads)
  * - {@link UpdateScriptContentQuery}      — push updated script content from a virtual editor to the modeler
  * - {@link UpdateScriptFormatQuery}       — push a script-format choice (Quick-Pick) back to the modeler
+ * - {@link ImplementationStatusQuery}     — push the per-activity implementation-resolution map for context-pad visibility
  *
  * Commands (webview → extension host):
  * - {@link GetBpmnFileCommand}                — webview is ready; request the BPMN file
@@ -26,6 +27,9 @@
  * - {@link GetDiagramAsSVGCommand}            — request an SVG export of the current diagram
  * - {@link OpenScriptEditorCommand}           — request the host to open a script task in a VS Code editor
  * - {@link UpdateScriptVariablesCommand}      — push the re-extracted process-variable model to the host
+ * - {@link NavigateToReferencedModelCommand}  — jump to the referenced BPMN/DMN file
+ * - {@link NavigateToImplementationCommand}   — jump to the source file implementing a task
+ * - {@link SyncActivitiesCommand}             — push the diagram's task implementation references so the host maintains the activity→code map
  *
  * @see messages.ts for the base {@link Query} and {@link Command} classes.
  */
@@ -225,6 +229,31 @@ export class LanguageQuery extends Query {
 }
 
 /**
+ * Pushes the host's maintained activity→code map down to the webview as a flat
+ * `key → resolved` lookup so the "Go to implementation" context-pad entry can
+ * hide for tasks whose implementation does not exist in the workspace.
+ *
+ * Keys are built with {@link implementationStatusKey} — `${activityId}::${reference}`,
+ * not the bare activity id. Folding the reference into the key makes a reference
+ * edit self-invalidating: the new reference produces a key the webview has not
+ * seen yet, so the entry shows optimistically until the host's next push lands,
+ * instead of briefly reusing the stale resolution of the old reference.
+ *
+ * A missing key means "unknown" — the webview shows the entry optimistically.
+ * Only an explicit `false` hides it. That is what keeps a cold first open
+ * flash-free (show, never flash-to-hidden) while still hiding once the host has
+ * confirmed there is nothing to navigate to.
+ */
+export class ImplementationStatusQuery extends Query {
+    public readonly resolved: Record<string, boolean>;
+
+    constructor(resolved: Record<string, boolean>) {
+        super("ImplementationStatusQuery");
+        this.resolved = resolved;
+    }
+}
+
+/**
  * <================================== Queries ===================================
  *
  * =================================== Commands ==================================>
@@ -310,6 +339,89 @@ export class NavigateToReferencedModelCommand extends Command {
         super("NavigateToReferencedModelCommand");
         this.referenceId = referenceId;
         this.referenceKind = referenceKind;
+    }
+}
+
+/**
+ * Discriminates how a task's Camunda implementation reference must be resolved
+ * to a workspace source file. The webview classifies the selected element's
+ * reference; the host picks the matching resolution strategy per kind.
+ *
+ * - `javaClass` — `camunda:class` FQCN → deterministic class-file glob.
+ * - `delegateExpression` — `camunda:delegateExpression="${bean}"` → bean id → class.
+ * - `expression` — `camunda:expression="${svc.run()}"` → leading id → class (lowest confidence).
+ * - `externalTopic` — C7 external-task `camunda:topic` → content search for the literal.
+ * - `jobType` — C8 `zeebe:taskDefinition type` → content search for the literal.
+ */
+export type ImplementationKind =
+    | "javaClass"
+    | "delegateExpression"
+    | "expression"
+    | "externalTopic"
+    | "jobType";
+
+/**
+ * One task's implementation binding as the webview reads it from the bpmn-js
+ * model: the activity's id plus the {@link ImplementationKind} / reference the
+ * host needs to resolve it to a source file.
+ *
+ * The host never parses the BPMN XML — bpmn-js has already parsed it for
+ * rendering, so the webview extracts these cheap strings and ships the list,
+ * keeping the (possibly huge) XML out of the host entirely.
+ */
+export interface ImplementationEntry {
+    readonly activityId: string;
+    readonly kind: ImplementationKind;
+    readonly reference: string;
+}
+
+/**
+ * Composite key for {@link ImplementationStatusQuery}'s lookup, shared by both
+ * sides of the protocol so they agree byte-for-byte. The reference is part of
+ * the key on purpose — see {@link ImplementationStatusQuery} for why a bare
+ * activity id would briefly reuse a stale resolution after a reference edit.
+ */
+export function implementationStatusKey(activityId: string, reference: string): string {
+    return `${activityId}::${reference}`;
+}
+
+/**
+ * Sent by the BPMN webview when the user clicks "Go to implementation" on a
+ * service / send / business-rule task that carries a Camunda implementation
+ * reference. The host resolves the {@link reference} according to {@link kind}
+ * and opens the unique source file, shows a QuickPick on multiple matches, or
+ * an info notification when nothing resolves.
+ *
+ * Only the reference string and its kind cross the boundary — workspace file
+ * paths never leave the host. Resolution happens on click, on demand.
+ */
+export class NavigateToImplementationCommand extends Command {
+    public readonly reference: string;
+
+    public readonly kind: ImplementationKind;
+
+    constructor(reference: string, kind: ImplementationKind) {
+        super("NavigateToImplementationCommand");
+        this.reference = reference;
+        this.kind = kind;
+    }
+}
+
+/**
+ * Sent by the BPMN webview whenever the diagram's set of task implementation
+ * references may have changed (on import and after edits, debounced). Carries
+ * the full current list so the host can diff it against the activity→code map
+ * it already holds and do filesystem work only for the delta.
+ *
+ * This is intentionally a cheap list of id/kind/reference strings, never
+ * resolved paths — resolution is the host's job and stays on the host.
+ */
+export class SyncActivitiesCommand extends Command {
+    public readonly entries: ImplementationEntry[];
+
+    constructor(entries: ImplementationEntry[]) {
+        super("SyncActivitiesCommand");
+        this.entries = entries;
     }
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,9 +25,12 @@
             "@miragon/bpmn-modeler-core": ["./libs/modeler-core/src/index.ts"],
             "@miragon/bpmn-modeler-clipboard": ["./libs/bpmn-clipboard/src/index.ts"],
             "@miragon/bpmn-modeler-i18n": ["./libs/bpmn-i18n/src/index.ts"],
-            "@miragon/bpmn-modeler-element-template-chooser": ["./libs/element-template-chooser/src/index.ts"],
+            "@miragon/bpmn-modeler-element-template-chooser": [
+                "./libs/element-template-chooser/src/index.ts"
+            ],
             "@miragon/bpmn-modeler-append-menu": ["./libs/append-menu/src/index.ts"],
-            "@miragon/bpmn-model-navigation": ["./libs/model-navigation/src/index.ts"]
+            "@miragon/bpmn-model-navigation": ["./libs/model-navigation/src/index.ts"],
+            "@miragon/bpmn-modeler-code-link": ["./libs/code-link/src/index.ts"]
         }
     },
     "exclude": ["node_modules", "tmp", "dist", "**/lib", "**/src-gen"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,6 +3510,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@miragon/bpmn-modeler-code-link@workspace:*, @miragon/bpmn-modeler-code-link@workspace:libs/code-link":
+  version: 0.0.0-use.local
+  resolution: "@miragon/bpmn-modeler-code-link@workspace:libs/code-link"
+  dependencies:
+    "@miragon/bpmn-modeler-shared": "workspace:*"
+    bpmn-js: "npm:18.16.1"
+    typescript: "npm:6.0.3"
+    vitest: "npm:4.1.8"
+  peerDependencies:
+    bpmn-js: 18.16.1
+  languageName: unknown
+  linkType: soft
+
 "@miragon/bpmn-modeler-core@workspace:*, @miragon/bpmn-modeler-core@workspace:libs/modeler-core":
   version: 0.0.0-use.local
   resolution: "@miragon/bpmn-modeler-core@workspace:libs/modeler-core"
@@ -3642,6 +3655,7 @@ __metadata:
     "@miragon/bpmn-model-navigation": "workspace:*"
     "@miragon/bpmn-modeler-append-menu": "workspace:*"
     "@miragon/bpmn-modeler-clipboard": "workspace:*"
+    "@miragon/bpmn-modeler-code-link": "workspace:*"
     "@miragon/bpmn-modeler-element-template-chooser": "workspace:*"
     "@miragon/bpmn-modeler-i18n": "workspace:*"
     "@miragon/bpmn-modeler-shared": "workspace:*"


### PR DESCRIPTION
**Issue**

Closes #856

**Description**

Adds a "Go to implementation" context-pad entry on service / send / business-rule tasks that resolves a Camunda implementation reference to its workspace source file on click, mirroring the existing model-navigation feature. The webview classifies the binding (C7 `camunda:class` / `delegateExpression` / `expression` / external `camunda:topic`, or C8 `zeebe:taskDefinition` job type) and posts only the reference string + kind to the host, which resolves it (deterministic FQCN glob for classes; heuristic filename/annotation/literal search for the rest) and opens the unique match, a QuickPick on several, or an info notification on none. Workspace search internals were extracted to `shared/` so the new `codeLink` host feature and the existing `navigation` feature share one implementation (its tests are the regression lock), and the title is translated across all nine locales. The branch also carries a small agent-config docs commit (`.agent/` commit-conventions guide).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
