### PR TITLE
feat(intellij): promote BPMN diff to production (#1069)

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffTool.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffTool.kt
@@ -45,7 +45,7 @@ class BpmnDiffTool : FrameDiffTool, SuppressiveDiffTool {
     }
 
     override fun createComponent(context: DiffContext, request: DiffRequest): FrameDiffTool.DiffViewer =
-        BpmnDiffViewer(request as ContentDiffRequest)
+        BpmnDiffViewer(context.project, request as ContentDiffRequest)
 
     override fun getSuppressedTools(): List<Class<out DiffTool>> =
         listOf(SimpleDiffTool::class.java, UnifiedDiffTool::class.java)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffTool.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffTool.kt
@@ -1,0 +1,70 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.diff.DiffContext
+import com.intellij.diff.DiffTool
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.SuppressiveDiffTool
+import com.intellij.diff.contents.DiffContent
+import com.intellij.diff.contents.DocumentContent
+import com.intellij.diff.contents.FileContent
+import com.intellij.diff.requests.ContentDiffRequest
+import com.intellij.diff.requests.DiffRequest
+import com.intellij.diff.tools.fragmented.UnifiedDiffTool
+import com.intellij.diff.tools.simple.SimpleDiffTool
+
+/**
+ * Registers the JCEF BPMN diff viewer with IntelliJ's `DiffManager`.
+ *
+ * Both targeted entry points — VCS "Show Diff" on a `.bpmn` change and "Compare
+ * Files" on two `.bpmn` files — produce a two-content [ContentDiffRequest] and
+ * route it through `DiffManager`, which selects among registered [DiffTool]s. So
+ * this single registration covers both paths; no VCS-specific extension point is
+ * needed there (those wrap or produce requests, they do not replace the viewer).
+ *
+ * Implements [SuppressiveDiffTool] to hide the built-in text diff tools for
+ * `.bpmn`, making the diagram viewer the default rather than a dropdown choice.
+ */
+class BpmnDiffTool : FrameDiffTool, SuppressiveDiffTool {
+    override fun getName(): String = "BPMN Diagram Diff"
+
+    /**
+     * Shows only for a two-content request whose **both** sides are `.bpmn`.
+     *
+     * Requiring both sides to be BPMN is deliberate: when a side is an
+     * `EmptyContent` (file added or deleted) or binary, [isBpmn] returns false
+     * and the request falls back to the text diff. Feeding an empty/non-XML side
+     * into the bpmn-js viewer would throw on import — declining here is the
+     * robust handling of those non-`DocumentContent` edge cases.
+     */
+    override fun canShow(context: DiffContext, request: DiffRequest): Boolean {
+        if (request !is ContentDiffRequest) {
+            return false
+        }
+        val contents = request.contents
+        return contents.size == 2 && contents.all { isBpmn(it) }
+    }
+
+    override fun createComponent(context: DiffContext, request: DiffRequest): FrameDiffTool.DiffViewer =
+        BpmnDiffViewer(request as ContentDiffRequest)
+
+    override fun getSuppressedTools(): List<Class<out DiffTool>> =
+        listOf(SimpleDiffTool::class.java, UnifiedDiffTool::class.java)
+
+    /**
+     * `.bpmn` detection by filename. The content type is unreliable here — BPMN
+     * has no registered IntelliJ file type, so it resolves to XML/unknown — but
+     * VCS contents carry a `highlightFile` (the working-tree file) and Compare
+     * Files contents carry their `file`, so the name is the firm signal. Any
+     * other content kind (empty, binary) has no name and is declined.
+     */
+    private fun isBpmn(content: DiffContent): Boolean {
+        val name =
+            when (content) {
+                is FileContent -> content.file.name
+                is DocumentContent -> content.highlightFile?.name
+                else -> null
+            } ?: return false
+        return name.endsWith(".bpmn", ignoreCase = true) ||
+            name.endsWith(".bpmn20.xml", ignoreCase = true)
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
@@ -1,0 +1,284 @@
+package io.miragon.intellij.bpmn
+
+import com.google.gson.JsonParser
+import com.intellij.diff.FrameDiffTool
+import com.intellij.diff.contents.DiffContent
+import com.intellij.diff.contents.DocumentContent
+import com.intellij.diff.contents.FileContent
+import com.intellij.diff.requests.ContentDiffRequest
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.JBSplitter
+import com.intellij.ui.jcef.JBCefApp
+import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefBrowserBase
+import com.intellij.ui.jcef.JBCefJSQuery
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.handler.CefLoadHandlerAdapter
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.SwingConstants
+
+/**
+ * Two-pane BPMN diff rendered with the real bpmn-js viewer, driven by the
+ * **out-of-process modeler core** ([CoreProcess]).
+ *
+ * A diff is *host-originated* (IntelliJ opens it with both sides known up front)
+ * and coordinates **two** JCEF browsers as one logical unit. Yet this viewer
+ * carries no diff logic — it forwards each pane's webview messages to the core
+ * and pushes core replies back into the matching browser. The differ
+ * ([BpmnDiffService] + `bpmn-js-differ`) runs entirely in the shared TypeScript
+ * core. The one exception is **swap-sides** (see [swap]): swapping recreates the
+ * two panes, a host/lifecycle concern, so it is handled here rather than in the
+ * vscode-free core — mirroring how VS Code keeps swap in `BpmnDiffController`.
+ *
+ * **Pane identity** ([uriFor]) is the key wrinkle: a `#<diffId>-<role>` fragment
+ * is appended to each side's file URL so that (a) the two sides stay distinct
+ * even when both VCS contents point at the same working-tree file, and (b) two
+ * simultaneous diffs of the *same* file never collide in the core's routing
+ * tables. `basenameOfUriString` in the core strips the fragment, so the legend
+ * still shows the real filename.
+ *
+ * **Crash recovery note:** diff panes are host-originated and their XML is held
+ * here (not in the core's document mirror), so a mid-diff bridge respawn does
+ * **not** auto-recover the diff — `CoreProcess.reregisterLiveSessions` covers
+ * editor sessions only. A diff tab is transient and re-openable, so this is an
+ * accepted limitation rather than a silent gap.
+ */
+class BpmnDiffViewer(
+    private val request: ContentDiffRequest,
+) : FrameDiffTool.DiffViewer {
+    private val coreProcess: CoreProcess? = if (JBCefApp.isSupported()) service<CoreProcess>() else null
+
+    // Matches the core's diff session key across open/dispose. Process-unique is
+    // enough — it never leaves this host.
+    private val diffId = "diff-${UUID.randomUUID()}"
+
+    private val ownDisposable = Disposer.newDisposable("BpmnDiffViewer")
+    private val rootComponent: JComponent
+
+    // Origin only drives the legend's compare-files chrome (filename + swap
+    // button), so a heuristic suffices: two distinct working files ⇒ a
+    // user-initiated Compare Files; a shared (or missing) file ⇒ a VCS diff.
+    private val origin: String
+
+    // The two physical browsers, fixed in place: [0] is the left / before-role
+    // pane, [1] the right / after-role pane. Swap exchanges the *files* assigned
+    // to these roles, not the browsers themselves.
+    private val panes = mutableListOf<Pane>()
+
+    // The file (URL + text) currently assigned to each role. Mutable so [swap]
+    // can exchange them; volatile because the JS→JVM handler reads them off the
+    // JCEF IO thread.
+    @Volatile private var beforeBaseUrl: String? = null
+
+    @Volatile private var afterBaseUrl: String? = null
+
+    @Volatile private var beforeText: String = ""
+
+    @Volatile private var afterText: String = ""
+
+    // Captured in the constructor (when the component tree is built) and acted on
+    // in init(), the EDT lifecycle point where heavy work belongs.
+    private var startSession: (() -> Unit)? = null
+
+    init {
+        if (coreProcess == null) {
+            origin = "scm"
+            rootComponent =
+                JLabel(
+                    "<html><center>JCEF (embedded Chromium) is not available in this IDE.<br>" +
+                        "Use an IntelliJ 2024.2+ build that bundles JCEF.</center></html>",
+                    SwingConstants.CENTER,
+                )
+        } else {
+            val before = request.contents[0]
+            val after = request.contents[1]
+            beforeBaseUrl = baseUrlOf(before)
+            afterBaseUrl = baseUrlOf(after)
+            beforeText = textOf(before)
+            afterText = textOf(after)
+            origin =
+                if (beforeBaseUrl != null && beforeBaseUrl != afterBaseUrl) "compare-files" else "scm"
+
+            val beforePane = createPane(ROLE_BEFORE)
+            val afterPane = createPane(ROLE_AFTER)
+            panes += beforePane
+            panes += afterPane
+
+            val splitter = JBSplitter(false, 0.5f)
+            splitter.firstComponent = beforePane.component
+            splitter.secondComponent = afterPane.component
+            rootComponent = splitter
+
+            startSession = { openAndLoad() }
+        }
+    }
+
+    override fun getComponent(): JComponent = rootComponent
+
+    override fun getPreferredFocusedComponent(): JComponent = rootComponent
+
+    override fun init(): FrameDiffTool.ToolbarComponents {
+        startSession?.invoke()
+        return FrameDiffTool.ToolbarComponents()
+    }
+
+    override fun dispose() {
+        coreProcess?.disposeDiff(diffId)
+        Disposer.dispose(ownDisposable)
+    }
+
+    /** Registers the diff with the current role assignment, then loads both pages. */
+    private fun openAndLoad() {
+        // Register the session before the pages load: each webview emits
+        // GetBpmnFileCommand as soon as its scripts run, and the core must
+        // already know the pane to answer with viewer-mode XML.
+        coreProcess?.openDiff(
+            diffId,
+            origin,
+            uriFor(ROLE_BEFORE),
+            beforeText,
+            panes[0].post,
+            uriFor(ROLE_AFTER),
+            afterText,
+            panes[1].post,
+        )
+        panes.forEach { it.load() }
+    }
+
+    /**
+     * Reverses the two sides of a compare-files diff (the webview's "Swap sides"
+     * button). The before-role pane (left browser) keeps its position but now
+     * shows the other file, and the differ re-runs with reversed before/after.
+     *
+     * Implemented as dispose → re-assign → re-open → reload, the IntelliJ
+     * analogue of VS Code recreating the `vscode.diff` tab. Ignored for SCM
+     * diffs (the button isn't shown there, but guard defensively since message
+     * routing can't encode origin).
+     */
+    private fun swap() {
+        if (origin != "compare-files") {
+            return
+        }
+        coreProcess?.disposeDiff(diffId)
+
+        val swappedBeforeUrl = afterBaseUrl
+        afterBaseUrl = beforeBaseUrl
+        beforeBaseUrl = swappedBeforeUrl
+        val swappedBeforeText = afterText
+        afterText = beforeText
+        beforeText = swappedBeforeText
+
+        openAndLoad()
+    }
+
+    /** One JCEF pane plus the host-side message pipes, mirroring [BpmnFileEditor]. */
+    private class Pane(
+        val component: JComponent,
+        val post: (String) -> Unit,
+        val load: () -> Unit,
+    )
+
+    /**
+     * Builds a JCEF browser for one diff role and wires both message pipes:
+     * JS → JVM via [JBCefJSQuery] (routed to the core under the role's *current*
+     * pane URI, recomputed live so it tracks [swap]), and JVM → JS via
+     * `window.postMessage`. Loading is deferred to [Pane.load] so the core
+     * session exists before the page's first buffered message flushes.
+     */
+    private fun createPane(role: String): Pane {
+        val browser = JBCefBrowser()
+        Disposer.register(ownDisposable, browser)
+
+        val post: (String) -> Unit = { json ->
+            // JSON is a valid JS object-literal expression; embed it directly.
+            browser.cefBrowser.executeJavaScript("window.postMessage($json, '*');", browser.cefBrowser.url, 0)
+        }
+
+        val jsQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
+        Disposer.register(browser, jsQuery)
+        jsQuery.addHandler { message ->
+            onPaneMessage(role, message)
+            null
+        }
+
+        // Install the JVM sink only after the page parses, so the shim's buffered
+        // messages flush into a handler that exists. Re-runs on every (re)load,
+        // including the reload swap triggers.
+        browser.jbCefClient.addLoadHandler(
+            object : CefLoadHandlerAdapter() {
+                override fun onLoadEnd(b: CefBrowser, frame: CefFrame, httpStatusCode: Int) {
+                    b.executeJavaScript(
+                        "window.__miranumSetSink(function (p) { ${jsQuery.inject("p")} });",
+                        b.url,
+                        0,
+                    )
+                }
+            },
+            browser.cefBrowser,
+        )
+
+        return Pane(browser.component, post) { browser.loadURL(service<WebviewServer>().ensureStarted()) }
+    }
+
+    /**
+     * Handles one raw webview message from a pane. Swap is intercepted here (a
+     * host/lifecycle command) and acted on locally; everything else forwards to
+     * the core under the role's live pane URI.
+     */
+    private fun onPaneMessage(role: String, rawMessage: String) {
+        if (isSwapCommand(rawMessage)) {
+            swap()
+            return
+        }
+        coreProcess?.forwardDiffMessage(uriFor(role), rawMessage)
+    }
+
+    /** True when the message is the webview's `SwapCompareSidesCommand`. */
+    private fun isSwapCommand(rawMessage: String): Boolean =
+        runCatching {
+            JsonParser.parseString(rawMessage).asJsonObject.get("type")?.asString == "SwapCompareSidesCommand"
+        }.getOrDefault(false)
+
+    /**
+     * Stable per-side identity, scoped by [diffId] so two diffs of the same file
+     * never collide and the two sides stay distinct even when both contents
+     * resolve to the same working-tree file (the usual VCS case).
+     */
+    private fun uriFor(role: String): String {
+        val base = (if (role == ROLE_BEFORE) beforeBaseUrl else afterBaseUrl) ?: "diff:///pane"
+        return "$base#$diffId-$role"
+    }
+
+    private fun baseUrlOf(content: DiffContent): String? =
+        when (content) {
+            is DocumentContent -> content.highlightFile?.url
+            is FileContent -> content.file.url
+            else -> null
+        }
+
+    /**
+     * Reads a side's text under a read action (Document/VFS access requires it).
+     * Handles both an open editor's [DocumentContent] and an on-disk
+     * [FileContent] (Compare Files on files with no open editor); other content
+     * kinds yield empty text, but [BpmnDiffTool.canShow] already declines those.
+     */
+    private fun textOf(content: DiffContent): String =
+        ReadAction.compute<String, RuntimeException> {
+            when (content) {
+                is DocumentContent -> content.document.text
+                is FileContent -> String(content.file.contentsToByteArray(), StandardCharsets.UTF_8)
+                else -> ""
+            }
+        }
+
+    private companion object {
+        const val ROLE_BEFORE = "before"
+        const val ROLE_AFTER = "after"
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
@@ -8,6 +8,7 @@ import com.intellij.diff.contents.FileContent
 import com.intellij.diff.requests.ContentDiffRequest
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.jcef.JBCefApp
@@ -50,9 +51,17 @@ import javax.swing.SwingConstants
  * accepted limitation rather than a silent gap.
  */
 class BpmnDiffViewer(
+    project: Project?,
     private val request: ContentDiffRequest,
 ) : FrameDiffTool.DiffViewer {
-    private val coreProcess: CoreProcess? = if (JBCefApp.isSupported()) service<CoreProcess>() else null
+    // CoreProcess is a PROJECT-level service, so it must be resolved from the
+    // project container (`project.service`), not the application one — the
+    // app-level `service<CoreProcess>()` accessor would send IntelliJ looking for
+    // an app service whose `(Project)` constructor matches no light-service
+    // signature, throwing InstantiationException. A null project (rare for a real
+    // diff) is treated as "unavailable" and falls back to the message below.
+    private val coreProcess: CoreProcess? =
+        if (JBCefApp.isSupported()) project?.service<CoreProcess>() else null
 
     // Matches the core's diff session key across open/dispose. Process-unique is
     // enough — it never leaves this host.

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -67,6 +67,12 @@ class CoreProcess(private val project: Project) : Disposable {
 
     private val sessions = ConcurrentHashMap<String, CoreSession>()
 
+    // Diff panes route by `paneUri`, not editor id: a diff has two browsers and
+    // is host-originated. `diffPanes` maps each pane's URI to its core→webview
+    // sink; `diffPaneUris` lets `disposeDiff` drop both panes of a diff at once.
+    private val diffPanes = ConcurrentHashMap<String, (String) -> Unit>()
+    private val diffPaneUris = ConcurrentHashMap<String, List<String>>()
+
     private val writeLock = Any()
     private var process: Process? = null
     private var writer: BufferedWriter? = null
@@ -280,6 +286,61 @@ class CoreProcess(private val project: Project) : Disposable {
         notify("session/dispose", linkedMapOf("editorId" to editorId))
     }
 
+    /**
+     * Starts a host-originated diff session in the core. Both sides are known up
+     * front (IntelliJ resolves the diff with HEAD and working-tree contents in
+     * hand), so the core arms a fully-paired diff session immediately — no
+     * VS Code-style out-of-order pane resolution. `postToBefore`/`postToAfter`
+     * sink core→webview messages into each side's JCEF browser; `beforeUri`/
+     * `afterUri` are the diff-scoped pane identities the core routes replies by.
+     */
+    fun openDiff(
+        diffId: String,
+        origin: String,
+        beforeUri: String,
+        beforeContent: String,
+        postToBefore: (String) -> Unit,
+        afterUri: String,
+        afterContent: String,
+        postToAfter: (String) -> Unit,
+    ) {
+        ensureStarted()
+        diffPanes[beforeUri] = postToBefore
+        diffPanes[afterUri] = postToAfter
+        diffPaneUris[diffId] = listOf(beforeUri, afterUri)
+        notify(
+            "diff/open",
+            linkedMapOf(
+                "diffId" to diffId,
+                "origin" to origin,
+                "before" to linkedMapOf("uri" to beforeUri, "content" to beforeContent),
+                "after" to linkedMapOf("uri" to afterUri, "content" to afterContent),
+            ),
+        )
+    }
+
+    /** Forwards one raw diff-pane webview message (already JSON) to the core. */
+    fun forwardDiffMessage(paneUri: String, rawMessage: String) {
+        val message =
+            try {
+                JsonParser.parseString(rawMessage)
+            } catch (e: Exception) {
+                log.warn("Discarding malformed diff message: $rawMessage", e)
+                return
+            }
+        notify("diff/webviewMessage", linkedMapOf("paneUri" to paneUri, "message" to message))
+    }
+
+    /**
+     * Tears a diff down: drops both panes' sinks (so a stray late reply can't
+     * resurrect a closed pane) and tells the core to retire the session. Called
+     * on tab close and, with an immediate re-`openDiff`, on swap.
+     */
+    fun disposeDiff(diffId: String) {
+        diffPaneUris.remove(diffId)?.forEach { diffPanes.remove(it) }
+        notify("diff/dispose", linkedMapOf("diffId" to diffId))
+    }
+
     // ── core → host ──────────────────────────────────────────────────────────
 
     /** Dispatches one line received from the core's stdout. */
@@ -303,6 +364,11 @@ class CoreProcess(private val project: Project) : Disposable {
                 // `message` is a JSON object; re-serialise it as the postMessage payload.
                 val payload = gson.toJson(params.get("message"))
                 sessions[editorId]?.postToWebview(payload)
+            }
+            "diff/postMessage" -> {
+                val paneUri = params.get("paneUri").asString
+                val payload = gson.toJson(params.get("message"))
+                diffPanes[paneUri]?.invoke(payload)
             }
             "document/write" -> handleWrite(params, id)
             "document/save" -> handleSave(params, id)
@@ -607,6 +673,8 @@ class CoreProcess(private val project: Project) : Disposable {
             if (!dying.waitFor(2, TimeUnit.SECONDS)) dying.destroyForcibly()
         }
         sessions.clear()
+        diffPanes.clear()
+        diffPaneUris.clear()
     }
 
     private companion object {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -640,7 +640,20 @@ class CoreProcess(private val project: Project) : Disposable {
 
     private fun ensureShutdownHook() {
         if (shutdownHook != null) return
-        val hook = Thread { runCatching { process?.destroyForcibly() } }
+        // On JVM exit the service's own dispose() may not run, so this hook is the
+        // only teardown. Mark `disposed` first so the process-exit handler treats
+        // the kill as intentional shutdown (not a crash to restart from), then
+        // close stdin so the bridge exits cleanly on EOF; destroyForcibly is the
+        // bounded fallback for a bridge that ignores the EOF.
+        val hook =
+            Thread {
+                disposed.set(true)
+                synchronized(writeLock) { runCatching { writer?.close() } }
+                val dying = process
+                if (dying != null && !dying.waitFor(500, TimeUnit.MILLISECONDS)) {
+                    runCatching { dying.destroyForcibly() }
+                }
+            }
         shutdownHook = hook
         runCatching { Runtime.getRuntime().addShutdownHook(hook) }
     }

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,31 @@
     <extensions defaultExtensionNs="com.intellij">
         <fileEditorProvider implementation="io.miragon.intellij.bpmn.BpmnFileEditorProvider"/>
 
+        <!--
+            JCEF two-pane diagram diff. Both targeted entry points — Git "Show
+            Diff" (VCS/SCM) and "Compare Files" — build a two-content
+            ContentDiffRequest and route it through DiffManager, which selects
+            among registered DiffTools; the VCS changes/log/commit diff previews
+            use the same DiffRequestProcessor → DiffManager path. So this single
+            registration makes the diagram diff the default for `.bpmn` across all
+            of them. BpmnDiffTool is a SuppressiveDiffTool, hiding the text diff
+            for `.bpmn`. (The platform diff framework lives under
+            com.intellij.modules.platform, so no extra <depends> is needed.)
+        -->
+        <diff.DiffTool implementation="io.miragon.intellij.bpmn.BpmnDiffTool"/>
+        <!--
+            On the changes view (commit / Local Changes / Log diff preview): the
+            EP `openapi.vcs.changes.actions.diff.ChangeDiffViewerWrapperProvider`
+            (in com.intellij.modules.vcs) does NOT replace the viewer — its
+            `process(...)` returns a DiffViewerWrapper that *decorates* a base
+            viewer with VCS line-staging/revert gutters. That chrome is
+            meaningless for a diagram diff, so we deliberately do not register it;
+            the diagram viewer reaches the changes view through the same
+            DiffManager → diff.DiffTool selection above. If a future change needs
+            changes-view-specific decoration, that is the hook (verified present
+            in 2024.2's intellij.platform.vcs.impl).
+        -->
+
         <!-- Engine version + element-template count, driven by the core's StatusBarPort. -->
         <statusBarWidgetFactory
             id="MiranumBpmnEngineWidget"

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -14,17 +14,23 @@
  *
  * Protocol (see {@link Rpc} for framing):
  *   Host → Core (notifications): session/register, webview/message,
- *                                document/didChange, session/setActive,
- *                                session/dispose
+ *                                document/didChange, settings/didChange,
+ *                                session/setActive, session/dispose,
+ *                                diff/open, diff/webviewMessage, diff/dispose
  *   Core → Host (requests):      document/write, document/save, picker/show
- *   Core → Host (notifications): editor/postMessage, notifier/*, statusBar/*
+ *   Core → Host (notifications): editor/postMessage, diff/postMessage,
+ *                                notifier/*, statusBar/*
  *
- * Diff, DMN, and deployment are deliberately out of scope here — they are their
- * own follow-up issues (#1067–#1069+); this is the BPMN-editor foundation.
+ * DMN and deployment are deliberately out of scope here — they are their own
+ * follow-up issues; this covers the BPMN editor (#1067) and diff (#1069). The
+ * diff path reuses the production diff brain verbatim (`DiffPaneStore` +
+ * `BpmnDiffService` + `bpmn-js-differ`), driven by host-originated `diff/*` RPC
+ * instead of VS Code's `vscode.diff` + custom-editor resolution.
  */
 
 import {
     Command,
+    DiffOrigin,
     Query,
     SetClipboardCommand,
     SetTextClipboardCommand,
@@ -33,9 +39,12 @@ import {
 import {
     ArtifactService,
     BpmnClipboardMediator,
+    BpmnDiffService,
     BpmnElementTemplatesService,
     BpmnModelerService,
     BpmnSettingsBroadcaster,
+    DiffPaneStore,
+    DiffSession,
     EditorSessionStore,
     WebviewMessageRouter,
 } from "@miragon/bpmn-modeler-core";
@@ -50,6 +59,7 @@ import {
     RpcStatusBar,
     SessionMeta,
 } from "./adapters";
+import { RpcDiffPaneHandle, dispatchDiffMessage } from "./diffAdapters";
 import { BridgeSettings, NodeWorkspace, SettingsSnapshot } from "./nodeAdapters";
 import { Rpc } from "./rpc";
 
@@ -116,8 +126,22 @@ export function createBridge(
     const clipboard = new RpcClipboard(rpc);
     const clipboardMediator = new BpmnClipboardMediator(store, clipboard, notifier);
 
+    // The diff feature reuses the production diff brain verbatim: the same store
+    // and service VS Code wires up. `settings` supplies the locale; diff panes are
+    // not editor sessions, so they don't ride the per-session settings hub — the
+    // locale is pushed on open via the service's `markReady` and re-pushed on
+    // `settings/didChange` via `rebroadcastLanguage` (see the handler below).
+    const diffStore = new DiffPaneStore();
+    const diffService = new BpmnDiffService(notifier, settings, diffStore);
+
     const handles = new Map<string, RpcEditorHandle>();
     const watchers = new Map<string, { dispose(): void }[]>();
+
+    // Diff panes route by `paneUri` (a diff has two browsers, indexed
+    // independently of editor sessions); `diffSessions` maps each `diffId` to
+    // its session so `diff/dispose` can detach and drop both panes at once.
+    const diffPanes = new Map<string, RpcDiffPaneHandle>();
+    const diffSessions = new Map<string, DiffSession>();
 
     // The real webview-message dispatch table. The file/sync/settings/templates/
     // clipboard handlers call the genuine services; the remaining handshake reply
@@ -207,8 +231,10 @@ export function createBridge(
 
     // One host frame updates every open editor: `apply` fires a SettingChange that
     // each session's broadcaster + configFolder listener turn into webview pushes.
+    // Diff panes aren't editor sessions, so they need an explicit locale re-push.
     rpc.on("settings/didChange", (params: { settings: Partial<SettingsSnapshot> }) => {
         settings.apply(params.settings);
+        diffService.rebroadcastLanguage();
     });
 
     rpc.on("webview/message", (params: { editorId: string; message: Command }) => {
@@ -252,5 +278,69 @@ export function createBridge(
         log(`session disposed: ${params.editorId}`);
     });
 
+    /**
+     * Host-originated diff start. Unlike VS Code — where the two panes resolve
+     * independently and the controller has to pair them — IntelliJ hands us both
+     * sides up front (it knows HEAD vs working tree), so we build the fully-armed
+     * session in one shot: two handles seeded with cached XML, both attached,
+     * indexed. Each pane's webview then boots, asks for its file, reports ready,
+     * and `markReady` runs the differ once both sides are in. Sides are already
+     * assigned by the host, so the `forScm`/`forCompareFiles` choice is made by
+     * origin alone — only so the legend's origin-specific chrome stays correct.
+     */
+    rpc.on("diff/open", (params: DiffOpenParams) => {
+        const beforeHandle = new RpcDiffPaneHandle(params.before.uri, params.before.content, rpc);
+        const afterHandle = new RpcDiffPaneHandle(params.after.uri, params.after.content, rpc);
+
+        const session =
+            params.origin === "scm"
+                ? DiffSession.forScm(beforeHandle, afterHandle)
+                : DiffSession.forCompareFiles(params.before.uri, params.after.uri);
+        session.attachPane(beforeHandle);
+        session.attachPane(afterHandle);
+        diffStore.index(session);
+
+        diffPanes.set(beforeHandle.uri, beforeHandle);
+        diffPanes.set(afterHandle.uri, afterHandle);
+        diffSessions.set(params.diffId, session);
+
+        log(`diff opened: ${params.diffId} (${params.origin})`);
+    });
+
+    rpc.on("diff/webviewMessage", (params: { paneUri: string; message: Command }) => {
+        const handle = diffPanes.get(params.paneUri);
+        if (handle) {
+            void dispatchDiffMessage(diffService, handle, params.message);
+        }
+    });
+
+    rpc.on("diff/dispose", (params: { diffId: string }) => {
+        const session = diffSessions.get(params.diffId);
+        if (!session) {
+            return;
+        }
+        for (const pane of session.attachedPanes()) {
+            diffPanes.delete(pane.uri);
+            session.detachPane(pane);
+            pane.dispose();
+        }
+        diffStore.remove(session);
+        diffSessions.delete(params.diffId);
+        log(`diff disposed: ${params.diffId}`);
+    });
+
     return { rpc };
+}
+
+interface DiffPaneInput {
+    /** Stable, diff-scoped pane identity (host appends `#<diffId>-<role>`). */
+    uri: string;
+    content: string;
+}
+
+interface DiffOpenParams {
+    diffId: string;
+    origin: DiffOrigin;
+    before: DiffPaneInput;
+    after: DiffPaneInput;
 }

--- a/apps/modeler-bridge/src/diff.spec.ts
+++ b/apps/modeler-bridge/src/diff.spec.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import { createBridge } from "./bridge";
+import { Rpc } from "./rpc";
+
+/**
+ * Drives the **diff** half of the bridge end-to-end: the real diff brain
+ * (`DiffPaneStore` + `BpmnDiffService` + `bpmn-js-differ`) over a captured-frame
+ * fake transport, exactly like `server.spec.ts` does for the editor path. No
+ * process, no JCEF — just the host-originated `diff/*` protocol and the frames
+ * it produces.
+ */
+
+/** Base diagram: one task. `before` side of every diff here. */
+const ONE_TASK = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" name="First" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+/** `after` side: adds `Task_2`, so the differ reports exactly one `_added`. */
+const TWO_TASKS = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:task id="Task_1" name="First" />
+    <bpmn:task id="Task_2" name="Second" />
+  </bpmn:process>
+</bpmn:definitions>`;
+
+/** Spins past pending microtasks/timers so the service's async dispatch settles. */
+async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function setup(): { rpc: Rpc; frames: any[] } {
+    const frames: any[] = [];
+    const { rpc } = createBridge((line) => frames.push(JSON.parse(line)));
+    return { rpc, frames };
+}
+
+function line(method: string, params: unknown): string {
+    return JSON.stringify({ method, params });
+}
+
+/** All `diff/postMessage` frames sent to a given pane, in order. */
+function postsTo(frames: any[], paneUri: string): any[] {
+    return frames
+        .filter((f) => f.method === "diff/postMessage" && f.params.paneUri === paneUri)
+        .map((f) => f.params.message);
+}
+
+describe("bridge diff (real diff brain over a fake transport)", () => {
+    const BEFORE = "file:///proc.bpmn#d1-before";
+    const AFTER = "file:///proc.bpmn#d1-after";
+
+    /** Opens a compare-files diff and walks both panes to ready. */
+    async function openAndReady(rpc: Rpc): Promise<void> {
+        await rpc.handleLine(
+            line("diff/open", {
+                diffId: "d1",
+                origin: "compare-files",
+                before: { uri: BEFORE, content: ONE_TASK },
+                after: { uri: AFTER, content: TWO_TASKS },
+            }),
+        );
+        for (const paneUri of [BEFORE, AFTER]) {
+            await rpc.handleLine(
+                line("diff/webviewMessage", { paneUri, message: { type: "GetBpmnFileCommand" } }),
+            );
+        }
+        await settle();
+        for (const paneUri of [BEFORE, AFTER]) {
+            await rpc.handleLine(
+                line("diff/webviewMessage", { paneUri, message: { type: "DiffReadyCommand" } }),
+            );
+        }
+        await settle();
+    }
+
+    it("answers each pane's GetBpmnFileCommand with its own viewer-mode XML", async () => {
+        const { rpc, frames } = setup();
+        await openAndReady(rpc);
+
+        const beforeFile = postsTo(frames, BEFORE).find((m) => m.type === "BpmnFileQuery");
+        const afterFile = postsTo(frames, AFTER).find((m) => m.type === "BpmnFileQuery");
+        expect(beforeFile).toMatchObject({ viewerMode: "viewer", content: ONE_TASK });
+        expect(afterFile).toMatchObject({ viewerMode: "viewer", content: TWO_TASKS });
+    });
+
+    it("runs the differ once both sides are ready and highlights each side", async () => {
+        const { rpc, frames } = setup();
+        await openAndReady(rpc);
+
+        const beforeHi = postsTo(frames, BEFORE).find((m) => m.type === "ApplyDiffHighlightsQuery");
+        const afterHi = postsTo(frames, AFTER).find((m) => m.type === "ApplyDiffHighlightsQuery");
+
+        // The added Task_2 belongs only on the after canvas; nothing was removed.
+        expect(afterHi).toMatchObject({ side: "after", added: ["Task_2"], removed: [] });
+        expect(beforeHi).toMatchObject({ side: "before", added: [], removed: [] });
+        // Both sides see the same counts (one addition).
+        expect(afterHi.counts).toMatchObject({ added: 1, removed: 0 });
+        expect(beforeHi.counts).toMatchObject({ added: 1, removed: 0 });
+    });
+
+    it("forwards viewport and cursor changes to the partner pane only", async () => {
+        const { rpc, frames } = setup();
+        await openAndReady(rpc);
+        const baseline = frames.length;
+
+        await rpc.handleLine(
+            line("diff/webviewMessage", {
+                paneUri: BEFORE,
+                message: {
+                    type: "ViewportChangedCommand",
+                    viewport: { x: 1, y: 2, width: 3, height: 4 },
+                },
+            }),
+        );
+        await rpc.handleLine(
+            line("diff/webviewMessage", {
+                paneUri: BEFORE,
+                message: { type: "CursorChangedCommand", index: 5 },
+            }),
+        );
+        await settle();
+
+        const fresh = frames.slice(baseline);
+        const sync = fresh.filter((f) => f.method === "diff/postMessage");
+        // Both sync queries target the partner (after), never the originator.
+        expect(sync.every((f) => f.params.paneUri === AFTER)).toBe(true);
+        expect(sync.map((f) => f.params.message.type)).toEqual([
+            "SyncViewportQuery",
+            "SyncCursorQuery",
+        ]);
+        expect(sync[0].params.message.viewport).toMatchObject({ x: 1, y: 2, width: 3, height: 4 });
+        expect(sync[1].params.message.index).toBe(5);
+    });
+
+    it("disposes both panes, after which stray pane messages are no-ops", async () => {
+        const { rpc, frames } = setup();
+        await openAndReady(rpc);
+
+        await rpc.handleLine(line("diff/dispose", { diffId: "d1" }));
+        const baseline = frames.length;
+
+        await rpc.handleLine(
+            line("diff/webviewMessage", {
+                paneUri: BEFORE,
+                message: { type: "GetBpmnFileCommand" },
+            }),
+        );
+        await settle();
+        expect(frames.length).toBe(baseline);
+    });
+
+    it("keeps two diffs of the same file independent (stable pane identity)", async () => {
+        const { rpc, frames } = setup();
+
+        // Same underlying file, but the host scopes each pane URI with the diff id,
+        // so the two diffs never share a routing key.
+        await rpc.handleLine(
+            line("diff/open", {
+                diffId: "dA",
+                origin: "compare-files",
+                before: { uri: "file:///x.bpmn#dA-before", content: ONE_TASK },
+                after: { uri: "file:///x.bpmn#dA-after", content: TWO_TASKS },
+            }),
+        );
+        await rpc.handleLine(
+            line("diff/open", {
+                diffId: "dB",
+                origin: "compare-files",
+                before: { uri: "file:///x.bpmn#dB-before", content: TWO_TASKS },
+                after: { uri: "file:///x.bpmn#dB-after", content: ONE_TASK },
+            }),
+        );
+        await rpc.handleLine(
+            line("diff/webviewMessage", {
+                paneUri: "file:///x.bpmn#dB-before",
+                message: { type: "GetBpmnFileCommand" },
+            }),
+        );
+        await settle();
+
+        // Diff B's before pane must answer with B's content, not A's.
+        const reply = postsTo(frames, "file:///x.bpmn#dB-before").find(
+            (m) => m.type === "BpmnFileQuery",
+        );
+        expect(reply.content).toBe(TWO_TASKS);
+        // Diff A's panes stayed silent — no cross-diff leakage.
+        expect(postsTo(frames, "file:///x.bpmn#dA-before")).toHaveLength(0);
+    });
+});

--- a/apps/modeler-bridge/src/diffAdapters.ts
+++ b/apps/modeler-bridge/src/diffAdapters.ts
@@ -1,0 +1,99 @@
+/**
+ * RPC-backed diff-pane adapter — the diff twin of {@link RpcEditorHandle}.
+ *
+ * Diff has a fundamentally different shape from the editor path: it is
+ * *host-originated* (the user clicks "Show Diff" / "Compare Files" in IntelliJ)
+ * and coordinates **two** panes as one logical unit. Yet the entire diff brain
+ * ({@link BpmnDiffService} + `bpmn-js-differ`) is `vscode`-free and runs here
+ * unchanged — the only per-host code is this thin per-pane handle plus the
+ * per-pane message dispatch, the bridge analogue of `BpmnDiffController.onMessage`.
+ *
+ * Unlike VS Code, where the two custom-editor panes resolve independently and
+ * out of order (hence the controller's pane-pairing dance), IntelliJ opens the
+ * diff with **both sides known up front**. So there is no pairing logic here:
+ * `bridge.ts` builds the {@link DiffSession} with both URIs and attaches both
+ * panes in one shot.
+ */
+
+import {
+    Command,
+    CursorChangedCommand,
+    ViewportChangedCommand,
+} from "@miragon/bpmn-modeler-shared";
+import { BpmnDiffService, DiffPaneHandle } from "@miragon/bpmn-modeler-core";
+
+import { Rpc } from "./rpc";
+
+/**
+ * One diff pane as the core sees it. `getText()` reads a content cache seeded by
+ * the host at `diff/open` (the diff twin of `DocumentMirror`) because
+ * {@link BpmnDiffService} reads pane XML **synchronously** — impossible over
+ * async RPC. `postMessage` emits a `diff/postMessage` notification the host
+ * routes to the matching JCEF browser by `paneUri`.
+ *
+ * `uri` is both the pane's canonical identity (for {@link DiffSession} lookups)
+ * and the routing key the host uses to pick the right browser. The host scopes
+ * it with the diff id so two simultaneous diffs of the same file never collide.
+ */
+export class RpcDiffPaneHandle implements DiffPaneHandle {
+    private ready = false;
+
+    constructor(
+        readonly uri: string,
+        private content: string,
+        private readonly rpc: Rpc,
+    ) {}
+
+    isReady(): boolean {
+        return this.ready;
+    }
+
+    setReady(): void {
+        this.ready = true;
+    }
+
+    getText(): string {
+        return this.content;
+    }
+
+    async postMessage(message: unknown): Promise<boolean> {
+        this.rpc.notify("diff/postMessage", { paneUri: this.uri, message });
+        return true;
+    }
+
+    dispose(): void {
+        // Content is the only retained resource; drop it so a stray late post
+        // can't resurrect a disposed pane's XML.
+        this.content = "";
+        this.ready = false;
+    }
+}
+
+/**
+ * Per-pane webview-message dispatch — the `onMessage` switch lifted out of
+ * `BpmnDiffController`, minus `SwapCompareSidesCommand`. Swap is a host/lifecycle
+ * concern (it recreates the two panes), so the IntelliJ host intercepts it in
+ * `BpmnDiffViewer` before forwarding — exactly as VS Code keeps swap in its
+ * *controller*, not in the vscode-free {@link BpmnDiffService}. It therefore
+ * never reaches this dispatch table.
+ */
+export async function dispatchDiffMessage(
+    service: BpmnDiffService,
+    handle: DiffPaneHandle,
+    message: Command,
+): Promise<void> {
+    switch (message.type) {
+        case "GetBpmnFileCommand":
+            await service.sendViewerFile(handle);
+            break;
+        case "DiffReadyCommand":
+            await service.markReady(handle);
+            break;
+        case "ViewportChangedCommand":
+            await service.forwardViewport(handle, (message as ViewportChangedCommand).viewport);
+            break;
+        case "CursorChangedCommand":
+            await service.forwardCursor(handle, (message as CursorChangedCommand).index);
+            break;
+    }
+}

--- a/apps/modeler-bridge/src/server.ts
+++ b/apps/modeler-bridge/src/server.ts
@@ -33,4 +33,10 @@ process.stdin.on("data", (chunk: string) => {
 });
 process.stdin.on("end", () => process.exit(0));
 
+// stdin EOF is the normal teardown, but the host also sends SIGTERM (its
+// graceful `Process.destroy()` before a force-kill fallback). Exit promptly on
+// it so a slow EOF can't leave the process to be SIGKILL'd after the host's
+// grace window.
+process.on("SIGTERM", () => process.exit(0));
+
 process.stderr.write("[core] modeler-core bridge ready\n");


### PR DESCRIPTION
**Issue**

Closes #1069 (parent epic #920 — IntelliJ host parity).

**Description**

Promotes the diff spike (`774b29a`) into the production host-foundation layout so the JCEF two-pane diagram diff is the default for `.bpmn` on both **Git Show Diff** and **Compare Files**, reusing the vscode-free diff brain (`BpmnDiffService` + `DiffPaneStore` + `bpmn-js-differ`) verbatim and adding only thin host glue. Bridge side adds `diffAdapters.ts` (`RpcDiffPaneHandle` + `dispatchDiffMessage`), `diff/open|webviewMessage|dispose` wiring in `createBridge`, and an end-to-end `diff.spec.ts`. IntelliJ side adds `BpmnDiffTool` (`FrameDiffTool` + `SuppressiveDiffTool`) and `BpmnDiffViewer` with the production hardening the spike skipped — diffId-scoped stable pane identity (multi-diff safe), `FileContent` text extraction (Compare Files on closed files), and host-driven swap-sides — plus `openDiff`/`forwardDiffMessage`/`disposeDiff` transport in `CoreProcess`. `ChangeDiffViewerWrapperProvider` is intentionally not registered: its real contract decorates a viewer with VCS line-staging gutters (meaningless for a diagram diff), and the changes/log/commit previews already route through `DiffManager → diff.DiffTool` selection.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented — bridge `diff.spec.ts` (open, differ broadcast, viewport/cursor sync, dispose, multi-diff identity); the JCEF Kotlin path needs `runIde` smoke testing (no headless harness)
* Documentation was created — rationale comments in `plugin.xml` and the new Kotlin/TS files