### PR TITLE
feat(intellij): promote bpmn editor to production over the core seam (#1067)

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnFileEditor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnFileEditor.kt
@@ -1,6 +1,9 @@
 package io.miragon.intellij.bpmn
 
 import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorState
 import com.intellij.openapi.project.Project
@@ -93,6 +96,20 @@ class BpmnFileEditor(
             // Register before the page loads so the core has the session ready by
             // the time the webview's first (buffered) message is forwarded.
             coreProcess!!.registerSession(coreSession)
+
+            // Mirror the live IntelliJ Document into the core so external edits
+            // (git revert/checkout, the plain-text tab, another tool) re-render the
+            // diagram. The core's own write-backs also fire this — that echo is
+            // filtered in the bridge, not here. Parented to this editor, so the
+            // listener is removed when the tab closes.
+            FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(
+                object : DocumentListener {
+                    override fun documentChanged(event: DocumentEvent) {
+                        coreProcess.notifyDocumentChanged(editorId, event.document.text)
+                    }
+                },
+                this,
+            )
 
             // JS → JVM channel: forward every webview message to the core untouched.
             val jsQuery = JBCefJSQuery.create(cefBrowser as com.intellij.ui.jcef.JBCefBrowserBase)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -10,6 +10,8 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.text.StringUtil
@@ -87,6 +89,21 @@ class CoreProcess(private val project: Project) : Disposable {
     private val outbound = ArrayDeque<OutFrame>()
     private val outboundMonitor = Object()
     private var writerThread: Thread? = null
+
+    init {
+        // Keep the core's active-editor pointer in sync with the focused tab so
+        // operations that target "the active editor" address the right session
+        // when several `.bpmn` files are open. Parented to this service, so the
+        // subscription dies with the project.
+        project.messageBus.connect(this).subscribe(
+            FileEditorManagerListener.FILE_EDITOR_MANAGER,
+            object : FileEditorManagerListener {
+                override fun selectionChanged(event: FileEditorManagerEvent) {
+                    event.newFile?.url?.let { setActiveEditor(it) }
+                }
+            },
+        )
+    }
 
     // ── lifecycle ────────────────────────────────────────────────────────────
 
@@ -238,6 +255,24 @@ class CoreProcess(private val project: Project) : Disposable {
         // only the latest XML matters for write-back — so collapse queued ones.
         val coalesceKey = if (type == "SyncDocumentCommand") "sync:$editorId" else null
         notify("webview/message", linkedMapOf("editorId" to editorId, "message" to parsed), coalesceKey)
+    }
+
+    /**
+     * Forwards a document change to the core so external edits (git revert/
+     * checkout, the plain-text tab, another tool) re-render the diagram. The host
+     * stays dumb: it reports *every* change, including the echo of its own
+     * `document/write`. The bridge tells the two apart — re-rendering our own
+     * write would loop, so it is filtered there, not here.
+     */
+    fun notifyDocumentChanged(editorId: String, content: String) {
+        if (!sessions.containsKey(editorId)) return
+        notify("document/didChange", linkedMapOf("editorId" to editorId, "content" to content))
+    }
+
+    /** Tells the core which open editor is focused (drives its active-editor pointer). */
+    private fun setActiveEditor(editorId: String) {
+        if (!sessions.containsKey(editorId)) return
+        notify("session/setActive", linkedMapOf("editorId" to editorId))
     }
 
     fun disposeSession(editorId: String) {

--- a/apps/modeler-bridge/README.md
+++ b/apps/modeler-bridge/README.md
@@ -21,7 +21,8 @@ isn't talking to VS Code.
 | Direction | Method(s) | Port / handle |
 |---|---|---|
 | host → core | `session/register`, `session/dispose` | editor lifecycle (seeds the `DocumentPort` mirror) |
-| host → core | `document/didChange` | host edit → mirror update |
+| host → core | `document/didChange` | document change → re-render (external edits) or no-op (own-write echo) |
+| host → core | `session/setActive` | focused tab → `EditorSessionStore` active-editor pointer |
 | host → core | `webview/message` | inbound `Command` → `WebviewMessageRouter` |
 | core → host | `document/write`, `document/save` | `DocumentPort.write` / `.save` |
 | core → host | `editor/postMessage` | `EditorHandle.postMessage` (Query/Command → webview) |
@@ -33,6 +34,15 @@ The **synchronous-read mismatch** — `BpmnModelerService.display()` reads
 `DocumentPort.getContent()` synchronously, impossible over async RPC — is solved
 by a local `DocumentMirror` the host seeds on `session/register` and keeps
 current with `document/didChange`, so reads hit a cache instead of blocking.
+
+**Echo prevention.** The host stays dumb: it reports *every* document change,
+including the echo of the core's own `document/write`. The bridge tells the two
+apart by content — `RpcDocumentPort.write` updates the mirror before the RPC, so
+a `document/didChange` whose content already equals the mirror is the host's echo
+and is dropped; only a genuinely different text (a git revert, the plain-text tab,
+another tool) re-renders. The core's `ModelerSession` guard stays wired as a
+second line of defence. This keeps echo prevention in TypeScript — host-agnostic,
+with no cross-process timing assumptions — so every future host inherits it.
 
 > **Why not the `window.__WS_BRIDGE__` / `WebSocketChannelImpl` seam?** That seam
 > (from #1061) is the right tool for the browser/CLI host, where the webview

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -14,7 +14,8 @@
  *
  * Protocol (see {@link Rpc} for framing):
  *   Host → Core (notifications): session/register, webview/message,
- *                                document/didChange, session/dispose
+ *                                document/didChange, session/setActive,
+ *                                session/dispose
  *   Core → Host (requests):      document/write, document/save, picker/show
  *   Core → Host (notifications): editor/postMessage, notifier/*, statusBar/*
  *
@@ -214,8 +215,26 @@ export function createBridge(
         handles.get(params.editorId)?.receive(params.message);
     });
 
-    rpc.on("document/didChange", (params: { editorId: string; content: string }) => {
+    // External edits (git revert/checkout, the IDE's plain-text tab, another
+    // tool) must re-render the open diagram. The host stays dumb and forwards
+    // *every* document change — including the echo of our own `document/write` —
+    // so the bridge classifies them here: `RpcDocumentPort.write` updates the
+    // mirror to the core-originated content before the RPC round-trip, so an
+    // unchanged compare means this is that echo and re-rendering would loop.
+    // Only a genuinely different text is an external edit worth displaying.
+    rpc.on("document/didChange", async (params: { editorId: string; content: string }) => {
+        if (mirror.content(params.editorId) === params.content) {
+            return;
+        }
         mirror.setContent(params.editorId, params.content);
+        await bpmnService.display(params.editorId);
+    });
+
+    // The host reports which editor tab is focused so the store's active-editor
+    // pointer stays correct with several `.bpmn` files open (commands/diff that
+    // target "the active editor" depend on it).
+    rpc.on("session/setActive", (params: { editorId: string }) => {
+        store.setActiveEditor(params.editorId);
     });
 
     rpc.on("session/dispose", (params: { editorId: string }) => {

--- a/apps/modeler-bridge/src/server.spec.ts
+++ b/apps/modeler-bridge/src/server.spec.ts
@@ -290,4 +290,125 @@ describe("bridge end-to-end (real core over a fake transport)", () => {
 
         await rpc.handleLine(JSON.stringify({ method: "session/dispose", params: { editorId } }));
     });
+
+    /** Counts the render frames (BpmnFileQuery) emitted for a given editor so far. */
+    function renders(frames: any[], editorId: string): any[] {
+        return frames.filter(
+            (f) =>
+                f.method === "editor/postMessage" &&
+                f.params.message.type === "BpmnFileQuery" &&
+                f.params.editorId === editorId,
+        );
+    }
+
+    /** Registers an editor and drives the initial GetBpmnFileCommand render. */
+    async function open(rpc: Rpc, editorId: string, root: string, fsPath: string): Promise<void> {
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "session/register",
+                params: registerParams(editorId, root, fsPath, C7_XML),
+            }),
+        );
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: { editorId, message: { type: "GetBpmnFileCommand" } },
+            }),
+        );
+        await settle();
+    }
+
+    it("re-renders the diagram on an external document/didChange", async () => {
+        const { rpc, frames, root, bpmnPath } = await setup();
+        const editorId = `file://${bpmnPath}`;
+        await open(rpc, editorId, root, bpmnPath);
+        const before = renders(frames, editorId).length;
+
+        // A genuine external edit (git revert, the plain-text tab) carries content
+        // the bridge has never seen, so it must be pushed back to the webview.
+        const external = C7_XML.replace("Process_1", "Process_externally_edited");
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "document/didChange",
+                params: { editorId, content: external },
+            }),
+        );
+        await settle();
+
+        const after = renders(frames, editorId);
+        expect(after).toHaveLength(before + 1);
+        expect(after[after.length - 1].params.message.content).toContain(
+            "Process_externally_edited",
+        );
+
+        await rpc.handleLine(JSON.stringify({ method: "session/dispose", params: { editorId } }));
+    });
+
+    it("suppresses the echo of its own write — no re-render loop", async () => {
+        const { rpc, frames, root, bpmnPath } = await setup();
+        const editorId = `file://${bpmnPath}`;
+        await open(rpc, editorId, root, bpmnPath);
+        const before = renders(frames, editorId).length;
+
+        // The webview edits the diagram → the core writes it back to the host…
+        const edited = C7_XML.replace("Process_1", "Process_synced");
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: { editorId, message: { type: "SyncDocumentCommand", content: edited } },
+            }),
+        );
+        await settle();
+        expect(frames.some((f) => f.method === "document/write")).toBe(true);
+
+        // …and the dumb host faithfully echoes that change back. Re-rendering it
+        // would loop; the bridge recognises the mirror already holds this content.
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "document/didChange",
+                params: { editorId, content: edited },
+            }),
+        );
+        await settle();
+
+        expect(renders(frames, editorId)).toHaveLength(before);
+
+        await rpc.handleLine(JSON.stringify({ method: "session/dispose", params: { editorId } }));
+    });
+
+    it("tracks the active editor without disturbing per-editor routing", async () => {
+        const { rpc, frames, root } = await setup();
+        const a = join(root, "a.bpmn");
+        const b = join(root, "b.bpmn");
+        await fs.writeFile(a, C7_XML, "utf8");
+        await fs.writeFile(b, C7_XML, "utf8");
+        const idA = `file://${a}`;
+        const idB = `file://${b}`;
+        await open(rpc, idA, root, a);
+        await open(rpc, idB, root, b);
+
+        // Focus moves back to A. The frame must be accepted, and an external edit
+        // to A still re-renders A specifically — active tracking is orthogonal to
+        // which editor a document change addresses.
+        await rpc.handleLine(
+            JSON.stringify({ method: "session/setActive", params: { editorId: idA } }),
+        );
+        const before = renders(frames, idA).length;
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "document/didChange",
+                params: { editorId: idA, content: C7_XML.replace("Process_1", "Process_a_edited") },
+            }),
+        );
+        await settle();
+
+        expect(renders(frames, idA)).toHaveLength(before + 1);
+
+        await rpc.handleLine(
+            JSON.stringify({ method: "session/dispose", params: { editorId: idA } }),
+        );
+        await rpc.handleLine(
+            JSON.stringify({ method: "session/dispose", params: { editorId: idB } }),
+        );
+    });
 });


### PR DESCRIPTION
**Issue**

Closes #1067 (parent: #920 — IntelliJ host parity).

**Description**

Promotes the throwaway IntelliJ editor spike into a production BPMN editor consuming `@miragon/bpmn-modeler-core`: external file changes (git revert/checkout, the plain-text tab, another tool) now re-render the open diagram, focused-tab tracking keeps the core's active-editor pointer correct with several files open, and the document listener disposes with the editor. Echo prevention deliberately lives in the bridge rather than the host — the Kotlin editor stays a dumb forwarder that reports every document change, and the bridge drops the echo of its own write by comparing against the mirror (updated before the RPC round-trip), keeping echo logic in TypeScript with no cross-process timing assumptions so future hosts inherit it; the core's `ModelerSession` guard stays wired as a second line of defence. Added three end-to-end bridge tests (external re-render, echo suppression, active-tab tracking is orthogonal to routing) — full bridge suite is 32/32 green, and the Kotlin compiles. DMN is left as a follow-up per the issue.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created