### PR TITLE
feat(intellij): SecretStore host port backed by PasswordSafe

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -58,6 +58,7 @@ class CoreProcess(private val project: Project) : Disposable {
     private val log = Logger.getInstance(CoreProcess::class.java)
     private val gson = Gson()
     private val notifications by lazy { HostNotifications(project) }
+    private val secretStore by lazy { IntellijSecretStore() }
 
     private val sessions = ConcurrentHashMap<String, CoreSession>()
 
@@ -288,6 +289,46 @@ class CoreProcess(private val project: Project) : Disposable {
                 notifications.log(params.get("level")?.asString, params.get("message")?.asString.orEmpty())
             "notifier/progressStart", "notifier/progressEnd" ->
                 log.debug("$method: ${params.get("title")?.asString}")
+            // PasswordSafe get/set block and must stay off the EDT; onLine runs on
+            // the background reader thread, so calling them inline here is safe.
+            "secretStore/saveBasicAuth" -> {
+                secretStore.saveBasicAuth(params.get("username").asString, params.get("password").asString)
+                id?.let { reply(it, null) }
+            }
+            "secretStore/getBasicAuth" -> {
+                val creds = secretStore.getBasicAuth()
+                val username = creds?.userName
+                val password = creds?.getPasswordAsString()
+                id?.let {
+                    reply(
+                        it,
+                        if (username != null && password != null) {
+                            mapOf("username" to username, "password" to password)
+                        } else {
+                            null
+                        },
+                    )
+                }
+            }
+            "secretStore/saveOAuth2" -> {
+                secretStore.saveOAuth2(params.get("clientId").asString, params.get("clientSecret").asString)
+                id?.let { reply(it, null) }
+            }
+            "secretStore/getOAuth2" -> {
+                val creds = secretStore.getOAuth2()
+                val clientId = creds?.userName
+                val clientSecret = creds?.getPasswordAsString()
+                id?.let {
+                    reply(
+                        it,
+                        if (clientId != null && clientSecret != null) {
+                            mapOf("clientId" to clientId, "clientSecret" to clientSecret)
+                        } else {
+                            null
+                        },
+                    )
+                }
+            }
             else -> log.debug("Unhandled core method: $method")
         }
     }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IntellijSecretStore.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IntellijSecretStore.kt
@@ -1,0 +1,44 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.credentialStore.CredentialAttributes
+import com.intellij.credentialStore.Credentials
+import com.intellij.credentialStore.generateServiceName
+import com.intellij.ide.passwordSafe.PasswordSafe
+
+/**
+ * Drives the core's `SecretStorePort` against IntelliJ's [PasswordSafe], the host
+ * equivalent of VS Code's `context.secrets` for deployment basic-auth / OAuth2
+ * credentials.
+ *
+ * **Scope (re-verified for #1065).** [PasswordSafe] is an *application*-level
+ * service (`PasswordSafe.instance` == `service<PasswordSafe>()`), **not**
+ * project-scoped: secrets are keyed only by [CredentialAttributes] and shared
+ * across every project window and IDE restart, encrypted at rest in the OS
+ * keychain (or an encrypted KeePass DB). That matches the VS Code `SecretStorage`
+ * scope the core was written against (global per extension), so no per-project
+ * disambiguation is needed.
+ *
+ * Username/clientId and password/secret travel together in one [Credentials] entry
+ * per auth kind, so a paired read never returns a half-populated result.
+ */
+class IntellijSecretStore {
+    private val passwordSafe get() = PasswordSafe.instance
+
+    fun saveBasicAuth(username: String, password: String) =
+        passwordSafe.set(basicAuthAttributes, Credentials(username, password))
+
+    fun getBasicAuth(): Credentials? = passwordSafe.get(basicAuthAttributes)
+
+    fun saveOAuth2(clientId: String, clientSecret: String) =
+        passwordSafe.set(oauth2Attributes, Credentials(clientId, clientSecret))
+
+    fun getOAuth2(): Credentials? = passwordSafe.get(oauth2Attributes)
+
+    private companion object {
+        // generateServiceName namespaces the keychain entry under the IDE +
+        // subsystem so it never collides with other plugins' stored secrets.
+        const val SUBSYSTEM = "Miranum BPMN Modeler Deployment"
+        val basicAuthAttributes = CredentialAttributes(generateServiceName(SUBSYSTEM, "basicAuth"))
+        val oauth2Attributes = CredentialAttributes(generateServiceName(SUBSYSTEM, "oauth2"))
+    }
+}

--- a/apps/modeler-bridge/README.md
+++ b/apps/modeler-bridge/README.md
@@ -27,6 +27,7 @@ isn't talking to VS Code.
 | core → host | `editor/postMessage` | `EditorHandle.postMessage` (Query/Command → webview) |
 | core → host | `notifier/*` | `NotifierPort` → IntelliJ `Notifications.Bus` + IDE log |
 | core → host | `statusBar/*` | `StatusBarPort` → `StatusBarWidget` (engine version + template count) |
+| core → host | `secretStore/*` | `SecretStorePort` → `PasswordSafe` (application-scoped, encrypted at rest) |
 
 The **synchronous-read mismatch** — `BpmnModelerService.display()` reads
 `DocumentPort.getContent()` synchronously, impossible over async RPC — is solved
@@ -71,7 +72,7 @@ it by writing NDJSON frames to its stdin and reading frames from its stdout.
 - `src/rpc.ts` — the bidirectional NDJSON JSON-RPC peer.
 - `src/adapters.ts` — `DocumentMirror` + the RPC-backed ports
   (`RpcEditorHandle`, `RpcDocumentPort`, `RpcNotifier`, `RpcStatusBar`,
-  `RpcPicker`).
+  `RpcSecretStore`, `RpcPicker`).
 - `src/nodeAdapters.ts` — pure-`fs` `WorkspacePort` / `SettingsPort` for the
   element-templates pipeline.
 - `src/server.ts` — the entrypoint that wires the real core to the adapters.

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -8,6 +8,7 @@ import {
     RpcEditorHandle,
     RpcNotifier,
     RpcPicker,
+    RpcSecretStore,
     RpcStatusBar,
     SessionMeta,
 } from "./adapters";
@@ -298,6 +299,52 @@ describe("RpcNotifier", () => {
             "notifier/progressStart",
             "notifier/progressEnd",
         ]);
+    });
+});
+
+describe("RpcSecretStore", () => {
+    it("routes saves and reads over secretStore/* request frames", async () => {
+        const { frames, rpc, answerLast } = harness();
+        const store = new RpcSecretStore(rpc);
+
+        const saveBasic = store.saveBasicAuth("user", "pw");
+        expect(last(frames)).toMatchObject({
+            method: "secretStore/saveBasicAuth",
+            params: { username: "user", password: "pw" },
+        });
+        await answerLast(null);
+        await expect(saveBasic).resolves.toBeUndefined();
+
+        const getBasic = store.getBasicAuth();
+        expect(last(frames)).toMatchObject({ method: "secretStore/getBasicAuth", params: {} });
+        await answerLast({ username: "user", password: "pw" });
+        await expect(getBasic).resolves.toEqual({ username: "user", password: "pw" });
+
+        const saveOauth = store.saveOAuth2("client", "secret");
+        expect(last(frames)).toMatchObject({
+            method: "secretStore/saveOAuth2",
+            params: { clientId: "client", clientSecret: "secret" },
+        });
+        await answerLast(null);
+        await expect(saveOauth).resolves.toBeUndefined();
+
+        const getOauth = store.getOAuth2();
+        expect(last(frames)).toMatchObject({ method: "secretStore/getOAuth2", params: {} });
+        await answerLast({ clientId: "client", clientSecret: "secret" });
+        await expect(getOauth).resolves.toEqual({ clientId: "client", clientSecret: "secret" });
+    });
+
+    it("resolves undefined when the host has no stored credentials", async () => {
+        const { rpc, answerLast } = harness();
+        const store = new RpcSecretStore(rpc);
+
+        const getBasic = store.getBasicAuth();
+        await answerLast(null);
+        await expect(getBasic).resolves.toBeUndefined();
+
+        const getOauth = store.getOAuth2();
+        await answerLast(null);
+        await expect(getOauth).resolves.toBeUndefined();
     });
 });
 

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -25,6 +25,7 @@ import {
     NotifierPort,
     PickerPort,
     ScriptLanguage,
+    SecretStorePort,
     SettingChange,
     StatusBarPort,
     UserCancelledError,
@@ -337,6 +338,42 @@ export class RpcStatusBar implements StatusBarPort {
 
     disposeEngineVersionStatus(): void {
         this.rpc.notify("statusBar/disposeEngineVersion", {});
+    }
+}
+
+/**
+ * Routes the core's {@link SecretStorePort} to the host's PasswordSafe-backed
+ * credential store. Unlike the fire-and-forget Notifier/StatusBar ports, all four
+ * calls are **requests**: the deployment service awaits a save before reporting
+ * success and awaits a read before pre-filling the form, so each must resolve only
+ * once the host has actually persisted/fetched the secret. A read maps a `null`
+ * host result to `undefined` to satisfy the port's `| undefined` contract.
+ */
+export class RpcSecretStore implements SecretStorePort {
+    constructor(private readonly rpc: Rpc) {}
+
+    async saveBasicAuth(username: string, password: string): Promise<void> {
+        await this.rpc.request("secretStore/saveBasicAuth", { username, password });
+    }
+
+    async getBasicAuth(): Promise<{ username: string; password: string } | undefined> {
+        const result = (await this.rpc.request("secretStore/getBasicAuth", {})) as {
+            username: string;
+            password: string;
+        } | null;
+        return result ?? undefined;
+    }
+
+    async saveOAuth2(clientId: string, clientSecret: string): Promise<void> {
+        await this.rpc.request("secretStore/saveOAuth2", { clientId, clientSecret });
+    }
+
+    async getOAuth2(): Promise<{ clientId: string; clientSecret: string } | undefined> {
+        const result = (await this.rpc.request("secretStore/getOAuth2", {})) as {
+            clientId: string;
+            clientSecret: string;
+        } | null;
+        return result ?? undefined;
     }
 }
 

--- a/docs/vscode/contributing/architecture/intellij-host-foundation.md
+++ b/docs/vscode/contributing/architecture/intellij-host-foundation.md
@@ -92,6 +92,17 @@ the host: **Notifier → `Notifications.Bus`** balloons + IDE log
 element-template count). The template count is genuine: the bridge wires the real
 `ArtifactService` + `BpmnElementTemplatesService` over pure-`fs` adapters.
 
+## Secret store
+
+Deployment credentials (basic-auth / OAuth2) route through `secretStore/*` to
+`IntellijSecretStore` → **`PasswordSafe`** — the host equivalent of VS Code's
+`context.secrets`. `PasswordSafe` is an *application*-level service (not
+project-scoped): secrets are keyed only by `CredentialAttributes`, shared across
+project windows and IDE restarts, and encrypted at rest in the OS keychain — the
+same scope the core assumes. The port adapter (`RpcSecretStore`) is shipped and
+unit-tested but not yet wired into a service; the deployment feature consumes it
+when it lands.
+
 ## Consequences
 
 - A second host exists as a thin Kotlin glue layer + a 58 MB Node-free binary;


### PR DESCRIPTION
**Issue**

Closes #1065 (parent epic #920 — IntelliJ host parity).

**Description**

Adds the `SecretStorePort` host port for the IntelliJ host so deployment basic-auth / OAuth2 credentials persist encrypted at rest — the host equivalent of VS Code's `context.secrets`. The bridge gets an `RpcSecretStore` adapter (all four calls are requests, not fire-and-forget, so saves/reads resolve only after the host confirms) with unit tests, and the plugin gets `IntellijSecretStore` over `PasswordSafe` plus `secretStore/*` RPC handlers in `CoreProcess` (called on the background reader thread, off the EDT, as `PasswordSafe.get/set` require). It re-verifies and documents the open question — `PasswordSafe` is an application-level service (not project-scoped), matching the `SecretStorage` scope the core assumes. The port ships ready and unit-tested; the deployment feature wires it into `DeploymentService` later (#1071).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created