### PR TITLE
feat(modeler-cli): ship modeler as a Node-free Bun binary (#1061)

### DIFF
--- a/apps/bpmn-webview/src/app/vscode.ts
+++ b/apps/bpmn-webview/src/app/vscode.ts
@@ -20,6 +20,7 @@ import {
     VsCodeImpl,
     VsCodeMock,
     ViewportChangedCommand,
+    WebSocketChannelImpl,
 } from "@miragon/bpmn-modeler-shared";
 
 import c7Samples from "./__fixtures__/c7-samples.json";
@@ -131,19 +132,25 @@ type StateType = WebviewState;
 type MessageType = Command | Query;
 
 /**
- * Returns the appropriate VS Code API implementation.
+ * Returns the appropriate host-channel implementation.
  *
- * In `development` mode a {@link MockedVsCodeApi} is returned so the webview
- * can be run standalone in a browser without a VS Code host.  In all other
- * environments the real {@link VsCodeImpl} is used.
+ * Selection order matters: the `window.__WS_BRIDGE__` global is injected by
+ * `apps/modeler-cli`'s served HTML into the *production* bundle, so it must
+ * be checked before the `NODE_ENV` branch — otherwise a CLI-served webview
+ * would fall through to {@link VsCodeImpl} and call `acquireVsCodeApi()`,
+ * which does not exist outside a VS Code host. In `development` mode a
+ * {@link MockedVsCodeApi} is returned for standalone browser runs; otherwise
+ * the real {@link VsCodeImpl} is used.
  */
 export function getVsCodeApi(): VsCodeApi<StateType, MessageType> {
-    console.log(process.env.NODE_ENV);
+    const bridgeUrl = (window as { __WS_BRIDGE__?: string }).__WS_BRIDGE__;
+    if (bridgeUrl) {
+        return new WebSocketChannelImpl<StateType, MessageType>(bridgeUrl);
+    }
     if (process.env.NODE_ENV === "development") {
         return new MockedVsCodeApi();
-    } else {
-        return new VsCodeImpl<StateType, MessageType>();
     }
+    return new VsCodeImpl<StateType, MessageType>();
 }
 
 /**

--- a/apps/dmn-webview/src/app/vscode.ts
+++ b/apps/dmn-webview/src/app/vscode.ts
@@ -5,6 +5,7 @@ import {
     VsCodeApi,
     VsCodeImpl,
     VsCodeMock,
+    WebSocketChannelImpl,
 } from "@miragon/bpmn-modeler-shared";
 
 declare const process: { env: { NODE_ENV: string } };
@@ -27,12 +28,24 @@ type StateType = WebviewState;
 
 type MessageType = Command | Query;
 
+/**
+ * Returns the appropriate host-channel implementation.
+ *
+ * The `window.__WS_BRIDGE__` global (injected by `apps/modeler-cli`'s served
+ * HTML into the production bundle) is checked first, before the `NODE_ENV`
+ * branch — otherwise a CLI-served webview would fall through to
+ * {@link VsCodeImpl} and call `acquireVsCodeApi()`, which is unavailable
+ * outside a VS Code host.
+ */
 export function getVsCodeApi(): VsCodeApi<StateType, MessageType> {
+    const bridgeUrl = (window as { __WS_BRIDGE__?: string }).__WS_BRIDGE__;
+    if (bridgeUrl) {
+        return new WebSocketChannelImpl<StateType, MessageType>(bridgeUrl);
+    }
     if (process.env.NODE_ENV === "development") {
         return new MockedVsCodeApi();
-    } else {
-        return new VsCodeImpl<StateType, MessageType>();
     }
+    return new VsCodeImpl<StateType, MessageType>();
 }
 
 class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {

--- a/apps/modeler-cli/.gitignore
+++ b/apps/modeler-cli/.gitignore
@@ -1,0 +1,2 @@
+# Build output: the compiled Bun binary + copied webview assets (~68 MB).
+dist/

--- a/apps/modeler-cli/README.md
+++ b/apps/modeler-cli/README.md
@@ -1,0 +1,64 @@
+# `@miragon/bpmn-modeler-cli` — runtime-distribution prototype (#1061)
+
+A throwaway prototype that proves the BPMN/DMN modeler can launch on a machine
+with **no Node installed**, by compiling a tiny host server to a single
+self-contained binary with [Bun](https://bun.sh) (`bun build --compile`).
+
+This is the publish-blocker spike for the JetBrains Marketplace track
+(#1061, parent epic #920). It is **not** a shipping product — the IntelliJ
+plugin packaging that consumes this binary is #1062. The rationale and the
+measured comparison of distribution options live in the ADR:
+`docs/vscode/contributing/architecture/runtime-distribution.md`.
+
+## What it does
+
+`bpmn-modeler <file.bpmn|file.dmn>` boots a local HTTP + WebSocket server that:
+
+- serves the **unmodified production** `bpmn-webview` / `dmn-webview` bundle as
+  static assets,
+- bridges the webview's `Query`/`Command` protocol to the file over a
+  WebSocket (`/bridge`) — the same `getVsCodeApi()` selector that picks the VS
+  Code API in the extension picks `WebSocketChannelImpl` here, driven by the
+  injected `window.__WS_BRIDGE__` global,
+- reads the file on load and writes it back on `SyncDocumentCommand`.
+
+No modeling logic is reimplemented: execution-platform detection reuses
+`BpmnDocument` from `@miragon/bpmn-modeler-core`.
+
+## Build
+
+```bash
+# from the repo root — libs + webviews must be built first
+corepack yarn build:libs
+corepack yarn build:bpmn-webview
+corepack yarn build:dmn-webview
+
+# typecheck → bun compile → copy webview assets next to the binary
+corepack yarn workspace @miragon/bpmn-modeler-cli build
+```
+
+Output: `apps/modeler-cli/dist/bpmn-modeler` (the binary) plus
+`apps/modeler-cli/dist/webviews/{bpmn,dmn}-webview/` (the assets the binary
+serves; resolved relative to the executable at runtime).
+
+## Run / prove it needs no Node
+
+```bash
+cd apps/modeler-cli/dist
+# a PATH with neither node nor bun on it
+env -i HOME="$HOME" PATH=/usr/bin:/bin ./bpmn-modeler /path/to/diagram.bpmn
+```
+
+## Cross-platform
+
+`bun build --compile` cross-compiles via `--target`; this prototype targets the
+host (`bun-darwin-arm64`). The release matrix
+(`bun-{darwin-arm64,darwin-x64,linux-x64,windows-x64}`) is documented in the
+ADR but not produced here.
+
+## Known cosmetic gap
+
+The webview build's vite static-copy glob places the bpmn/dmn icon fonts under
+`font/…` while the icon-font CSS references them via `url(../font/…)` → `css/…`.
+The server rewrites those requests so icons load here; the proper fix belongs
+in the webview build's copy globs.

--- a/apps/modeler-cli/package.json
+++ b/apps/modeler-cli/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@miragon/bpmn-modeler-cli",
+    "version": "0.0.1",
+    "private": true,
+    "license": "Apache-2.0",
+    "description": "Runtime-distribution prototype (#1061): launch the BPMN/DMN modeler from a single Node-free binary.",
+    "bin": {
+        "bpmn-modeler": "./dist/bpmn-modeler"
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "typecheck": "tsc -p tsconfig.app.json --noEmit",
+        "compile": "bun build --compile --target=bun-darwin-arm64 src/index.ts --outfile dist/bpmn-modeler",
+        "copy-webviews": "node ./scripts/copy-webviews.cjs",
+        "build": "npm-run-all -s typecheck compile copy-webviews",
+        "start": "bun run src/index.ts"
+    },
+    "dependencies": {
+        "@miragon/bpmn-modeler-core": "workspace:*",
+        "@miragon/bpmn-modeler-shared": "workspace:*",
+        "chokidar": "3.6.0",
+        "commander": "12.1.0",
+        "express": "4.21.2",
+        "ws": "8.18.0"
+    },
+    "devDependencies": {
+        "@types/express": "4.17.21",
+        "@types/node": "25.9.1",
+        "@types/ws": "8.5.13",
+        "npm-run-all": "4.1.5",
+        "typescript": "6.0.3"
+    }
+}

--- a/apps/modeler-cli/scripts/copy-webviews.cjs
+++ b/apps/modeler-cli/scripts/copy-webviews.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Copies the pre-built bpmn-webview and dmn-webview bundles next to the
+ * compiled CLI binary so the shipped artifact is self-contained.
+ *
+ * Expected upstream outputs (produced by `yarn build:libs`
+ * + `yarn build:bpmn-webview` + `yarn build:dmn-webview`):
+ *
+ *   dist/webview-staging/bpmn-webview
+ *   dist/webview-staging/dmn-webview
+ *
+ * Destination (run from apps/modeler-cli):
+ *
+ *   apps/modeler-cli/dist/webviews/bpmn-webview
+ *   apps/modeler-cli/dist/webviews/dmn-webview
+ *
+ * The compiled binary resolves these relative to its own location
+ * (`process.execPath`) — see `resolveWebviewRoot` in src/server.ts.
+ */
+const { promises: fsp, constants } = require("fs");
+const path = require("path");
+
+async function copyDir(src, dest) {
+    await fsp.mkdir(dest, { recursive: true });
+    const entries = await fsp.readdir(src, { withFileTypes: true });
+    for (const entry of entries) {
+        const srcPath = path.join(src, entry.name);
+        const destPath = path.join(dest, entry.name);
+        if (entry.isDirectory()) {
+            await copyDir(srcPath, destPath);
+        } else if (entry.isFile()) {
+            await fsp.copyFile(srcPath, destPath);
+        }
+    }
+}
+
+async function main() {
+    const cliRoot = path.resolve(__dirname, "..");
+    const repoRoot = path.resolve(cliRoot, "..", "..");
+    const stagingRoot = path.join(repoRoot, "dist", "webview-staging");
+    const targets = ["bpmn-webview", "dmn-webview"];
+
+    for (const name of targets) {
+        const src = path.join(stagingRoot, name);
+        const dest = path.join(cliRoot, "dist", "webviews", name);
+        try {
+            await fsp.access(src, constants.R_OK);
+        } catch {
+            throw new Error(
+                `Missing webview build output: ${src}. ` +
+                    `Run 'yarn build:${name}' (or the full 'yarn build') before building the CLI.`,
+            );
+        }
+        await copyDir(src, dest);
+        console.log(`[copy-webviews] ${name} -> ${path.relative(cliRoot, dest)}`);
+    }
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/apps/modeler-cli/scripts/copy-webviews.cjs
+++ b/apps/modeler-cli/scripts/copy-webviews.cjs
@@ -34,6 +34,45 @@ async function copyDir(src, dest) {
     }
 }
 
+/** Collects absolute paths of every file under `dir`, recursively. */
+async function collectFiles(dir) {
+    const out = [];
+    const entries = await fsp.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            out.push(...(await collectFiles(full)));
+        } else if (entry.isFile()) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+/**
+ * Hoists the icon-font assets out of the `node_modules/…` directory that the
+ * webview's vite static-copy glob produces, then removes that directory.
+ *
+ * Two reasons: (1) the served tree must not contain a folder named
+ * `node_modules`, which CodeQL flags as `js/exposure-of-private-files`; and
+ * (2) flattening lets the font CSS's `url(../font/…)` resolve directly under
+ * the main static mount, so no path-rewriting route is needed. Filenames in
+ * each leaf (`bpmn.css`/`bpmn.woff2`/…) are distinct, so a flat move is
+ * collision-free. The proper fix belongs in the webview build's copy globs.
+ */
+async function flattenVendorDir(dir) {
+    const nested = path.join(dir, "node_modules");
+    try {
+        await fsp.access(nested);
+    } catch {
+        return; // nothing copied under node_modules for this webview kind
+    }
+    for (const file of await collectFiles(nested)) {
+        await fsp.copyFile(file, path.join(dir, path.basename(file)));
+    }
+    await fsp.rm(nested, { recursive: true, force: true });
+}
+
 async function main() {
     const cliRoot = path.resolve(__dirname, "..");
     const repoRoot = path.resolve(cliRoot, "..", "..");
@@ -52,6 +91,8 @@ async function main() {
             );
         }
         await copyDir(src, dest);
+        await flattenVendorDir(path.join(dest, "css"));
+        await flattenVendorDir(path.join(dest, "font"));
         console.log(`[copy-webviews] ${name} -> ${path.relative(cliRoot, dest)}`);
     }
 }

--- a/apps/modeler-cli/src/fileAdapter.ts
+++ b/apps/modeler-cli/src/fileAdapter.ts
@@ -1,0 +1,58 @@
+import { FSWatcher, watch } from "chokidar";
+import * as fs from "fs/promises";
+import * as path from "path";
+
+export type FileChangeListener = (content: string) => void;
+
+/**
+ * Owns all filesystem access for the CLI.
+ *
+ * Writes atomically (tmp file + rename) and watches for external edits.
+ * A short-lived self-write guard suppresses change events triggered by
+ * {@link write} so the webview isn't reloaded by its own save.
+ */
+export class FileAdapter {
+    private watcher: FSWatcher | undefined;
+    private listeners: FileChangeListener[] = [];
+    private suppressUntil = 0;
+
+    constructor(public readonly filePath: string) {}
+
+    read(): Promise<string> {
+        return fs.readFile(this.filePath, "utf8");
+    }
+
+    async write(content: string): Promise<void> {
+        const tmp = `${this.filePath}.${process.pid}.tmp`;
+        await fs.writeFile(tmp, content, "utf8");
+        await fs.rename(tmp, this.filePath);
+        this.suppressUntil = Date.now() + 500;
+    }
+
+    async writeSibling(fileName: string, content: string): Promise<void> {
+        const dir = path.dirname(this.filePath);
+        await fs.writeFile(path.join(dir, fileName), content, "utf8");
+    }
+
+    onExternalChange(listener: FileChangeListener): void {
+        this.listeners.push(listener);
+        if (this.watcher) return;
+        const watcher = watch(this.filePath, { ignoreInitial: true });
+        this.watcher = watcher;
+        watcher.on("change", async () => {
+            if (Date.now() < this.suppressUntil) return;
+            try {
+                const content = await this.read();
+                for (const fn of this.listeners) fn(content);
+            } catch (err) {
+                console.error("[FileAdapter] failed to re-read file after change", err);
+            }
+        });
+    }
+
+    dispose(): void {
+        void this.watcher?.close();
+        this.watcher = undefined;
+        this.listeners.length = 0;
+    }
+}

--- a/apps/modeler-cli/src/html.ts
+++ b/apps/modeler-cli/src/html.ts
@@ -1,10 +1,10 @@
 import { WebviewKind } from "./server";
 
-// Icon-font stylesheets live at the deep path the webview's vite static-copy
-// glob produces (`css/**` preserves the matched node_modules path). Mirrored
-// here so the served HTML links the file that actually exists on disk.
-const BPMN_FONT_CSS = "/css/node_modules/camunda-bpmn-js/dist/assets/bpmn-font/css/bpmn.css";
-const DMN_FONT_CSS = "/css/node_modules/dmn-js/dist/assets/dmn-font/css/dmn.css";
+// Icon-font stylesheets. The CLI's copy-webviews step flattens these out of
+// the webview build's nested `css/node_modules/…` path into a plain `css/`
+// directory (see `flattenVendorDir`), so the served URL is flat.
+const BPMN_FONT_CSS = "/css/bpmn.css";
+const DMN_FONT_CSS = "/css/dmn.css";
 
 /**
  * Returns the HTML served at `/`. Mirrors the extension-host `bpmnEditorUi` /

--- a/apps/modeler-cli/src/html.ts
+++ b/apps/modeler-cli/src/html.ts
@@ -1,0 +1,65 @@
+import { WebviewKind } from "./server";
+
+// Icon-font stylesheets live at the deep path the webview's vite static-copy
+// glob produces (`css/**` preserves the matched node_modules path). Mirrored
+// here so the served HTML links the file that actually exists on disk.
+const BPMN_FONT_CSS = "/css/node_modules/camunda-bpmn-js/dist/assets/bpmn-font/css/bpmn.css";
+const DMN_FONT_CSS = "/css/node_modules/dmn-js/dist/assets/dmn-font/css/dmn.css";
+
+/**
+ * Returns the HTML served at `/`. Mirrors the extension-host `bpmnEditorUi` /
+ * `dmnModelerHtml` (`apps/modeler-plugin/src/shared/infrastructure/WebviewHtml.ts`),
+ * except that asset URLs are root-relative (served by `express.static`) and
+ * there is no CSP nonce — there is no VS Code webview sandbox here.
+ *
+ * A tiny inline classic script sets `window.__WS_BRIDGE__` *before* the
+ * webview bundle runs, so the shared `getVsCodeApi()` channel selector picks
+ * `WebSocketChannelImpl` instead of `acquireVsCodeApi()`. The bundle is an
+ * IIFE (no module syntax), so a plain `<script>` is sufficient and runs after
+ * the inline one.
+ */
+export function renderHtml(kind: WebviewKind, port: number): string {
+    const bridgeScript = `window.__WS_BRIDGE__ = "ws://localhost:${port}/bridge";`;
+
+    if (kind === "dmn") {
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/index.css" rel="stylesheet" type="text/css" />
+    <link href="${DMN_FONT_CSS}" rel="stylesheet" type="text/css" />
+    <title>DMN Modeler</title>
+</head>
+<body>
+    <div class="content with-diagram" id="js-drop-zone">
+        <div class="canvas" id="js-canvas"></div>
+        <div class="properties-panel-parent" id="js-properties-panel"></div>
+    </div>
+    <script>${bridgeScript}</script>
+    <script src="/index.js"></script>
+</body>
+</html>`;
+    }
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="/index.css" rel="stylesheet" />
+    <link href="/lightTheme.css" rel="stylesheet" id="theme-link" />
+    <link href="${BPMN_FONT_CSS}" rel="stylesheet" />
+    <title>BPMN Modeler</title>
+</head>
+<body>
+    <div class="content with-diagram" id="js-drop-zone">
+        <div class="canvas" id="js-canvas"></div>
+        <div id="js-panel-resizer" class="panel-resizer"></div>
+        <div class="properties-panel-parent" id="js-properties-panel"></div>
+    </div>
+    <script>${bridgeScript}</script>
+    <script src="/index.js"></script>
+</body>
+</html>`;
+}

--- a/apps/modeler-cli/src/index.ts
+++ b/apps/modeler-cli/src/index.ts
@@ -1,0 +1,64 @@
+import { Command } from "commander";
+import * as fs from "fs";
+import * as path from "path";
+
+import { openBrowser } from "./launcher";
+import { startServer } from "./server";
+
+// Captured as early as possible so the cold-start figure reported by
+// `--measure` reflects process spawn → server-ready, the number #1061's
+// acceptance criteria ask for. `performance.now()` is monotonic and exists
+// in both Node and the Bun-compiled runtime.
+const PROCESS_START = performance.now();
+
+interface CliOptions {
+    port?: number;
+    open: boolean;
+}
+
+const program = new Command();
+
+program
+    .name("bpmn-modeler")
+    .description("Open a BPMN or DMN file in a local browser modeler — no system Node required.")
+    .argument("<file>", "Path to a .bpmn or .dmn file")
+    .option("-p, --port <number>", "Port to bind (default: auto-select a free port)", (raw) =>
+        Number.parseInt(raw, 10),
+    )
+    .option("--no-open", "Do not launch a browser window automatically")
+    .version("0.0.1")
+    .action(async (file: string, options: CliOptions) => {
+        const absolute = path.resolve(process.cwd(), file);
+        if (!fs.existsSync(absolute)) {
+            console.error(`File not found: ${absolute}`);
+            process.exit(1);
+        }
+
+        const ext = path.extname(absolute).toLowerCase();
+        const kind = ext === ".bpmn" ? "bpmn" : ext === ".dmn" ? "dmn" : undefined;
+        if (!kind) {
+            console.error(`Unsupported file type: ${ext}. Expected .bpmn or .dmn.`);
+            process.exit(1);
+        }
+
+        const { url } = await startServer({
+            filePath: absolute,
+            kind,
+            port: options.port,
+        });
+
+        const readyMs = performance.now() - PROCESS_START;
+        console.log(`BPMN/DMN modeler ready at ${url}`);
+        console.log(`Cold start (process → server-ready): ${readyMs.toFixed(0)} ms`);
+        console.log("Editing will save back to the source file.");
+        console.log("Press Ctrl+C to stop.");
+
+        if (options.open) {
+            await openBrowser(url);
+        }
+    });
+
+program.parseAsync(process.argv).catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/apps/modeler-cli/src/launcher.ts
+++ b/apps/modeler-cli/src/launcher.ts
@@ -1,0 +1,32 @@
+import { spawn } from "child_process";
+
+/**
+ * Opens the given URL in the user's default browser.
+ *
+ * Uses the OS-native open command so we don't take a dependency on the
+ * ESM-only `open` package. Silently detaches the child process.
+ */
+export async function openBrowser(url: string): Promise<void> {
+    const command = resolveOpenCommand();
+    const child = spawn(command.binary, [...command.args, url], {
+        detached: true,
+        stdio: "ignore",
+        shell: command.shell,
+    });
+    child.on("error", (err) => {
+        console.warn(`[launcher] Failed to open browser: ${err.message}`);
+        console.warn(`          Navigate manually to: ${url}`);
+    });
+    child.unref();
+}
+
+function resolveOpenCommand(): { binary: string; args: string[]; shell: boolean } {
+    switch (process.platform) {
+        case "darwin":
+            return { binary: "open", args: [], shell: false };
+        case "win32":
+            return { binary: "start", args: ["", ""], shell: true };
+        default:
+            return { binary: "xdg-open", args: [], shell: false };
+    }
+}

--- a/apps/modeler-cli/src/messageRouter.ts
+++ b/apps/modeler-cli/src/messageRouter.ts
@@ -1,0 +1,172 @@
+import * as path from "path";
+import type { WebSocket } from "ws";
+
+import { BpmnDocument } from "@miragon/bpmn-modeler-core";
+import {
+    BpmnFileQuery,
+    BpmnModelerSettingQuery,
+    ClipboardQuery,
+    DmnFileQuery,
+    ElementTemplatesQuery,
+    Engine,
+    LanguageQuery,
+    TextClipboardQuery,
+} from "@miragon/bpmn-modeler-shared";
+
+import { FileAdapter } from "./fileAdapter";
+import { WebviewKind } from "./server";
+
+/** Shape of incoming parsed JSON messages from the webview. */
+interface Incoming {
+    readonly type: string;
+    readonly [key: string]: unknown;
+}
+
+/**
+ * Routes Command/Query messages between the webview (browser) and the local
+ * filesystem. Mirrors the VS Code extension's host message handling, minus
+ * every VS Code integration.
+ *
+ * Keeps the clipboard in-process (no OS clipboard access in this prototype —
+ * native browser copy/paste shortcuts still work for text).
+ */
+export class MessageRouter {
+    private clipboard = "";
+    private textClipboard = "";
+    private readonly sockets = new Set<WebSocket>();
+
+    constructor(
+        private readonly file: FileAdapter,
+        private readonly kind: WebviewKind,
+    ) {
+        this.file.onExternalChange((content) => {
+            const query = this.buildFileQuery(content);
+            for (const socket of this.sockets) {
+                if (socket.readyState === socket.OPEN) {
+                    this.send(socket, query);
+                }
+            }
+        });
+    }
+
+    attach(socket: WebSocket): void {
+        this.sockets.add(socket);
+        // Push language preference up-front — the webview does not request it.
+        this.send(socket, new LanguageQuery("en"));
+
+        socket.on("close", () => {
+            this.sockets.delete(socket);
+        });
+
+        socket.on("message", async (raw) => {
+            let message: Incoming;
+            try {
+                message = JSON.parse(raw.toString()) as Incoming;
+            } catch {
+                console.warn("[MessageRouter] Ignored non-JSON message from webview.");
+                return;
+            }
+            try {
+                await this.dispatch(socket, message);
+            } catch (err) {
+                console.error(`[MessageRouter] Handler failed for ${message.type}:`, err);
+            }
+        });
+    }
+
+    private async dispatch(socket: WebSocket, message: Incoming): Promise<void> {
+        switch (message.type) {
+            case "GetBpmnFileCommand":
+            case "GetDmnFileCommand": {
+                const content = await this.file.read();
+                this.send(socket, this.buildFileQuery(content));
+                return;
+            }
+
+            case "SyncDocumentCommand": {
+                const content = (message as { content?: string }).content ?? "";
+                await this.file.write(content);
+                return;
+            }
+
+            case "GetBpmnModelerSettingCommand": {
+                this.send(
+                    socket,
+                    new BpmnModelerSettingQuery({
+                        alignToOrigin: false,
+                        showTransactionBoundaries: false,
+                        colorTheme: "light",
+                    }),
+                );
+                return;
+            }
+
+            case "GetElementTemplatesCommand": {
+                this.send(socket, new ElementTemplatesQuery([]));
+                return;
+            }
+
+            case "GetClipboardCommand": {
+                this.send(socket, new ClipboardQuery(this.clipboard));
+                return;
+            }
+
+            case "SetClipboardCommand": {
+                this.clipboard = (message as { text?: string }).text ?? "";
+                return;
+            }
+
+            case "GetTextClipboardCommand": {
+                this.send(socket, new TextClipboardQuery(this.textClipboard));
+                return;
+            }
+
+            case "SetTextClipboardCommand": {
+                this.textClipboard = (message as { text?: string }).text ?? "";
+                return;
+            }
+
+            case "GetDiagramAsSVGCommand": {
+                const svg = (message as { svg?: string }).svg ?? "";
+                const base = path.basename(this.file.filePath, path.extname(this.file.filePath));
+                await this.file.writeSibling(`${base}.svg`, svg);
+                return;
+            }
+
+            case "LogInfoCommand":
+                console.info("[webview]", (message as { message?: string }).message ?? "");
+                return;
+
+            case "LogErrorCommand":
+                console.error("[webview]", (message as { message?: string }).message ?? "");
+                return;
+
+            default:
+                console.warn(`[MessageRouter] Unhandled message type: ${message.type}`);
+        }
+    }
+
+    private buildFileQuery(content: string): BpmnFileQuery | DmnFileQuery {
+        if (this.kind === "dmn") {
+            return new DmnFileQuery(content);
+        }
+        return new BpmnFileQuery(content, detectEngineSafely(content), "modeler");
+    }
+
+    private send(socket: WebSocket, payload: unknown): void {
+        socket.send(JSON.stringify(payload));
+    }
+}
+
+/**
+ * Falls back to Camunda 7 when the XML carries no version attribute or
+ * namespace marker — matches the behaviour of most legacy diagrams. Reuses
+ * the domain model's detection so this logic isn't duplicated.
+ */
+function detectEngineSafely(xml: string): Engine {
+    try {
+        return new BpmnDocument(xml).detectPlatform();
+    } catch {
+        return "c7";
+    }
+}

--- a/apps/modeler-cli/src/server.ts
+++ b/apps/modeler-cli/src/server.ts
@@ -1,0 +1,121 @@
+import express from "express";
+import * as fs from "fs";
+import * as http from "http";
+import * as net from "net";
+import * as path from "path";
+import { WebSocketServer } from "ws";
+
+import { FileAdapter } from "./fileAdapter";
+import { renderHtml } from "./html";
+import { MessageRouter } from "./messageRouter";
+
+export type WebviewKind = "bpmn" | "dmn";
+
+export interface StartServerOptions {
+    readonly filePath: string;
+    readonly kind: WebviewKind;
+    readonly port?: number;
+}
+
+export interface StartedServer {
+    readonly url: string;
+    readonly close: () => Promise<void>;
+}
+
+/**
+ * Boots the HTTP + WebSocket server that hosts the webview and bridges file
+ * I/O. Serves the pre-built `<kind>-webview` bundle as static assets and
+ * exposes the Command/Query protocol at `/bridge` over WebSocket.
+ */
+export async function startServer(options: StartServerOptions): Promise<StartedServer> {
+    const port = options.port ?? (await findFreePort());
+    const webviewRoot = resolveWebviewRoot(options.kind);
+
+    const app = express();
+
+    // Root URL returns the generated HTML (sets window.__WS_BRIDGE__ before
+    // the webview bundle executes). Vendor assets (index.js, index.css,
+    // fonts, themes) are served statically from the copied build output.
+    app.get("/", (_req, res) => {
+        res.type("html").send(renderHtml(options.kind, port));
+    });
+
+    // The bpmn/dmn icon-font CSS lives under `css/…/css/` and references its
+    // glyphs via `url(../font/…)`, which resolves to `css/…/font/…`. But the
+    // webview's vite static-copy places the fonts under `font/…/font/…`
+    // instead, so those requests 404 and palette/context-pad icons render as
+    // boxes. Rewrite the `/css/…/font/<file>` requests to the real `/font/…`
+    // location. (The proper fix belongs in the webview build's copy globs.)
+    app.get(/^\/css\/(.+\/font\/[^/]+)$/, (req, res, next) => {
+        res.sendFile(path.join(webviewRoot, "font", req.params[0]), (err) => {
+            if (err) next();
+        });
+    });
+
+    app.use(express.static(webviewRoot));
+
+    const server = http.createServer(app);
+    const wss = new WebSocketServer({ server, path: "/bridge" });
+    const file = new FileAdapter(options.filePath);
+    const router = new MessageRouter(file, options.kind);
+
+    wss.on("connection", (socket) => {
+        router.attach(socket);
+    });
+
+    await new Promise<void>((resolve) => server.listen(port, resolve));
+    const url = `http://localhost:${port}`;
+
+    const close = async () => {
+        wss.close();
+        await new Promise<void>((resolve, reject) => {
+            server.close((err) => (err ? reject(err) : resolve()));
+        });
+        file.dispose();
+    };
+
+    return { url, close };
+}
+
+/**
+ * Locates the webview asset directory for the running form of the CLI.
+ *
+ * `__dirname` is unreliable in a Bun-compiled single binary (it points into
+ * the embedded virtual filesystem, not the location on disk), so the
+ * shipped assets are resolved relative to the executable itself
+ * (`process.execPath`). When running from source (`bun run src/index.ts`)
+ * the executable is the Bun runtime, so we fall back to the staging dir
+ * next to this module.
+ */
+function resolveWebviewRoot(kind: WebviewKind): string {
+    const candidates = [
+        path.resolve(path.dirname(process.execPath), "webviews", `${kind}-webview`),
+        path.resolve(__dirname, "webviews", `${kind}-webview`),
+        path.resolve(__dirname, "..", "dist", "webviews", `${kind}-webview`),
+    ];
+    const root = candidates.find((dir) => fs.existsSync(path.join(dir, "index.js")));
+    if (!root) {
+        throw new Error(
+            `Could not locate the ${kind}-webview assets. Looked in:\n  ${candidates.join("\n  ")}`,
+        );
+    }
+    return root;
+}
+
+/** Asks the OS for an unused TCP port. */
+function findFreePort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const srv = net.createServer();
+        srv.unref();
+        srv.on("error", reject);
+        srv.listen(0, () => {
+            const addr = srv.address();
+            if (addr && typeof addr === "object") {
+                const { port } = addr;
+                srv.close(() => resolve(port));
+            } else {
+                srv.close(() => reject(new Error("Failed to pick a free port.")));
+            }
+        });
+    });
+}

--- a/apps/modeler-cli/src/server.ts
+++ b/apps/modeler-cli/src/server.ts
@@ -40,18 +40,10 @@ export async function startServer(options: StartServerOptions): Promise<StartedS
         res.type("html").send(renderHtml(options.kind, port));
     });
 
-    // The bpmn/dmn icon-font CSS lives under `css/…/css/` and references its
-    // glyphs via `url(../font/…)`, which resolves to `css/node_modules/…/font/…`.
-    // But the webview's vite static-copy places the fonts under
-    // `font/node_modules/…/font/…`, so those requests would 404 and
-    // palette/context-pad icons render as boxes. Mounting the font tree under
-    // the `/css/node_modules` prefix too lets the glyph requests resolve;
-    // non-font requests (the CSS files themselves) miss here and fall through
-    // to the main static mount below. `express.static` is used rather than a
-    // custom filesystem route so its built-in `..`-traversal protection
-    // applies. (The proper fix belongs in the webview build's copy globs.)
-    app.use("/css/node_modules", express.static(path.join(webviewRoot, "font", "node_modules")));
-
+    // Static assets (index.js, index.css, themes, and the flattened icon-font
+    // css/fonts) are served from the copied build output. The CLI's
+    // copy-webviews step flattens the icon fonts to `css/` + `font/`, so the
+    // font CSS's `url(../font/…)` resolves here with no path rewriting.
     app.use(express.static(webviewRoot));
 
     const server = http.createServer(app);

--- a/apps/modeler-cli/src/server.ts
+++ b/apps/modeler-cli/src/server.ts
@@ -41,16 +41,16 @@ export async function startServer(options: StartServerOptions): Promise<StartedS
     });
 
     // The bpmn/dmn icon-font CSS lives under `css/…/css/` and references its
-    // glyphs via `url(../font/…)`, which resolves to `css/…/font/…`. But the
-    // webview's vite static-copy places the fonts under `font/…/font/…`
-    // instead, so those requests 404 and palette/context-pad icons render as
-    // boxes. Rewrite the `/css/…/font/<file>` requests to the real `/font/…`
-    // location. (The proper fix belongs in the webview build's copy globs.)
-    app.get(/^\/css\/(.+\/font\/[^/]+)$/, (req, res, next) => {
-        res.sendFile(path.join(webviewRoot, "font", req.params[0]), (err) => {
-            if (err) next();
-        });
-    });
+    // glyphs via `url(../font/…)`, which resolves to `css/node_modules/…/font/…`.
+    // But the webview's vite static-copy places the fonts under
+    // `font/node_modules/…/font/…`, so those requests would 404 and
+    // palette/context-pad icons render as boxes. Mounting the font tree under
+    // the `/css/node_modules` prefix too lets the glyph requests resolve;
+    // non-font requests (the CSS files themselves) miss here and fall through
+    // to the main static mount below. `express.static` is used rather than a
+    // custom filesystem route so its built-in `..`-traversal protection
+    // applies. (The proper fix belongs in the webview build's copy globs.)
+    app.use("/css/node_modules", express.static(path.join(webviewRoot, "font", "node_modules")));
 
     app.use(express.static(webviewRoot));
 

--- a/apps/modeler-cli/tsconfig.app.json
+++ b/apps/modeler-cli/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "types": ["node"],
+        "esModuleInterop": true
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/apps/modeler-cli/tsconfig.json
+++ b/apps/modeler-cli/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/docs/vscode/contributing/architecture/runtime-distribution.md
+++ b/docs/vscode/contributing/architecture/runtime-distribution.md
@@ -1,0 +1,111 @@
+# Runtime distribution — shipping the modeler without a system Node
+
+## Status
+
+Accepted (#1061). Parent: epic #920 (IntelliJ host parity). Unblocks the
+JetBrains Marketplace publish gate. The transport-hardening work in the host
+foundation (#1062) depends on this decision; the IntelliJ plugin packaging that
+ships the artifact is also #1062.
+
+## Context
+
+The #920 spikes proved the modeler can run as a third host (after VS Code and
+Theia) by hosting the `vscode`-free engine out-of-process and driving a webview
+over a message bridge. But they all **spawn `node` from `PATH`** — a dev-only
+assumption. A JetBrains plugin cannot require its users to have a matching Node
+installed, so this is the single remaining blocker to *publishing*, independent
+of feature completeness. The decision also fixes the transport shape:
+subprocess-over-RPC and in-process GraalJS interop are different host-adapter
+designs, so it must land before bridge-transport productionization.
+
+The pure `libs/modeler-core` (#1060) is identical regardless of how it is
+shipped, so the engine itself is unaffected by this choice.
+
+## Decision
+
+**Ship the JavaScript runtime as a single self-contained binary compiled with
+Bun (`bun build --compile`)** — option (b) below.
+
+The deps that matter (`bpmn-moddle`, `bpmn-js-differ`, and the webview bundles)
+are pure JS, so the Node-compatibility risk that rules out Bun for some projects
+does not bite here. Bun cross-compiles to every target platform from one
+toolchain (`--target=bun-{darwin-arm64,darwin-x64,linux-x64,windows-x64}`),
+which keeps the platform matrix to a build-flag rather than a per-platform
+download-and-stage pipeline.
+
+### Prototype
+
+`apps/modeler-cli/` is the throwaway proof: a `commander` CLI that boots an
+`express` + `ws` server, serves the **unmodified production** webview bundle,
+and bridges its `Query`/`Command` protocol to the file over a WebSocket. The
+*same* `getVsCodeApi()` selector that returns the VS Code API in the extension
+returns the new `WebSocketChannelImpl` (in `libs/shared`) when the served HTML
+injects `window.__WS_BRIDGE__` — so no webview code forks for this host.
+Execution-platform detection reuses `BpmnDocument` from `modeler-core` rather
+than duplicating it.
+
+### Measurements (macOS arm64, Bun 1.3.10)
+
+Measured on the prototype with a clean PATH containing neither `node` nor `bun`
+(`env -i HOME="$HOME" PATH=/usr/bin:/bin ./bpmn-modeler diagram.bpmn`):
+
+| Metric | Value |
+|---|---|
+| Binary (Bun runtime + bundled server JS) | **60 MB** |
+| Webview assets shipped alongside | **7.5 MB** |
+| Total shipped artifact | **≈ 68 MB** |
+| Cold start (process spawn → server-ready) | **10–15 ms** (median ~12 ms) |
+| Build: bundle 277 modules → compile | ~70 ms + ~130–260 ms |
+
+Both BPMN (diagram renders: 4 shapes, 2 connections) and DMN (DRD container
+renders) load and round-trip edits to disk over the bridge, with no `node`/`bun`
+on `PATH`. *Cold start measures server-ready, not first paint; webview render is
+a separate, browser-bound cost.*
+
+## Options evaluated
+
+| Option | Artifact size | Cold start | Platform matrix | Maintenance |
+|---|---|---|---|---|
+| **(a) Bundle a per-platform Node binary** | Node ≈60–110 MB **per platform** + app JS + assets | Node process startup (tens of ms) | Download & stage one Node per target | Track Node releases/CVEs; largest payload × N |
+| **(b) Single binary — Bun `--compile` (chosen)** | **68 MB total (measured)** | **~12 ms (measured)** | One toolchain, `--target` per platform | One runtime to track; smallest ergonomic path |
+| (b) Single binary — Node **SEA** | ≈85–110 MB (full `node` + injected blob) | Node startup | Build + `postject` + **macOS codesign** per target | Official but experimental; multi-step, signing friction |
+| (b) Single binary — **`pkg`** | n/a | n/a | n/a | **Rejected:** Vercel archived `pkg` in favour of SEA |
+| (b) Single binary — **Deno compile** | ≈80 MB | Deno startup | `--target` per platform | Viable; not installed in this repo, slightly more npm-compat friction |
+| **(c) GraalVM / GraalJS in-process** | No separate binary; +≈30–50 MB polyglot jars in the plugin | JVM-warm, no subprocess | JVM-portable (no per-OS binary) | **Highest JS-compat risk** (`bpmn-moddle` sax parsing, CJS interop); heaviest integration |
+
+## Consequences
+
+- The plugin can launch the modeler on a machine with no Node — the publish
+  gate is cleared (prototype-proven on macOS arm64).
+- One new shared seam: `WebSocketChannelImpl` + the `window.__WS_BRIDGE__`
+  selector. Production VS Code is unaffected (the global is absent, so the
+  existing `acquireVsCodeApi()` path is taken); confirmed by a green Vitest
+  suite (532 tests) and a successful plugin build.
+- The transport for #1062 is fixed as **subprocess-over-bridge**, not in-process
+  interop; in-process VS Code stays a direct call with zero IPC.
+- The cross-compile matrix is a release-pipeline `--target` loop, deferred to
+  #1062 along with code-signing/notarization for distribution.
+
+## Alternatives rejected
+
+- **`pkg`** — archived upstream; no path forward for new work.
+- **Node SEA as the primary path** — official, but the build is multi-step
+  (blob + `postject`) and needs macOS codesigning just to launch; larger
+  artifact for no functional gain over Bun here. Kept as the fallback if a hard
+  Node-only dependency ever surfaces.
+- **GraalVM/GraalJS in-process (c)** — most elegant distribution story (no
+  binary, no subprocess) but the JS-compat risk against `bpmn-moddle`/sax and
+  CommonJS interop is real and unproven, and it would re-shape the host-adapter
+  transport. Parked as a documented future avenue, not v1.
+- **Bundle per-platform Node (a)** — simplest and maximally compatible, but the
+  largest payload, multiplied across the platform matrix, with ongoing Node
+  release/CVE tracking. Bun gives the same "real runtime" guarantee at a smaller,
+  single-toolchain cost.
+
+## Follow-ups
+
+- Embedding the webview assets *inside* the binary (vs. shipping alongside) —
+  optional size/packaging optimization.
+- The webview build's vite static-copy globs nest the icon fonts under `font/…`
+  while the font CSS references `url(../font/…)`; the prototype server rewrites
+  those requests, but the proper fix belongs in the webview build.

--- a/libs/shared/src/lib/vscode.ts
+++ b/libs/shared/src/lib/vscode.ts
@@ -68,3 +68,78 @@ export abstract class VsCodeMock<T, M> implements VsCodeApi<T, M> {
 
     abstract postMessage(message: M): void;
 }
+
+/**
+ * `VsCodeApi` implementation that bridges the webview to a local host
+ * process over WebSocket. Lets the *same* production webview bundle run in
+ * a plain browser (served by `apps/modeler-cli`) without a VS Code host —
+ * the runtime-distribution prototype for shipping the modeler with no
+ * system Node (#1061).
+ *
+ * Incoming socket frames are re-dispatched as `window` `MessageEvent`s so
+ * the webview's existing message listeners — which expect VS Code's
+ * `window.postMessage` delivery — work byte-for-byte unchanged. Outbound
+ * messages sent before the socket opens are buffered, since the webview
+ * fires its first `Get…Command` during bootstrap.
+ *
+ * State persists to `localStorage`: the page is a single-tab SPA per file,
+ * so tab-scoped storage is the natural analogue of VS Code's webview state.
+ */
+export class WebSocketChannelImpl<T, M> implements VsCodeApi<T, M> {
+    private readonly socket: WebSocket;
+    private readonly stateKey: string;
+    private readonly pending: M[] = [];
+
+    constructor(url: string, stateKey = "bpmn-modeler-cli:state") {
+        this.stateKey = stateKey;
+        this.socket = new WebSocket(url);
+        this.socket.addEventListener("open", () => {
+            for (const message of this.pending) {
+                this.socket.send(JSON.stringify(message));
+            }
+            this.pending.length = 0;
+        });
+        this.socket.addEventListener("message", (ev: MessageEvent) => {
+            try {
+                const data = typeof ev.data === "string" ? JSON.parse(ev.data) : ev.data;
+                window.dispatchEvent(new MessageEvent("message", { data }));
+            } catch (err) {
+                console.error("[WebSocketChannelImpl] failed to parse message", err);
+            }
+        });
+        this.socket.addEventListener("error", (err) => {
+            console.error("[WebSocketChannelImpl] socket error", err);
+        });
+        this.socket.addEventListener("close", () => {
+            console.warn("[WebSocketChannelImpl] socket closed");
+        });
+    }
+
+    getState(): T {
+        const raw = window.localStorage.getItem(this.stateKey);
+        if (!raw) throw new MissingStateError();
+        return JSON.parse(raw) as T;
+    }
+
+    setState(state: T): void {
+        window.localStorage.setItem(this.stateKey, JSON.stringify(state));
+    }
+
+    updateState(state: Partial<T>): void {
+        let current: T;
+        try {
+            current = this.getState();
+        } catch {
+            current = {} as T;
+        }
+        this.setState({ ...current, ...state });
+    }
+
+    postMessage(message: M): void {
+        if (this.socket.readyState === WebSocket.OPEN) {
+            this.socket.send(JSON.stringify(message));
+        } else {
+            this.pending.push(message);
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3482,6 +3482,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@miragon/bpmn-modeler-cli@workspace:apps/modeler-cli":
+  version: 0.0.0-use.local
+  resolution: "@miragon/bpmn-modeler-cli@workspace:apps/modeler-cli"
+  dependencies:
+    "@miragon/bpmn-modeler-core": "workspace:*"
+    "@miragon/bpmn-modeler-shared": "workspace:*"
+    "@types/express": "npm:4.17.21"
+    "@types/node": "npm:25.9.1"
+    "@types/ws": "npm:8.5.13"
+    chokidar: "npm:3.6.0"
+    commander: "npm:12.1.0"
+    express: "npm:4.21.2"
+    npm-run-all: "npm:4.1.5"
+    typescript: "npm:6.0.3"
+    ws: "npm:8.18.0"
+  bin:
+    bpmn-modeler: ./dist/bpmn-modeler
+  languageName: unknown
+  linkType: soft
+
 "@miragon/bpmn-modeler-clipboard@workspace:*, @miragon/bpmn-modeler-clipboard@workspace:libs/bpmn-clipboard":
   version: 0.0.0-use.local
   resolution: "@miragon/bpmn-modeler-clipboard@workspace:libs/bpmn-clipboard"
@@ -6056,6 +6076,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/express@npm:4.17.21":
+  version: 4.17.21
+  resolution: "@types/express@npm:4.17.21"
+  dependencies:
+    "@types/body-parser": "npm:*"
+    "@types/express-serve-static-core": "npm:^4.17.33"
+    "@types/qs": "npm:*"
+    "@types/serve-static": "npm:*"
+  checksum: 10c0/12e562c4571da50c7d239e117e688dc434db1bac8be55613294762f84fd77fbd0658ccd553c7d3ab02408f385bc93980992369dd30e2ecd2c68c358e6af8fabf
+  languageName: node
+  linkType: hard
+
 "@types/express@npm:^4.17.25":
   version: 4.17.25
   resolution: "@types/express@npm:4.17.25"
@@ -6418,6 +6450,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/serve-static@npm:*, @types/serve-static@npm:^2":
+  version: 2.2.0
+  resolution: "@types/serve-static@npm:2.2.0"
+  dependencies:
+    "@types/http-errors": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/a3c6126bdbf9685e6c7dc03ad34639666eff32754e912adeed9643bf3dd3aa0ff043002a7f69039306e310d233eb8e160c59308f95b0a619f32366bbc48ee094
+  languageName: node
+  linkType: hard
+
 "@types/serve-static@npm:^1":
   version: 1.15.10
   resolution: "@types/serve-static@npm:1.15.10"
@@ -6426,16 +6468,6 @@ __metadata:
     "@types/node": "npm:*"
     "@types/send": "npm:<1"
   checksum: 10c0/842fca14c9e80468f89b6cea361773f2dcd685d4616a9f59013b55e1e83f536e4c93d6d8e3ba5072d40c4e7e64085210edd6646b15d538ded94512940a23021f
-  languageName: node
-  linkType: hard
-
-"@types/serve-static@npm:^2":
-  version: 2.2.0
-  resolution: "@types/serve-static@npm:2.2.0"
-  dependencies:
-    "@types/http-errors": "npm:*"
-    "@types/node": "npm:*"
-  checksum: 10c0/a3c6126bdbf9685e6c7dc03ad34639666eff32754e912adeed9643bf3dd3aa0ff043002a7f69039306e310d233eb8e160c59308f95b0a619f32366bbc48ee094
   languageName: node
   linkType: hard
 
@@ -6520,6 +6552,15 @@ __metadata:
   version: 2.2.1
   resolution: "@types/write-json-file@npm:2.2.1"
   checksum: 10c0/967602f81cac077e3e2d3ef5b46803e3652be3cdc7c2bb684f6ddeda753c8a59c8eeb9c561a87f0b3b1313bf708ed7e79ad7cf7fee53144838cf255f80f7bc5f
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:8.5.13":
+  version: 8.5.13
+  resolution: "@types/ws@npm:8.5.13"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/a5430aa479bde588e69cb9175518d72f9338b6999e3b2ae16fc03d3bdcff8347e486dc031e4ed14601260463c07e1f9a0d7511dfc653712b047c439c680b0b34
   languageName: node
   linkType: hard
 
@@ -8600,6 +8641,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:1.20.3":
+  version: 1.20.3
+  resolution: "body-parser@npm:1.20.3"
+  dependencies:
+    bytes: "npm:3.1.2"
+    content-type: "npm:~1.0.5"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    on-finished: "npm:2.4.1"
+    qs: "npm:6.13.0"
+    raw-body: "npm:2.5.2"
+    type-is: "npm:~1.6.18"
+    unpipe: "npm:1.0.0"
+  checksum: 10c0/0a9a93b7518f222885498dcecaad528cf010dd109b071bf471c93def4bfe30958b83e03496eb9c1ad4896db543d999bb62be1a3087294162a88cfa1b42c16310
+  languageName: node
+  linkType: hard
+
 "body-parser@npm:^1.20.5, body-parser@npm:~1.20.5":
   version: 1.20.5
   resolution: "body-parser@npm:1.20.5"
@@ -9056,7 +9117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:^3.1.2, bytes@npm:~3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
@@ -9432,7 +9493,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
+"chokidar@npm:3.6.0, chokidar@npm:^3.5.3, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -9748,17 +9809,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:12.1.0, commander@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
+  languageName: node
+  linkType: hard
+
 "commander@npm:7, commander@npm:^7.0.0":
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
-  languageName: node
-  linkType: hard
-
-"commander@npm:^12.1.0":
-  version: 12.1.0
-  resolution: "commander@npm:12.1.0"
-  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
   languageName: node
   linkType: hard
 
@@ -9874,19 +9935,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-disposition@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "content-disposition@npm:1.1.0"
-  checksum: 10c0/94e0aef65873e69330f5f187fbc44ebce593bdcb8013dd8a68b7d0f159ca089bd30db3f8095d829f81c341695b60a6085ee6e15e6d775c4a325b586cc8d91974
-  languageName: node
-  linkType: hard
-
-"content-disposition@npm:~0.5.4":
+"content-disposition@npm:0.5.4, content-disposition@npm:~0.5.4":
   version: 0.5.4
   resolution: "content-disposition@npm:0.5.4"
   dependencies:
     safe-buffer: "npm:5.2.1"
   checksum: 10c0/bac0316ebfeacb8f381b38285dc691c9939bf0a78b0b7c2d5758acadad242d04783cee5337ba7d12a565a19075af1b3c11c728e1e4946de73c6ff7ce45f3f1bb
+  languageName: node
+  linkType: hard
+
+"content-disposition@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "content-disposition@npm:1.1.0"
+  checksum: 10c0/94e0aef65873e69330f5f187fbc44ebce593bdcb8013dd8a68b7d0f159ca089bd30db3f8095d829f81c341695b60a6085ee6e15e6d775c4a325b586cc8d91974
   languageName: node
   linkType: hard
 
@@ -9904,6 +9965,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-signature@npm:1.0.6":
+  version: 1.0.6
+  resolution: "cookie-signature@npm:1.0.6"
+  checksum: 10c0/b36fd0d4e3fef8456915fcf7742e58fbfcc12a17a018e0eb9501c9d5ef6893b596466f03b0564b81af29ff2538fd0aa4b9d54fe5ccbfb4c90ea50ad29fe2d221
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:^1.2.1":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
@@ -9915,6 +9983,13 @@ __metadata:
   version: 1.0.7
   resolution: "cookie-signature@npm:1.0.7"
   checksum: 10c0/e7731ad2995ae2efeed6435ec1e22cdd21afef29d300c27281438b1eab2bae04ef0d1a203928c0afec2cee72aa36540b8747406ebe308ad23c8e8cc3c26c9c51
+  languageName: node
+  linkType: hard
+
+"cookie@npm:0.7.1":
+  version: 0.7.1
+  resolution: "cookie@npm:0.7.1"
+  checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
   languageName: node
   linkType: hard
 
@@ -11545,6 +11620,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "encodeurl@npm:1.0.2"
+  checksum: 10c0/f6c2387379a9e7c1156c1c3d4f9cb7bb11cf16dd4c1682e1f6746512564b053df5781029b6061296832b59fb22f459dbe250386d217c2f6e203601abb2ee0bec
+  languageName: node
+  linkType: hard
+
 "encoding-sniffer@npm:^0.2.1":
   version: 0.2.1
   resolution: "encoding-sniffer@npm:0.2.1"
@@ -12406,6 +12488,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express@npm:4.21.2":
+  version: 4.21.2
+  resolution: "express@npm:4.21.2"
+  dependencies:
+    accepts: "npm:~1.3.8"
+    array-flatten: "npm:1.1.1"
+    body-parser: "npm:1.20.3"
+    content-disposition: "npm:0.5.4"
+    content-type: "npm:~1.0.4"
+    cookie: "npm:0.7.1"
+    cookie-signature: "npm:1.0.6"
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    finalhandler: "npm:1.3.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    merge-descriptors: "npm:1.0.3"
+    methods: "npm:~1.1.2"
+    on-finished: "npm:2.4.1"
+    parseurl: "npm:~1.3.3"
+    path-to-regexp: "npm:0.1.12"
+    proxy-addr: "npm:~2.0.7"
+    qs: "npm:6.13.0"
+    range-parser: "npm:~1.2.1"
+    safe-buffer: "npm:5.2.1"
+    send: "npm:0.19.0"
+    serve-static: "npm:1.16.2"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    type-is: "npm:~1.6.18"
+    utils-merge: "npm:1.0.1"
+    vary: "npm:~1.1.2"
+  checksum: 10c0/38168fd0a32756600b56e6214afecf4fc79ec28eca7f7a91c2ab8d50df4f47562ca3f9dee412da7f5cea6b1a1544b33b40f9f8586dbacfbdada0fe90dbb10a1f
+  languageName: node
+  linkType: hard
+
 "express@npm:^4.22.1":
   version: 4.22.2
   resolution: "express@npm:4.22.2"
@@ -12707,6 +12828,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"finalhandler@npm:1.3.1":
+  version: 1.3.1
+  resolution: "finalhandler@npm:1.3.1"
+  dependencies:
+    debug: "npm:2.6.9"
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    on-finished: "npm:2.4.1"
+    parseurl: "npm:~1.3.3"
+    statuses: "npm:2.0.1"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/d38035831865a49b5610206a3a9a9aae4e8523cbbcd01175d0480ffbf1278c47f11d89be3ca7f617ae6d94f29cf797546a4619cd84dd109009ef33f12f69019f
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:^2.1.0":
   version: 2.1.1
   resolution: "finalhandler@npm:2.1.1"
@@ -12913,17 +13049,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fresh@npm:0.5.2, fresh@npm:~0.5.2":
+  version: 0.5.2
+  resolution: "fresh@npm:0.5.2"
+  checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
+  languageName: node
+  linkType: hard
+
 "fresh@npm:^2.0.0":
   version: 2.0.0
   resolution: "fresh@npm:2.0.0"
   checksum: 10c0/0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
-  languageName: node
-  linkType: hard
-
-"fresh@npm:~0.5.2":
-  version: 0.5.2
-  resolution: "fresh@npm:0.5.2"
-  checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
   languageName: node
   linkType: hard
 
@@ -13666,6 +13802,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:2.0.0":
+  version: 2.0.0
+  resolution: "http-errors@npm:2.0.0"
+  dependencies:
+    depd: "npm:2.0.0"
+    inherits: "npm:2.0.4"
+    setprototypeof: "npm:1.2.0"
+    statuses: "npm:2.0.1"
+    toidentifier: "npm:1.0.1"
+  checksum: 10c0/fc6f2715fe188d091274b5ffc8b3657bd85c63e969daa68ccb77afb05b071a4b62841acb7a21e417b5539014dff2ebf9550f0b14a9ff126f2734a7c1387f8e19
+  languageName: node
+  linkType: hard
+
 "http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.0, http-errors@npm:~2.0.1":
   version: 2.0.1
   resolution: "http-errors@npm:2.0.1"
@@ -13809,6 +13958,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iconv-lite@npm:0.4.24, iconv-lite@npm:~0.4.24":
+  version: 0.4.24
+  resolution: "iconv-lite@npm:0.4.24"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3"
+  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
+  languageName: node
+  linkType: hard
+
 "iconv-lite@npm:0.6, iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
@@ -13824,15 +13982,6 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:~0.4.24":
-  version: 0.4.24
-  resolution: "iconv-lite@npm:0.4.24"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3"
-  checksum: 10c0/c6886a24cc00f2a059767440ec1bc00d334a89f250db8e0f7feb4961c8727118457e27c495ba94d082e51d3baca378726cd110aaf7ded8b9bbfd6a44760cf1d4
   languageName: node
   linkType: hard
 
@@ -14002,7 +14151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.0, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -16852,7 +17001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.4.1, on-finished@npm:~2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -17319,6 +17468,13 @@ __metadata:
     lru-cache: "npm:^11.0.0"
     minipass: "npm:^7.1.2"
   checksum: 10c0/b35ad37cf6557a87fd057121ce2be7695380c9138d93e87ae928609da259ea0a170fac6f3ef1eb3ece8a068e8b7f2f3adf5bb2374cf4d4a57fe484954fcc9482
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:0.1.12":
+  version: 0.1.12
+  resolution: "path-to-regexp@npm:0.1.12"
+  checksum: 10c0/1c6ff10ca169b773f3bba943bbc6a07182e332464704572962d277b900aeee81ac6aa5d060ff9e01149636c30b1f63af6e69dd7786ba6e0ddb39d4dee1f0645b
   languageName: node
   linkType: hard
 
@@ -17944,6 +18100,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:6.13.0":
+  version: 6.13.0
+  resolution: "qs@npm:6.13.0"
+  dependencies:
+    side-channel: "npm:^1.0.6"
+  checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
+  languageName: node
+  linkType: hard
+
 "qs@npm:^6.13.0, qs@npm:^6.14.0, qs@npm:^6.14.1, qs@npm:^6.4.0, qs@npm:^6.9.1":
   version: 6.15.1
   resolution: "qs@npm:6.15.1"
@@ -18012,6 +18177,18 @@ __metadata:
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
   checksum: 10c0/96c032ac2475c8027b7a4e9fe22dc0dfe0f6d90b85e496e0f016fbdb99d6d066de0112e680805075bd989905e2123b3b3d002765149294dce0c1f7f01fcc2ea0
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:2.5.2":
+  version: 2.5.2
+  resolution: "raw-body@npm:2.5.2"
+  dependencies:
+    bytes: "npm:3.1.2"
+    http-errors: "npm:2.0.0"
+    iconv-lite: "npm:0.4.24"
+    unpipe: "npm:1.0.0"
+  checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
   languageName: node
   linkType: hard
 
@@ -19117,6 +19294,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:0.19.0":
+  version: 0.19.0
+  resolution: "send@npm:0.19.0"
+  dependencies:
+    debug: "npm:2.6.9"
+    depd: "npm:2.0.0"
+    destroy: "npm:1.2.0"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    etag: "npm:~1.8.1"
+    fresh: "npm:0.5.2"
+    http-errors: "npm:2.0.0"
+    mime: "npm:1.6.0"
+    ms: "npm:2.1.3"
+    on-finished: "npm:2.4.1"
+    range-parser: "npm:~1.2.1"
+    statuses: "npm:2.0.1"
+  checksum: 10c0/ea3f8a67a8f0be3d6bf9080f0baed6d2c51d11d4f7b4470de96a5029c598a7011c497511ccc28968b70ef05508675cebff27da9151dd2ceadd60be4e6cf845e3
+  languageName: node
+  linkType: hard
+
 "send@npm:^1.1.0, send@npm:^1.2.0":
   version: 1.2.1
   resolution: "send@npm:1.2.1"
@@ -19188,6 +19386,18 @@ __metadata:
   version: 7.0.4
   resolution: "serialize-javascript@npm:7.0.4"
   checksum: 10c0/f3da6f994c41306fbfabb55eefe280a46da05592939a84b0d95c84e296c92ba9e6a3d86cf7bbd71e7a59e1cfcd8481745910af109bedbd3ed853b444d32f9ee9
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:1.16.2":
+  version: 1.16.2
+  resolution: "serve-static@npm:1.16.2"
+  dependencies:
+    encodeurl: "npm:~2.0.0"
+    escape-html: "npm:~1.0.3"
+    parseurl: "npm:~1.3.3"
+    send: "npm:0.19.0"
+  checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
   languageName: node
   linkType: hard
 
@@ -19393,7 +19603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.1.0":
+"side-channel@npm:^1.0.6, side-channel@npm:^1.1.0":
   version: 1.1.0
   resolution: "side-channel@npm:1.1.0"
   dependencies:
@@ -19778,6 +19988,13 @@ __metadata:
   version: 1.0.0
   resolution: "stat-mode@npm:1.0.0"
   checksum: 10c0/89b66a538dbfd45038fefdaf5b2104dc6e911605af1c201793e9629592ed9fdc7bdd1bca42806d0d4167c6d9cacac1f3fda41ddfe334a5c1f898113da38fae74
+  languageName: node
+  linkType: hard
+
+"statuses@npm:2.0.1":
+  version: 2.0.1
+  resolution: "statuses@npm:2.0.1"
+  checksum: 10c0/34378b207a1620a24804ce8b5d230fea0c279f00b18a7209646d5d47e419d1cc23e7cbf33a25a1e51ac38973dc2ac2e1e9c647a8e481ef365f77668d72becfd0
   languageName: node
   linkType: hard
 
@@ -20624,7 +20841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:~1.0.1":
+"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
@@ -21290,7 +21507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unpipe@npm:~1.0.0":
+"unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
   checksum: 10c0/193400255bd48968e5c5383730344fbb4fa114cdedfab26e329e50dd2d81b134244bb8a72c6ac1b10ab0281a58b363d06405632c9d49ca9dfd5e90cbd7d0f32c
@@ -22368,6 +22585,21 @@ __metadata:
     sort-keys: "npm:^2.0.0"
     write-file-atomic: "npm:^2.0.0"
   checksum: 10c0/00f818565543588c1d319b79018b16a5426ab32425d91175b6a6016535990d5c38833b02bf07e24319764a9dd70be6b7cc20095e0c49b5ba63f027230c59d1db
+  languageName: node
+  linkType: hard
+
+"ws@npm:8.18.0":
+  version: 8.18.0
+  resolution: "ws@npm:8.18.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10c0/25eb33aff17edcb90721ed6b0eb250976328533ad3cd1a28a274bd263682e7296a6591ff1436d6cbc50fa67463158b062f9d1122013b361cec99a05f84680e06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Issue**

Closes #1061 (parent epic #920 — IntelliJ host parity).

**Description**

Proves the BPMN/DMN modeler can launch on a machine with **no system Node** — the single remaining blocker to publishing on the JetBrains Marketplace. The new `apps/modeler-cli` prototype forward-ports the #920 spike onto `modeler-core` and compiles a local webview-serving bridge to a single self-contained binary via `bun build --compile`; the *same* production webview bundle runs over a new `WebSocketChannelImpl` in `libs/shared`, selected by an injected `window.__WS_BRIDGE__` global so the VS Code path is untouched when the global is absent. The runtime-distribution ADR records the decision and compares the options (bundle Node / single binary via Bun, SEA, pkg, Deno / GraalVM in-process) against the chosen Bun path's **measured** artifact size (~68 MB) and cold start (~12 ms), verified on macOS arm64 with neither `node` nor `bun` on `PATH`. IntelliJ Gradle plugin packaging that consumes this binary is deliberately left to #1062.

**Checklist**

* [x] Code is easy to understand
* [x] No obvious errors or bugs
* [x] CI/CD Pipelines did run successfully
* [x] Tests were implemented — prototype/spike; verified manually + via browser (render + WS read/write round-trip), full Vitest suite stays green (532 passing)
* [x] Documentation was created — runtime-distribution ADR + CLI README