### PR TITLE
feat(intellij): implement Picker host port with JBPopup (#1064)

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -37,7 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger
  *  - push core→webview messages into the right JCEF browser (`editor/postMessage`);
  *  - satisfy the document port (`document/write` / `document/save`) against the
  *    real IntelliJ `Document`;
- *  - render the core's `NotifierPort` / `StatusBarPort` as IntelliJ UI.
+ *  - render the core's `NotifierPort` / `StatusBarPort` as IntelliJ UI, and its
+ *    `PickerPort` (`picker/show`) as a native `JBPopup` chooser.
  *
  * **Topology.** A project-level service: one supervised bridge per project
  * window, lazily spawned on the first editor and torn down with the project.
@@ -266,6 +267,7 @@ class CoreProcess(private val project: Project) : Disposable {
             }
             "document/write" -> handleWrite(params, id)
             "document/save" -> handleSave(params, id)
+            "picker/show" -> handlePick(params, id)
             "statusBar/showEngineVersion" -> {
                 val label = if (params.get("platform")?.asString == "c7") "Camunda 7" else "Camunda 8"
                 EngineStatusBarWidget.updateEngine(project, "$label ${params.get("version")?.asString}")
@@ -327,6 +329,38 @@ class CoreProcess(private val project: Project) : Disposable {
                 if (document != null) FileDocumentManager.getInstance().saveDocument(document)
             }
             id?.let { reply(it, mapOf("saved" to true)) }
+        }
+    }
+
+    /**
+     * Shows a native list popup for the core's `PickerPort` and replies with the
+     * chosen item indices, or `null` on dismissal. The host renders only the
+     * chooser; the cancel-vs-throw convention is applied core-side.
+     */
+    private fun handlePick(params: JsonObject, id: Int?) {
+        // A picker prompt is always a request expecting a reply; a missing id
+        // would mean nothing to answer, so there is nothing to do.
+        if (id == null) return
+        val title = params.get("title")?.takeIf { !it.isJsonNull }?.asString
+        val placeholder = params.get("placeholder")?.takeIf { !it.isJsonNull }?.asString.orEmpty()
+        val canPickMany = params.get("canPickMany")?.takeIf { !it.isJsonNull }?.asBoolean ?: false
+        val items =
+            params.getAsJsonArray("items").mapIndexed { index, element ->
+                val obj = element.asJsonObject
+                HostPicker.PickItem(
+                    index,
+                    obj.get("label").asString,
+                    obj.get("description")?.takeIf { !it.isJsonNull }?.asString,
+                )
+            }
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) {
+                reply(id, mapOf("selected" to null))
+                return@invokeLater
+            }
+            HostPicker.show(project, title, placeholder, canPickMany, items) { selected ->
+                reply(id, mapOf("selected" to selected))
+            }
         }
     }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/HostPicker.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/HostPicker.kt
@@ -1,0 +1,86 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.JBPopupListener
+import com.intellij.openapi.ui.popup.LightweightWindowEvent
+import com.intellij.ui.ColoredListCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JList
+import javax.swing.ListSelectionModel
+
+/**
+ * Renders the core's `PickerPort` as a native list popup (`JBPopup`). The host
+ * owns only the UI: it shows the items the core supplied and reports back the
+ * chosen indices, or `null` when the user dismissed the popup.
+ *
+ * The cancel-vs-throw convention stays core-side (TypeScript `RpcPicker`), so
+ * this object is deliberately domain-agnostic — it never maps a choice to an
+ * engine, scope, or path, only to the index the core handed it.
+ */
+object HostPicker {
+    /** One offered row, carrying its original index so callbacks can report it. */
+    data class PickItem(val index: Int, val label: String, val description: String?)
+
+    /**
+     * Shows the chooser centered in the project window and invokes [onResult]
+     * exactly once: the chosen indices on confirmation, or `null` on dismissal.
+     * Must be called on the EDT.
+     *
+     * Cancellation is detected via [JBPopupListener.onClosed] rather than a
+     * cancel callback: `onClosed` always fires once, and the item-chosen
+     * callback runs first when the user confirmed — so a still-`null` record
+     * unambiguously means the popup was dismissed.
+     */
+    fun show(
+        project: Project,
+        title: String?,
+        placeholder: String,
+        canPickMany: Boolean,
+        items: List<PickItem>,
+        onResult: (List<Int>?) -> Unit,
+    ) {
+        val chosen = AtomicReference<List<Int>?>(null)
+
+        val builder =
+            JBPopupFactory.getInstance()
+                .createPopupChooserBuilder(items)
+                .setTitle(title ?: placeholder)
+                .setRenderer(
+                    object : ColoredListCellRenderer<PickItem>() {
+                        override fun customizeCellRenderer(
+                            list: JList<out PickItem>,
+                            value: PickItem,
+                            index: Int,
+                            selected: Boolean,
+                            hasFocus: Boolean,
+                        ) {
+                            append(value.label)
+                            // The detail (full path, extension) disambiguates rows
+                            // that share a basename; greyed so the label stays primary.
+                            value.description?.let {
+                                append("  $it", SimpleTextAttributes.GRAYED_ATTRIBUTES)
+                            }
+                        }
+                    },
+                )
+
+        if (canPickMany) {
+            builder.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION)
+            builder.setItemsChosenCallback { set -> chosen.set(set.map { it.index }.sorted()) }
+        } else {
+            builder.setItemChosenCallback { item -> chosen.set(listOf(item.index)) }
+        }
+
+        val popup = builder.createPopup()
+        popup.addListener(
+            object : JBPopupListener {
+                override fun onClosed(event: LightweightWindowEvent) {
+                    onResult(chosen.get())
+                }
+            },
+        )
+        popup.showCenteredInCurrentWindow(project)
+    }
+}

--- a/apps/modeler-bridge/README.md
+++ b/apps/modeler-bridge/README.md
@@ -71,7 +71,7 @@ it by writing NDJSON frames to its stdin and reading frames from its stdout.
 - `src/rpc.ts` — the bidirectional NDJSON JSON-RPC peer.
 - `src/adapters.ts` — `DocumentMirror` + the RPC-backed ports
   (`RpcEditorHandle`, `RpcDocumentPort`, `RpcNotifier`, `RpcStatusBar`,
-  `StubPicker`).
+  `RpcPicker`).
 - `src/nodeAdapters.ts` — pure-`fs` `WorkspacePort` / `SettingsPort` for the
   element-templates pipeline.
 - `src/server.ts` — the entrypoint that wires the real core to the adapters.

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { UserCancelledError } from "@miragon/bpmn-modeler-core";
+
 import {
     DocumentMirror,
     RpcDocumentPort,
     RpcEditorHandle,
     RpcNotifier,
+    RpcPicker,
     RpcStatusBar,
     SessionMeta,
 } from "./adapters";
@@ -320,5 +323,158 @@ describe("RpcStatusBar", () => {
 
         statusBar.hideEngineVersion();
         expect(last(frames)).toEqual({ method: "statusBar/hideEngineVersion", params: {} });
+    });
+});
+
+describe("RpcPicker", () => {
+    /** Lets a `findFiles`-then-`show` chain settle before the frame is asserted. */
+    const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    function setup() {
+        const h = harness();
+        const finder = { findFiles: vi.fn() };
+        return { ...h, finder, picker: new RpcPicker(h.rpc, finder) };
+    }
+
+    it("pickExecutionPlatform maps the chosen label to an engine", async () => {
+        const { frames, picker, answerLast } = setup();
+        const pending = picker.pickExecutionPlatform("Pick a platform", ["Camunda 7", "Camunda 8"]);
+        expect(last(frames)).toMatchObject({
+            method: "picker/show",
+            params: {
+                placeholder: "Pick a platform",
+                canPickMany: false,
+                items: [{ label: "Camunda 7" }, { label: "Camunda 8" }],
+            },
+        });
+        await answerLast({ selected: [1] });
+        await expect(pending).resolves.toBe("c8");
+    });
+
+    it("pickExecutionPlatform throws UserCancelledError on dismissal", async () => {
+        const { picker, answerLast } = setup();
+        const pending = picker.pickExecutionPlatform("Pick", ["Camunda 7"]);
+        await answerLast({ selected: null });
+        await expect(pending).rejects.toBeInstanceOf(UserCancelledError);
+    });
+
+    it("pickMigrationScope labels the counts and maps the selection", async () => {
+        const { frames, picker, answerLast } = setup();
+        const pending = picker.pickMigrationScope(1, 3);
+        expect(last(frames).params.items.map((item: { label: string }) => item.label)).toEqual([
+            "Camunda 7 only (1 diagram)",
+            "Camunda 8 only (3 diagrams)",
+            "Both (4 diagrams)",
+        ]);
+        await answerLast({ selected: [2] });
+        await expect(pending).resolves.toBe("both");
+    });
+
+    it("pickMigrationScope throws on dismissal", async () => {
+        const { picker, answerLast } = setup();
+        const pending = picker.pickMigrationScope(2, 2);
+        await answerLast({ selected: null });
+        await expect(pending).rejects.toBeInstanceOf(UserCancelledError);
+    });
+
+    it("pickEngineVersion returns the chosen version", async () => {
+        const { frames, picker, answerLast } = setup();
+        const pending = picker.pickEngineVersion("c7", ["7.19", "7.20"]);
+        expect(last(frames)).toMatchObject({
+            method: "picker/show",
+            params: { placeholder: "Select Camunda 7 engine version", canPickMany: false },
+        });
+        await answerLast({ selected: [1] });
+        await expect(pending).resolves.toBe("7.20");
+    });
+
+    it("pickEngineVersion throws on dismissal", async () => {
+        const { picker, answerLast } = setup();
+        const pending = picker.pickEngineVersion("c8", ["8.5"]);
+        await answerLast({ selected: null });
+        await expect(pending).rejects.toBeInstanceOf(UserCancelledError);
+    });
+
+    it("pickPayloadFile returns the chosen path with a basename label", async () => {
+        const { frames, picker, answerLast } = setup();
+        const pending = picker.pickPayloadFile(["/w/a.json", "/w/sub/b.json"]);
+        expect(last(frames).params.items).toEqual([
+            { label: "a.json", description: "/w/a.json" },
+            { label: "b.json", description: "/w/sub/b.json" },
+        ]);
+        await answerLast({ selected: [1] });
+        await expect(pending).resolves.toEqual({ filePath: "/w/sub/b.json", label: "b.json" });
+    });
+
+    it("pickPayloadFile returns null on dismissal", async () => {
+        const { picker, answerLast } = setup();
+        const pending = picker.pickPayloadFile(["/w/a.json"]);
+        await answerLast({ selected: null });
+        await expect(pending).resolves.toBeNull();
+    });
+
+    it("pickReferencedModel sorts by path and returns the chosen one", async () => {
+        const { frames, picker, answerLast } = setup();
+        const pending = picker.pickReferencedModel(["/w/b.bpmn", "/w/a.bpmn"]);
+        expect(
+            last(frames).params.items.map((item: { description: string }) => item.description),
+        ).toEqual(["/w/a.bpmn", "/w/b.bpmn"]);
+        await answerLast({ selected: [0] });
+        await expect(pending).resolves.toBe("/w/a.bpmn");
+    });
+
+    it("pickReferencedModel returns undefined on dismissal", async () => {
+        const { picker, answerLast } = setup();
+        const pending = picker.pickReferencedModel(["/w/a.bpmn"]);
+        await answerLast({ selected: null });
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it("pickScriptLanguage pins the current format first and returns it", async () => {
+        const { frames, picker, answerLast } = setup();
+        const pending = picker.pickScriptLanguage("groovy");
+        expect(last(frames).params.title).toBe("Script Language");
+        expect(last(frames).params.items[0]).toEqual({ label: "Groovy", description: ".groovy" });
+        await answerLast({ selected: [0] });
+        await expect(pending).resolves.toBe("groovy");
+    });
+
+    it("pickScriptLanguage returns undefined on dismissal", async () => {
+        const { picker, answerLast } = setup();
+        const pending = picker.pickScriptLanguage("javascript");
+        await answerLast({ selected: null });
+        await expect(pending).resolves.toBeUndefined();
+    });
+
+    it("pickWorkspaceFiles globs then maps the multi-selection", async () => {
+        const { frames, picker, answerLast, finder } = setup();
+        finder.findFiles.mockResolvedValue(["/w/a.form", "/w/b.json", "/w/c.dmn"]);
+        const pending = picker.pickWorkspaceFiles({
+            glob: "**/*.{form,json,dmn}",
+            exclude: "**/element-templates/**",
+            placeholder: "Pick files",
+        });
+        await flush();
+
+        expect(finder.findFiles).toHaveBeenCalledWith(
+            "**/*.{form,json,dmn}",
+            "**/element-templates/**",
+            undefined,
+        );
+        expect(last(frames)).toMatchObject({
+            method: "picker/show",
+            params: { canPickMany: true, placeholder: "Pick files" },
+        });
+        await answerLast({ selected: [0, 2] });
+        await expect(pending).resolves.toEqual(["/w/a.form", "/w/c.dmn"]);
+    });
+
+    it("pickWorkspaceFiles returns [] on dismissal", async () => {
+        const { picker, answerLast, finder } = setup();
+        finder.findFiles.mockResolvedValue(["/w/a.form"]);
+        const pending = picker.pickWorkspaceFiles({ glob: "**/*.form", placeholder: "Pick" });
+        await flush();
+        await answerLast({ selected: null });
+        await expect(pending).resolves.toEqual([]);
     });
 });

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -14,15 +14,20 @@
  * hit a local cache instead of blocking on a round-trip.
  */
 
+import { posix } from "node:path";
+
 import { Command, Engine, Query } from "@miragon/bpmn-modeler-shared";
 import {
     DocumentPort,
     EditorHandle,
     EditorSubscription,
+    MigrationScope,
     NotifierPort,
     PickerPort,
+    ScriptLanguage,
     SettingChange,
     StatusBarPort,
+    UserCancelledError,
 } from "@miragon/bpmn-modeler-core";
 
 import { BridgeSettings } from "./nodeAdapters";
@@ -336,31 +341,161 @@ export class RpcStatusBar implements StatusBarPort {
 }
 
 /**
- * Stub {@link PickerPort}: the BPMN-render foundation never reaches a picker for
- * a non-empty diagram. Domain-aware pickers (engine, migration scope, …) are a
- * later host port (#1064); until then the unreachable prompts throw and the two
- * render-safe defaults keep an empty/undetectable diagram from blocking.
+ * Narrow file-discovery dependency for {@link RpcPicker.pickWorkspaceFiles} —
+ * the one picker that searches the workspace rather than receiving its
+ * candidates. Typed as a slice of `WorkspacePort` so it is trivially satisfied
+ * by `NodeWorkspace` and stubbable in tests.
  */
-export class StubPicker implements PickerPort {
-    async pickExecutionPlatform(): Promise<Engine> {
-        return "c7";
+export interface FileFinder {
+    findFiles(pattern: string, exclude?: string | null, limit?: number): Promise<string[]>;
+}
+
+/** One row offered to the host popup: a label plus optional greyed detail. */
+interface PickItem {
+    label: string;
+    description?: string;
+}
+
+/**
+ * Real {@link PickerPort} over RPC: the host shows a native `JBPopup` list and
+ * replies with the chosen indices (or `null` on dismissal); this class keeps
+ * each prompt's item array and re-applies the cancel-vs-throw convention.
+ *
+ * The convention lives here, not in Kotlin, so it stays byte-for-byte identical
+ * to `VsCodePicker` (the contract's reference) and the host carries no
+ * per-picker logic — it only renders a generic chooser.
+ */
+export class RpcPicker implements PickerPort {
+    constructor(
+        private readonly rpc: Rpc,
+        private readonly fileFinder: FileFinder,
+    ) {}
+
+    /** Round-trips one popup; returns the chosen indices or `null` on cancel. */
+    private async show(opts: {
+        title?: string;
+        placeholder: string;
+        canPickMany: boolean;
+        items: PickItem[];
+    }): Promise<number[] | null> {
+        const result = (await this.rpc.request("picker/show", opts)) as {
+            selected?: number[] | null;
+        } | null;
+        return result?.selected ?? null;
     }
-    async pickMigrationScope(): Promise<never> {
-        throw new Error("Picker not available in the IntelliJ host yet (#1064)");
+
+    async pickExecutionPlatform(placeHolder: string, items: string[]): Promise<Engine> {
+        const selected = await this.show({
+            placeholder: placeHolder,
+            canPickMany: false,
+            items: items.map((label) => ({ label })),
+        });
+        if (selected === null) {
+            throw new UserCancelledError();
+        }
+        const result = items[selected[0]];
+        if (result === "Camunda 7") {
+            return "c7";
+        } else if (result === "Camunda 8") {
+            return "c8";
+        }
+        throw new Error(`Unknown execution platform version: "${result}"`);
     }
-    async pickEngineVersion(): Promise<never> {
-        throw new Error("Picker not available in the IntelliJ host yet (#1064)");
+
+    async pickMigrationScope(c7Count: number, c8Count: number): Promise<MigrationScope> {
+        const items = [
+            `Camunda 7 only (${c7Count} diagram${c7Count !== 1 ? "s" : ""})`,
+            `Camunda 8 only (${c8Count} diagram${c8Count !== 1 ? "s" : ""})`,
+            `Both (${c7Count + c8Count} diagram${c7Count + c8Count !== 1 ? "s" : ""})`,
+        ];
+        const selected = await this.show({
+            placeholder: "Which diagrams do you want to migrate?",
+            canPickMany: false,
+            items: items.map((label) => ({ label })),
+        });
+        if (selected === null) {
+            throw new UserCancelledError();
+        }
+        const result = items[selected[0]];
+        if (result.startsWith("Camunda 7")) {
+            return "c7";
+        } else if (result.startsWith("Camunda 8")) {
+            return "c8";
+        }
+        return "both";
     }
-    async pickWorkspaceFiles(): Promise<string[]> {
-        return [];
+
+    async pickEngineVersion(platform: Engine, versions: readonly string[]): Promise<string> {
+        const label = platform === "c7" ? "Camunda 7" : "Camunda 8";
+        const selected = await this.show({
+            placeholder: `Select ${label} engine version`,
+            canPickMany: false,
+            items: versions.map((version) => ({ label: version })),
+        });
+        if (selected === null) {
+            throw new UserCancelledError();
+        }
+        return versions[selected[0]];
     }
-    async pickPayloadFile(): Promise<null> {
-        return null;
+
+    async pickWorkspaceFiles(opts: {
+        glob: string;
+        exclude?: string | null;
+        placeholder: string;
+        limit?: number;
+    }): Promise<string[]> {
+        const paths = await this.fileFinder.findFiles(opts.glob, opts.exclude, opts.limit);
+        const selected = await this.show({
+            placeholder: opts.placeholder,
+            canPickMany: true,
+            items: paths.map((path) => ({ label: posix.basename(path), description: path })),
+        });
+        return selected?.map((index) => paths[index]) ?? [];
     }
-    async pickScriptLanguage(): Promise<undefined> {
-        return undefined;
+
+    async pickPayloadFile(paths: string[]): Promise<{ filePath: string; label: string } | null> {
+        const selected = await this.show({
+            placeholder: "Select a payload file",
+            canPickMany: false,
+            items: paths.map((path) => ({ label: posix.basename(path), description: path })),
+        });
+        if (selected === null) {
+            return null;
+        }
+        const filePath = paths[selected[0]];
+        return { filePath, label: posix.basename(filePath) };
     }
-    async pickReferencedModel(): Promise<undefined> {
-        return undefined;
+
+    async pickScriptLanguage(currentFormat: string): Promise<string | undefined> {
+        const normalized = currentFormat.toLowerCase().trim();
+        // Pin the current format to the top so it stays the default highlighted
+        // option even when unrecognised (mirrors VsCodePicker).
+        const formats = [...ScriptLanguage.supportedFormats()].sort((a, b) => {
+            if (a === normalized) return -1;
+            if (b === normalized) return 1;
+            return 0;
+        });
+        const selected = await this.show({
+            title: "Script Language",
+            placeholder: "Select the scripting language",
+            canPickMany: false,
+            items: formats.map((format) => ({
+                label: format.charAt(0).toUpperCase() + format.slice(1),
+                description: `.${new ScriptLanguage(format).extension}`,
+            })),
+        });
+        return selected === null ? undefined : formats[selected[0]];
+    }
+
+    async pickReferencedModel(paths: string[]): Promise<string | undefined> {
+        // Sort by path so nearby files surface first. The bridge has no VS Code
+        // `asRelativePath`, so the absolute path is both the detail and sort key.
+        const sorted = [...paths].sort((a, b) => a.localeCompare(b));
+        const selected = await this.show({
+            placeholder: "Select the referenced model to open",
+            canPickMany: false,
+            items: sorted.map((path) => ({ label: posix.basename(path), description: path })),
+        });
+        return selected === null ? undefined : sorted[selected[0]];
     }
 }

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -15,7 +15,7 @@
  * Protocol (see {@link Rpc} for framing):
  *   Host → Core (notifications): session/register, webview/message,
  *                                document/didChange, session/dispose
- *   Core → Host (requests):      document/write, document/save
+ *   Core → Host (requests):      document/write, document/save, picker/show
  *   Core → Host (notifications): editor/postMessage, notifier/*, statusBar/*
  *
  * Diff, DMN, and deployment are deliberately out of scope here — they are their
@@ -37,9 +37,9 @@ import {
     RpcDocumentPort,
     RpcEditorHandle,
     RpcNotifier,
+    RpcPicker,
     RpcStatusBar,
     SessionMeta,
-    StubPicker,
 } from "./adapters";
 import { BridgeSettings, NodeWorkspace, SettingsSnapshot } from "./nodeAdapters";
 import { Rpc } from "./rpc";
@@ -71,19 +71,22 @@ export function createBridge(
 
     const mirror = new DocumentMirror();
     const notifier = new RpcNotifier(rpc);
-    const picker = new StubPicker();
     const statusBar = new RpcStatusBar(rpc);
     const documentPort = new RpcDocumentPort(rpc, mirror);
-
-    // onOpenCountChanged is the VS Code setContext hook; irrelevant out-of-process.
-    const store = new EditorSessionStore(() => {});
-    const bpmnService = new BpmnModelerService(store, documentPort, picker, statusBar, notifier);
 
     // The element-templates pipeline is the *real* production stack: the only new
     // code is the two pure-fs/host-fed port adapters (NodeWorkspace/BridgeSettings).
     // This is what makes the status-bar template count genuine rather than a placeholder.
     const nodeWorkspace = new NodeWorkspace();
     const settings = new BridgeSettings();
+
+    // The picker reuses NodeWorkspace for its one filesystem-backed prompt
+    // (pickWorkspaceFiles); every other prompt receives its candidates inline.
+    const picker = new RpcPicker(rpc, nodeWorkspace);
+
+    // onOpenCountChanged is the VS Code setContext hook; irrelevant out-of-process.
+    const store = new EditorSessionStore(() => {});
+    const bpmnService = new BpmnModelerService(store, documentPort, picker, statusBar, notifier);
     const artifactSvc = new ArtifactService(nodeWorkspace, settings);
     const templatesSvc = new BpmnElementTemplatesService(
         store,

--- a/apps/modeler-bridge/src/nodeAdapters.spec.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.spec.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { NodeWorkspace } from "./nodeAdapters";
+
+/**
+ * `findFiles` is the picker's one filesystem-backed prompt. These exercise its
+ * real `fs.glob` behaviour against a temp tree — brace globs, the `exclude`
+ * predicate, and the result cap — since no host (VS Code mock) is involved.
+ */
+describe("NodeWorkspace.findFiles", () => {
+    let root: string;
+
+    beforeAll(async () => {
+        root = await fs.mkdtemp(join(tmpdir(), "miranum-find-"));
+        await fs.mkdir(join(root, "forms"), { recursive: true });
+        // A non-dot directory so the `**/element-templates/**` exclude is actually
+        // exercised — fs.glob skips dot-directories by default.
+        await fs.mkdir(join(root, "config/element-templates"), { recursive: true });
+        await fs.writeFile(join(root, "forms/a.form"), "{}");
+        await fs.writeFile(join(root, "forms/b.json"), "{}");
+        await fs.writeFile(join(root, "config/element-templates/t.json"), "{}");
+    });
+
+    afterAll(async () => {
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    function workspace(): NodeWorkspace {
+        const ws = new NodeWorkspace();
+        ws.registerRoot(root);
+        return ws;
+    }
+
+    it("matches a brace glob across the registered root", async () => {
+        const found = await workspace().findFiles("**/*.{form,json}");
+        expect(found.sort()).toEqual(
+            [
+                join(root, "config/element-templates/t.json"),
+                join(root, "forms/a.form"),
+                join(root, "forms/b.json"),
+            ].sort(),
+        );
+    });
+
+    it("drops paths matching the exclude glob", async () => {
+        const found = await workspace().findFiles("**/*.json", "**/element-templates/**");
+        expect(found).toEqual([join(root, "forms/b.json")]);
+    });
+
+    it("respects the result limit", async () => {
+        const found = await workspace().findFiles("**/*.{form,json}", null, 1);
+        expect(found).toHaveLength(1);
+    });
+
+    it("returns [] when no root is registered", async () => {
+        expect(await new NodeWorkspace().findFiles("**/*.json")).toEqual([]);
+    });
+});

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -24,7 +24,7 @@
  */
 
 import { promises as fs, watch } from "node:fs";
-import { posix } from "node:path";
+import { posix, sep } from "node:path";
 
 import {
     DirectoryNotFound,
@@ -38,6 +38,35 @@ import {
 /** Strips a leading `file://` so the string is a real OS path Node `fs` accepts. */
 function toFsPath(path: string): string {
     return path.replace(/^file:\/\//, "");
+}
+
+/**
+ * Compiles a glob into a path-matching `RegExp`. Used only to honour the
+ * `exclude` argument of {@link NodeWorkspace.findFiles}: Node's `fs.glob`
+ * accepts the positive pattern natively, but its `exclude` option shape differs
+ * across Node and Bun, so we match excluded paths ourselves to stay portable.
+ *
+ * Supports the operators the callers use: a double-star (across path segments,
+ * with a trailing slash swallowed so a leading double-star also matches at the
+ * root), and single `*` / `?` within one segment.
+ */
+function globToRegExp(glob: string): RegExp {
+    let re = "";
+    for (let i = 0; i < glob.length; i++) {
+        const c = glob[i];
+        if (c === "*" && glob[i + 1] === "*") {
+            re += ".*";
+            i++;
+            if (glob[i + 1] === "/") i++;
+        } else if (c === "*") {
+            re += "[^/]*";
+        } else if (c === "?") {
+            re += "[^/]";
+        } else {
+            re += c.replace(/[.+^${}()|[\]\\]/, "\\$&");
+        }
+    }
+    return new RegExp(`^${re}$`);
 }
 
 /**
@@ -203,8 +232,34 @@ export class NodeWorkspace implements WorkspacePort {
     writeFile(): Promise<void> {
         throw new Error("not implemented in bridge");
     }
-    findFiles(): Promise<string[]> {
-        throw new Error("not implemented in bridge");
+
+    /**
+     * Globs `pattern` across every registered workspace root, returning absolute
+     * paths. Mirrors `VsCodeWorkspace.findFiles` for the picker's workspace-file
+     * prompt: `exclude` drops matches, `limit` caps the result count.
+     *
+     * `fs.glob` is the Node/Bun built-in (no extra dependency); excluded paths
+     * are filtered via {@link globToRegExp} for cross-runtime stability.
+     */
+    async findFiles(pattern: string, exclude?: string | null, limit?: number): Promise<string[]> {
+        const excludeRe = exclude ? globToRegExp(exclude) : undefined;
+        const results: string[] = [];
+        for (const root of this.roots) {
+            const cwd = toFsPath(root);
+            for await (const match of fs.glob(pattern, { cwd })) {
+                // fs.glob yields paths relative to cwd using the OS separator;
+                // normalise to posix so the exclude matcher and join are stable.
+                const relative = match.split(sep).join("/");
+                if (excludeRe?.test(relative)) {
+                    continue;
+                }
+                results.push(posix.join(cwd, relative));
+                if (limit !== undefined && results.length >= limit) {
+                    return results;
+                }
+            }
+        }
+        return results;
     }
 }
 

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -63,7 +63,11 @@ function globToRegExp(glob: string): RegExp {
         } else if (c === "?") {
             re += "[^/]";
         } else {
-            re += c.replace(/[.+^${}()|[\]\\]/, "\\$&");
+            // `c` is a single character; backslash-escape it when it carries
+            // regex meaning. (A non-global `.replace` here would only escape the
+            // first match — fine for one char, but the explicit test is clearer
+            // and side-steps the incomplete-sanitization trap.)
+            re += /[.*+?^${}()|[\]\\]/.test(c) ? `\\${c}` : c;
         }
     }
     return new RegExp(`^${re}$`);


### PR DESCRIPTION
**Issue**

Closes #1064 — Host port: Picker (QuickPick → JBPopup).

**Description**

Replaces the hard-coded `StubPicker` in the IntelliJ host bridge with a real `PickerPort` backed by a native `JBPopup` chooser, so all domain-aware quick-picks (execution platform, engine version, migration scope, payload/workspace files, script language, referenced model) work out-of-process. A single generic `picker/show` RPC keeps the Kotlin host domain-agnostic — it shows a chooser and returns the chosen indices (or `null` on cancel) — while the cancel-vs-throw convention stays in TypeScript (`RpcPicker`), mirroring `VsCodePicker` so each method matches the contract's reference behaviour. `NodeWorkspace.findFiles` is implemented via the built-in `fs.glob` for the one filesystem-backed prompt. Verified with 47 passing bridge tests (17 new picker/findFiles cases) and a clean `compileKotlin` against the IntelliJ SDK; the popup UI itself is exercised manually via `runIde` since the plugin has no Kotlin test sourceset.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created