### PR TITLE
feat(intellij): wire clipboard port to the IntelliJ system clipboard (#1066)

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -10,8 +10,11 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.InputStream
@@ -269,6 +272,8 @@ class CoreProcess(private val project: Project) : Disposable {
             "document/write" -> handleWrite(params, id)
             "document/save" -> handleSave(params, id)
             "picker/show" -> handlePick(params, id)
+            "clipboard/read" -> handleClipboardRead(id)
+            "clipboard/write" -> handleClipboardWrite(params)
             "statusBar/showEngineVersion" -> {
                 val label = if (params.get("platform")?.asString == "c7") "Camunda 7" else "Camunda 8"
                 EngineStatusBarWidget.updateEngine(project, "$label ${params.get("version")?.asString}")
@@ -402,6 +407,31 @@ class CoreProcess(private val project: Project) : Disposable {
             HostPicker.show(project, title, placeholder, canPickMany, items) { selected ->
                 reply(id, mapOf("selected" to selected))
             }
+        }
+    }
+
+    /**
+     * Reads the system clipboard for the webview's copy/paste mediator. The
+     * sandboxed JCEF page can't touch the clipboard and the core is a separate
+     * process, so the host reads on their behalf and replies with the text.
+     * `runCatching` → `""` keeps a denied/empty/non-text clipboard from breaking
+     * paste — an empty string is a valid "nothing to paste" answer.
+     */
+    private fun handleClipboardRead(id: Int?) {
+        ApplicationManager.getApplication().invokeLater {
+            val text =
+                runCatching {
+                    CopyPasteManager.getInstance().getContents<String>(DataFlavor.stringFlavor)
+                }.getOrNull().orEmpty()
+            id?.let { reply(it, mapOf("text" to text)) }
+        }
+    }
+
+    /** Writes the webview's copied text onto the system clipboard (fire-and-forget). */
+    private fun handleClipboardWrite(params: JsonObject) {
+        val text = params.get("text")?.takeIf { !it.isJsonNull }?.asString.orEmpty()
+        ApplicationManager.getApplication().invokeLater {
+            CopyPasteManager.getInstance().setContents(StringSelection(text))
         }
     }
 

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -4,6 +4,7 @@ import { UserCancelledError } from "@miragon/bpmn-modeler-core";
 
 import {
     DocumentMirror,
+    RpcClipboard,
     RpcDocumentPort,
     RpcEditorHandle,
     RpcNotifier,
@@ -345,6 +346,37 @@ describe("RpcSecretStore", () => {
         const getOauth = store.getOAuth2();
         await answerLast(null);
         await expect(getOauth).resolves.toBeUndefined();
+    });
+});
+
+describe("RpcClipboard", () => {
+    it("reads via a clipboard/read request and resolves with the host's text", async () => {
+        const { frames, rpc, answerLast } = harness();
+        const clipboard = new RpcClipboard(rpc);
+
+        const pending = clipboard.readClipboard();
+        expect(last(frames)).toMatchObject({ method: "clipboard/read", params: {} });
+        await answerLast({ text: "copied" });
+
+        await expect(pending).resolves.toBe("copied");
+    });
+
+    it("resolves to an empty string when the host reports no clipboard text", async () => {
+        const { rpc, answerLast } = harness();
+        const clipboard = new RpcClipboard(rpc);
+
+        const pending = clipboard.readClipboard();
+        await answerLast({});
+
+        await expect(pending).resolves.toBe("");
+    });
+
+    it("writes via a fire-and-forget clipboard/write notification", () => {
+        const { frames, rpc } = harness();
+
+        new RpcClipboard(rpc).writeClipboard("payload");
+
+        expect(last(frames)).toEqual({ method: "clipboard/write", params: { text: "payload" } });
     });
 });
 

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -18,6 +18,7 @@ import { posix } from "node:path";
 
 import { Command, Engine, Query } from "@miragon/bpmn-modeler-shared";
 import {
+    ClipboardPort,
     DocumentPort,
     EditorHandle,
     EditorSubscription,
@@ -338,6 +339,31 @@ export class RpcStatusBar implements StatusBarPort {
 
     disposeEngineVersionStatus(): void {
         this.rpc.notify("statusBar/disposeEngineVersion", {});
+    }
+}
+
+/**
+ * Routes {@link ClipboardPort} calls to the host's system clipboard so the
+ * sandboxed-iframe mediator pattern works out-of-process: the webview can't
+ * reach the clipboard, the core can't either (it's a subprocess), so the host
+ * does the real read/write on their behalf.
+ *
+ * Read is a request — the core needs the value back to satisfy a paste — while
+ * write is fire-and-forget, matching the notifier/status-bar split (a copy needs
+ * no confirmation, and the mediator already swallows/logs failures).
+ */
+export class RpcClipboard implements ClipboardPort {
+    constructor(private readonly rpc: Rpc) {}
+
+    async readClipboard(): Promise<string> {
+        const result = (await this.rpc.request("clipboard/read", {})) as {
+            text?: string;
+        } | null;
+        return result?.text ?? "";
+    }
+
+    async writeClipboard(text: string): Promise<void> {
+        this.rpc.notify("clipboard/write", { text });
     }
 }
 

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -22,9 +22,16 @@
  * own follow-up issues (#1067–#1069+); this is the BPMN-editor foundation.
  */
 
-import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
+import {
+    Command,
+    Query,
+    SetClipboardCommand,
+    SetTextClipboardCommand,
+    SyncDocumentCommand,
+} from "@miragon/bpmn-modeler-shared";
 import {
     ArtifactService,
+    BpmnClipboardMediator,
     BpmnElementTemplatesService,
     BpmnModelerService,
     BpmnSettingsBroadcaster,
@@ -34,6 +41,7 @@ import {
 
 import {
     DocumentMirror,
+    RpcClipboard,
     RpcDocumentPort,
     RpcEditorHandle,
     RpcNotifier,
@@ -102,15 +110,20 @@ export function createBridge(
     // host's RPC snapshots rather than `workspace.onDidChangeConfiguration`.
     const settingsBroadcaster = new BpmnSettingsBroadcaster(store, settings, notifier);
 
+    // Real clipboard mediator (sandboxed-iframe pattern): the host reads/writes
+    // the system clipboard on the webview's behalf over RPC.
+    const clipboard = new RpcClipboard(rpc);
+    const clipboardMediator = new BpmnClipboardMediator(store, clipboard, notifier);
+
     const handles = new Map<string, RpcEditorHandle>();
     const watchers = new Map<string, { dispose(): void }[]>();
 
-    // The real webview-message dispatch table. The file/sync/settings/templates
-    // handlers call the genuine services; the remaining handshake replies are
-    // bridge-level stubs because their real services (properties panel, clipboard)
-    // pull in host ports that are later issues (#1065–#1066). They must still
-    // answer, or the webview's `Promise.all` over templates+settings+panel-state
-    // never resolves and bootstrap stalls.
+    // The real webview-message dispatch table. The file/sync/settings/templates/
+    // clipboard handlers call the genuine services; the remaining handshake reply
+    // is a bridge-level stub because its real service (properties panel) pulls in a
+    // host port that is a later issue (#1065). It must still answer, or the
+    // webview's `Promise.all` over templates+settings+panel-state never resolves
+    // and bootstrap stalls.
     const router = new WebviewMessageRouter();
     router
         .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
@@ -136,10 +149,16 @@ export function createBridge(
             store.postMessage(editorId, query("PropertiesPanelStateQuery", { visible: true }));
         })
         .on("GetClipboardCommand", (_m: Command, editorId: string) => {
-            store.postMessage(editorId, query("ClipboardQuery", { text: "" }));
+            void clipboardMediator.readClipboard(editorId);
+        })
+        .on("SetClipboardCommand", (message: Command) => {
+            void clipboardMediator.writeClipboard((message as SetClipboardCommand).text);
         })
         .on("GetTextClipboardCommand", (_m: Command, editorId: string) => {
-            store.postMessage(editorId, query("TextClipboardQuery", { text: "" }));
+            void clipboardMediator.readTextClipboard(editorId);
+        })
+        .on("SetTextClipboardCommand", (message: Command) => {
+            void clipboardMediator.writeClipboard((message as SetTextClipboardCommand).text);
         });
 
     rpc.on("session/register", async (params: RegisterParams) => {


### PR DESCRIPTION
**Issue**

Closes #1066 (parent epic #920 — IntelliJ host parity)

**Description**

The IntelliJ host bridge stubbed the clipboard (empty reads, unrouted writes), so modeler copy/paste was dead. This wires the real `ClipboardPort` through the existing host-agnostic `BpmnClipboardMediator`: a new `RpcClipboard` adapter forwards reads as a `clipboard/read` request and writes as a `clipboard/write` notification, the bridge routes all four `Get/Set` × element/text commands to the mediator, and `CoreProcess` satisfies the RPC against IntelliJ's `CopyPasteManager` on the EDT (denied/empty clipboard falls back to an empty string so paste can't break). No changes to the webview, `libs/shared`, or `libs/modeler-core` — the protocol and mediator were already host-agnostic. Added unit tests for the new adapter.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created