### PR TITLE
feat(intellij): cross-platform element-templates watcher via chokidar (#1068)

### DIFF
--- a/apps/modeler-bridge/package.json
+++ b/apps/modeler-bridge/package.json
@@ -18,7 +18,8 @@
     },
     "dependencies": {
         "@miragon/bpmn-modeler-core": "workspace:*",
-        "@miragon/bpmn-modeler-shared": "workspace:*"
+        "@miragon/bpmn-modeler-shared": "workspace:*",
+        "chokidar": "3.6.0"
     },
     "devDependencies": {
         "@types/node": "25.9.1",

--- a/apps/modeler-bridge/src/nodeAdapters.spec.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.spec.ts
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NodeWorkspace } from "./nodeAdapters";
 
@@ -59,4 +59,132 @@ describe("NodeWorkspace.findFiles", () => {
     it("returns [] when no root is registered", async () => {
         expect(await new NodeWorkspace().findFiles("**/*.json")).toEqual([]);
     });
+});
+
+/**
+ * Exercises {@link NodeWorkspace.createWatcher} against a real temp directory
+ * and real chokidar. The point of this suite is cross-platform confidence: the
+ * add/change/unlink → onCreate/onChange/onDelete mapping is the same code on
+ * every OS, and the create-after-start case is exactly the Linux/Bun-<1.3.14
+ * gap (dynamically-created subdirectories) that motivated the switch away from
+ * recursive `fs.watch`.
+ */
+
+/** chokidar is ignored by the adapter (`_glob`); any constant documents intent. */
+const PATTERN = "**/.camunda/element-templates/**/*.json";
+
+// chokidar needs a moment to arm its watchers; the adapter debounces ~50ms on
+// top of that. Timeouts are deliberately generous to keep CI off the flake line.
+const SETTLE_MS = 500;
+const EVENT_TIMEOUT_MS = 6000;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Polls until `spy` has been invoked, or throws once `EVENT_TIMEOUT_MS` elapses. */
+async function waitForCall(spy: ReturnType<typeof vi.fn>): Promise<void> {
+    const start = Date.now();
+    while (spy.mock.calls.length === 0) {
+        if (Date.now() - start > EVENT_TIMEOUT_MS) {
+            throw new Error("watcher handler was not called within the timeout");
+        }
+        await sleep(20);
+    }
+}
+
+describe("NodeWorkspace.createWatcher", () => {
+    let root: string;
+    let templatesDir: string;
+    let workspace: NodeWorkspace;
+    let handle: { dispose(): void } | undefined;
+
+    beforeEach(async () => {
+        root = await fs.mkdtemp(join(tmpdir(), "miranum-watch-"));
+        templatesDir = join(root, ".camunda", "element-templates");
+        workspace = new NodeWorkspace();
+    });
+
+    afterEach(async () => {
+        handle?.dispose();
+        handle = undefined;
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    it("fires onCreate for a template added in a folder created after the watch starts", async () => {
+        const onCreate = vi.fn();
+        handle = workspace.createWatcher(root, PATTERN, { onCreate });
+        await sleep(SETTLE_MS);
+
+        // The element-templates folder did not exist when the watch armed — this
+        // is the dynamic-subdirectory case Bun's recursive fs.watch misses on Linux.
+        await fs.mkdir(templatesDir, { recursive: true });
+        await fs.writeFile(join(templatesDir, "task.json"), "[]", "utf8");
+
+        await waitForCall(onCreate);
+        expect(onCreate).toHaveBeenCalled();
+    }, 15000);
+
+    it("fires onChange when an existing template is modified", async () => {
+        await fs.mkdir(templatesDir, { recursive: true });
+        const file = join(templatesDir, "task.json");
+        await fs.writeFile(file, "[]", "utf8");
+
+        const onChange = vi.fn();
+        handle = workspace.createWatcher(root, PATTERN, { onChange });
+        await sleep(SETTLE_MS);
+
+        await fs.writeFile(file, '[{"name":"a"}]', "utf8");
+
+        await waitForCall(onChange);
+        expect(onChange).toHaveBeenCalled();
+    }, 15000);
+
+    it("fires onDelete when a template is removed", async () => {
+        await fs.mkdir(templatesDir, { recursive: true });
+        const file = join(templatesDir, "task.json");
+        await fs.writeFile(file, "[]", "utf8");
+
+        const onDelete = vi.fn();
+        handle = workspace.createWatcher(root, PATTERN, { onDelete });
+        await sleep(SETTLE_MS);
+
+        await fs.rm(file);
+
+        await waitForCall(onDelete);
+        expect(onDelete).toHaveBeenCalled();
+    }, 15000);
+
+    it("ignores non-json files and json files outside element-templates", async () => {
+        const onCreate = vi.fn();
+        const onChange = vi.fn();
+        handle = workspace.createWatcher(root, PATTERN, { onCreate, onChange });
+        await sleep(SETTLE_MS);
+
+        // JSON under the config folder but not in element-templates → ignored.
+        await fs.mkdir(join(root, ".camunda"), { recursive: true });
+        await fs.writeFile(join(root, ".camunda", "config.json"), "{}", "utf8");
+        // Non-JSON inside element-templates → ignored.
+        await fs.mkdir(templatesDir, { recursive: true });
+        await fs.writeFile(join(templatesDir, "notes.txt"), "hi", "utf8");
+
+        await sleep(SETTLE_MS);
+        expect(onCreate).not.toHaveBeenCalled();
+        expect(onChange).not.toHaveBeenCalled();
+    }, 15000);
+
+    it("stops firing after dispose", async () => {
+        const onCreate = vi.fn();
+        handle = workspace.createWatcher(root, PATTERN, { onCreate });
+        await sleep(SETTLE_MS);
+
+        handle.dispose();
+        handle = undefined;
+
+        await fs.mkdir(templatesDir, { recursive: true });
+        await fs.writeFile(join(templatesDir, "task.json"), "[]", "utf8");
+
+        await sleep(SETTLE_MS);
+        expect(onCreate).not.toHaveBeenCalled();
+    }, 15000);
 });

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -23,7 +23,8 @@
  * both paths.
  */
 
-import { promises as fs, watch } from "node:fs";
+import { watch } from "chokidar";
+import { promises as fs } from "node:fs";
 import { posix, sep } from "node:path";
 
 import {
@@ -176,12 +177,20 @@ export class NodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Recursive {@link watch} over the workspace root, firing `onChange`
-     * whenever an element-template JSON changes. Debounced ~50ms to coalesce
-     * the editor's multi-event save bursts into a single re-load.
+     * Watches the workspace root for element-template JSON changes via chokidar,
+     * firing the matching handler debounced ~50ms to coalesce the editor's
+     * multi-event save bursts into a single re-load.
      *
-     * Recursive `fs.watch` is macOS/Windows only — Linux would need chokidar or
-     * per-directory watches (tracked for the Linux release target).
+     * chokidar replaces `fs.watch({ recursive: true })`: the latter's recursive
+     * mode is unreliable across platforms — under Bun on Linux it only tracks
+     * subdirectories that existed when the watch began (fixed only in Bun
+     * ≥1.3.14), so a freshly-created `element-templates/` folder would go
+     * unnoticed. chokidar gives version-independent recursive watching on
+     * macOS/Windows/Linux, matching VS Code's `FileSystemWatcher` behaviour.
+     *
+     * `node_modules`/`.git` are pruned so arming the recursive watch on a large
+     * repo stays within the OS watch-descriptor budget (inotify on Linux).
+     * Dot-dirs in general must stay watched — templates live under `.camunda/`.
      */
     createWatcher(
         rootPath: string,
@@ -193,31 +202,50 @@ export class NodeWorkspace implements WorkspacePort {
         },
     ): { dispose(): void } {
         const root = toFsPath(rootPath);
-        const fire = handlers.onChange ?? handlers.onCreate ?? handlers.onDelete;
         let timer: NodeJS.Timeout | undefined;
 
-        const watcher = watch(root, { recursive: true }, (_event, filename) => {
-            if (!filename) {
-                return;
-            }
-            const name = filename.toString();
-            // The glob targets `<configFolder>/element-templates/**/*.json`;
-            // match its intent against the changed path's relative form.
-            if (!name.includes("/element-templates/") || !name.endsWith(".json")) {
+        // The glob targets `<configFolder>/element-templates/**/*.json`; match
+        // its intent against the changed path. chokidar emits OS-native paths,
+        // so normalise separators before the substring check.
+        const isTemplate = (changed: string): boolean => {
+            const normalized = changed.replace(/\\/g, "/");
+            return normalized.includes("/element-templates/") && normalized.endsWith(".json");
+        };
+
+        // One shared timer across add/change/unlink: every event resolves to the
+        // same template re-load downstream, so coalescing a burst into the last
+        // event's handler is correct and avoids redundant reloads.
+        const fireDebounced = (
+            handler: ((path: string) => void) | undefined,
+            changed: string,
+        ): void => {
+            if (!handler || !isTemplate(changed)) {
                 return;
             }
             if (timer) {
                 clearTimeout(timer);
             }
-            timer = setTimeout(() => fire?.(posix.join(root, name)), 50);
+            timer = setTimeout(() => handler(changed), 50);
+        };
+
+        const watcher = watch(root, {
+            // The initial load runs via the webview's `GetElementTemplatesCommand`;
+            // skip the synthetic `add` storm chokidar emits for existing files.
+            ignoreInitial: true,
+            ignored: /(^|[/\\])(node_modules|\.git)([/\\]|$)/,
         });
+        watcher
+            .on("add", (p) => fireDebounced(handlers.onCreate, p))
+            .on("change", (p) => fireDebounced(handlers.onChange, p))
+            .on("unlink", (p) => fireDebounced(handlers.onDelete, p));
 
         return {
             dispose(): void {
                 if (timer) {
                     clearTimeout(timer);
                 }
-                watcher.close();
+                // chokidar's close() is async; nothing awaits teardown here.
+                void watcher.close();
             },
         };
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,6 +3489,7 @@ __metadata:
     "@miragon/bpmn-modeler-core": "workspace:*"
     "@miragon/bpmn-modeler-shared": "workspace:*"
     "@types/node": "npm:25.9.1"
+    chokidar: "npm:3.6.0"
     npm-run-all: "npm:4.1.5"
     typescript: "npm:6.0.3"
   bin:


### PR DESCRIPTION
**Issue**

#1068 (parent: #920 — IntelliJ host parity)

**Description**

Promotes the IntelliJ-host element-templates spike to production by replacing the bridge's raw recursive `fs.watch` (`NodeWorkspace.createWatcher`) with **chokidar** — already a proven dependency in the Bun-compiled `modeler-cli`. Bun's recursive `fs.watch` on Linux only tracks subdirectories that existed when the watch began (fixed only in Bun ≥1.3.14; the repo runs 1.3.10), so a freshly-created `element-templates/` folder went unnoticed; chokidar gives version-independent recursive watching on macOS/Windows/Linux, prunes `node_modules`/`.git`, and maps `add`/`change`/`unlink` onto the existing `onCreate`/`onChange`/`onDelete` handlers with the ~50 ms debounce. A real-fs `nodeAdapters.spec.ts` covers create-after-watch-start (the exact Linux gap), change, delete, the non-template-ignored case, and dispose. With this in place all three of #1068's acceptance criteria hold: templates load and live-reload cross-platform, the status-bar count is shown (#1082), and a `configFolder` change reloads them (now wired and tested by #1063's `settings/didChange` → `BridgeSettings` → templates-reload path — no longer blocked). Emitting per-OS binaries so the watcher actually runs on Linux/Windows is tracked separately in #1093 (the host already resolves a per-platform binary at runtime; only the compile/staging matrix is outstanding).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
