### PR TITLE
feat(intellij): wire model navigation through the bridge (#1070)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,16 +7,9 @@ enableScripts: true
 
 nodeLinker: node-modules
 
-# The only registry-resolved @miragon dependency is the public-npm package
-# @miragon/create-append-c7; every other @miragon/* dep is a workspace. Pin the
-# scope so a contributor whose global config routes @miragon to GitHub Packages
-# still resolves it from public npm.
+npmPreapprovedPackages:
+  - "@miragon/create-append-c7"
+
 npmScopes:
   miragon:
     npmRegistryServer: "https://registry.npmjs.org"
-
-# Exempt our own first-party package from Yarn's 24h minimum-release-age gate
-# (npmMinimalAgeGate), so a fresh @miragon/create-append-c7 publish doesn't
-# quarantine installs here or in CI for a day.
-npmPreapprovedPackages:
-  - "@miragon/create-append-c7"

--- a/apps/modeler-bridge/src/bridge.navigate.spec.ts
+++ b/apps/modeler-bridge/src/bridge.navigate.spec.ts
@@ -1,0 +1,210 @@
+/**
+ * End-to-end coverage for the "Go to referenced model" RPC path on the bridge.
+ *
+ * Same harness style as `server.spec.ts`: the real bridge (`createBridge`) runs
+ * against a fake transport (a frames array) over a real temp filesystem, so the
+ * `ReferencedModelLocator` + `ModelNavigationService` it constructs do an
+ * actual `fs.glob` + read-and-regex search. The tests cover the four branches
+ * the navigation flow exposes to the host: single-match (direct open), multi-
+ * match (picker round-trip), no-match (info balloon, no open), and unknown
+ * `referenceKind` (warn log, no search).
+ */
+
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createBridge } from "./bridge";
+import { Rpc } from "./rpc";
+
+const C7_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="Process_1" isExecutable="true" />
+</bpmn:definitions>`;
+
+/** XML whose `<bpmn:process id>` matches `id`, used to seed target files. */
+function bpmnWithProcessId(id: string): string {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_X" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="${id}" isExecutable="true" />
+</bpmn:definitions>`;
+}
+
+async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Waits for a frame matching `predicate` to land, or rejects after `timeoutMs`.
+ * The navigation flow awaits `notifier.withProgress` → an async fs.glob → an
+ * `await Promise.all` over per-file reads, so a single `settle()` isn't enough
+ * turns to drain it; polling lets the test stay deterministic without coupling
+ * to the number of microtasks the service happens to chain.
+ */
+async function waitForFrame(
+    frames: any[],
+    predicate: (frame: any) => boolean,
+    timeoutMs = 2000,
+): Promise<any> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const match = frames.find(predicate);
+        if (match) return match;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("waitForFrame timed out");
+}
+
+function registerParams(editorId: string, root: string, fsPath: string, content: string) {
+    return {
+        editorId,
+        uriString: editorId,
+        path: editorId.replace(/^file:\/\//, ""),
+        fsPath,
+        scheme: "file",
+        workspaceRoot: root,
+        content,
+    };
+}
+
+describe("bridge navigation (real core + locator over a fake transport)", () => {
+    const cleanups: Array<() => Promise<void> | void> = [];
+
+    afterEach(async () => {
+        for (const cleanup of cleanups.splice(0)) {
+            await cleanup();
+        }
+    });
+
+    /**
+     * Builds a bridge whose emitted frames are captured, over a fresh temp
+     * workspace, then registers a single source editor so the handler has a
+     * valid `editorStore.requireHandle(editorId)`. Returns everything the
+     * tests need to feed inbound frames and inspect outbound ones.
+     */
+    async function setup(): Promise<{
+        rpc: Rpc;
+        frames: any[];
+        root: string;
+        sourcePath: string;
+        editorId: string;
+    }> {
+        const root = await fs.mkdtemp(join(tmpdir(), "modeler-bridge-nav-"));
+        const sourcePath = join(root, "source.bpmn");
+        await fs.writeFile(sourcePath, C7_XML, "utf8");
+
+        const frames: any[] = [];
+        const { rpc } = createBridge((line) => frames.push(JSON.parse(line)));
+        const editorId = `file://${sourcePath}`;
+
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "session/register",
+                params: registerParams(editorId, root, sourcePath, C7_XML),
+            }),
+        );
+
+        cleanups.push(() => fs.rm(root, { recursive: true, force: true }));
+        return { rpc, frames, root, sourcePath, editorId };
+    }
+
+    async function feedNavigate(
+        rpc: Rpc,
+        editorId: string,
+        referenceId: string,
+        referenceKind: unknown,
+    ): Promise<void> {
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: {
+                        type: "NavigateToReferencedModelCommand",
+                        referenceId,
+                        referenceKind,
+                    },
+                },
+            }),
+        );
+        await settle();
+    }
+
+    it("opens the file directly when exactly one model declares the id", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        const targetPath = join(root, "target.bpmn");
+        const otherPath = join(root, "other.bpmn");
+        await fs.writeFile(targetPath, bpmnWithProcessId("Target"), "utf8");
+        await fs.writeFile(otherPath, bpmnWithProcessId("Unrelated"), "utf8");
+
+        await feedNavigate(rpc, editorId, "Target", "process");
+
+        const open = await waitForFrame(frames, (f) => f.method === "notifier/openDocument");
+        expect(open.params.path).toBe(targetPath);
+        // A single match must short-circuit the picker.
+        expect(frames.find((f) => f.method === "picker/show")).toBeUndefined();
+        expect(frames.filter((f) => f.method === "notifier/openDocument")).toHaveLength(1);
+    });
+
+    it("prompts via picker/show when multiple files declare the id, then opens the choice", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        const aPath = join(root, "a.bpmn");
+        const bPath = join(root, "b.bpmn");
+        await fs.writeFile(aPath, bpmnWithProcessId("Shared"), "utf8");
+        await fs.writeFile(bPath, bpmnWithProcessId("Shared"), "utf8");
+
+        await feedNavigate(rpc, editorId, "Shared", "process");
+
+        const picker = await waitForFrame(
+            frames,
+            (f) => f.method === "picker/show" && f.id != null,
+        );
+        expect(picker.params.canPickMany).toBe(false);
+        const labels = picker.params.items.map((it: { description: string }) => it.description);
+        expect(labels).toEqual([...labels].sort());
+        expect(new Set(labels)).toEqual(new Set([aPath, bPath]));
+
+        // Reply selecting the first item; the service then forwards it as openDocument.
+        await rpc.handleLine(JSON.stringify({ id: picker.id, result: { selected: [0] } }));
+
+        const open = await waitForFrame(frames, (f) => f.method === "notifier/openDocument");
+        expect(open.params.path).toBe(labels[0]);
+    });
+
+    it("emits showInfo and no open when no model declares the id", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        const path = join(root, "other.bpmn");
+        await fs.writeFile(path, bpmnWithProcessId("Unrelated"), "utf8");
+
+        await feedNavigate(rpc, editorId, "Missing", "process");
+
+        const info = await waitForFrame(frames, (f) => f.method === "notifier/showInfo");
+        expect(String(info.params.message)).toContain("Missing");
+        expect(frames.find((f) => f.method === "notifier/openDocument")).toBeUndefined();
+        expect(frames.find((f) => f.method === "picker/show")).toBeUndefined();
+    });
+
+    it("rejects an unknown referenceKind with a warn log and no search", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        // Seed a candidate file so a fall-through bug would visibly hit `findFiles`.
+        await fs.writeFile(join(root, "target.bpmn"), bpmnWithProcessId("Target"), "utf8");
+
+        // Reset frames so the assertion isn't muddied by the register-time logs.
+        const before = frames.length;
+        await feedNavigate(rpc, editorId, "Target", "spell");
+
+        const newFrames = frames.slice(before);
+        expect(newFrames.find((f) => f.method === "notifier/openDocument")).toBeUndefined();
+        expect(newFrames.find((f) => f.method === "picker/show")).toBeUndefined();
+        // The service's own progress/showInfo paths must not run either — the
+        // guard is meant to short-circuit before the locator is touched.
+        expect(newFrames.find((f) => f.method === "notifier/progressStart")).toBeUndefined();
+        const warn = newFrames.find(
+            (f) => f.method === "notifier/log" && f.params.level === "warn",
+        );
+        expect(warn).toBeDefined();
+        expect(String(warn.params.message)).toContain("spell");
+    });
+});

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -31,6 +31,7 @@
 import {
     Command,
     DiffOrigin,
+    NavigateToReferencedModelCommand,
     Query,
     SetClipboardCommand,
     SetTextClipboardCommand,
@@ -46,6 +47,8 @@ import {
     DiffPaneStore,
     DiffSession,
     EditorSessionStore,
+    ModelNavigationService,
+    ReferencedModelLocator,
     WebviewMessageRouter,
 } from "@miragon/bpmn-modeler-core";
 
@@ -134,6 +137,17 @@ export function createBridge(
     const diffStore = new DiffPaneStore();
     const diffService = new BpmnDiffService(notifier, settings, diffStore);
 
+    // The model-navigation brain is `vscode`-free, so it runs unmodified here:
+    // the locator searches via NodeWorkspace's findFiles/readFile/readDirectory,
+    // and the service surfaces results through the same notifier/picker the host
+    // already implements over RPC (notifier/openDocument + picker/show).
+    const referencedModelLocator = new ReferencedModelLocator(nodeWorkspace, notifier);
+    const modelNavigationService = new ModelNavigationService(
+        referencedModelLocator,
+        notifier,
+        picker,
+    );
+
     const handles = new Map<string, RpcEditorHandle>();
     const watchers = new Map<string, { dispose(): void }[]>();
 
@@ -144,11 +158,11 @@ export function createBridge(
     const diffSessions = new Map<string, DiffSession>();
 
     // The real webview-message dispatch table. The file/sync/settings/templates/
-    // clipboard handlers call the genuine services; the remaining handshake reply
-    // is a bridge-level stub because its real service (properties panel) pulls in a
-    // host port that is a later issue (#1065). It must still answer, or the
-    // webview's `Promise.all` over templates+settings+panel-state never resolves
-    // and bootstrap stalls.
+    // clipboard/navigation handlers call the genuine services; the remaining
+    // handshake reply is a bridge-level stub because its real service (properties
+    // panel) pulls in a host port that is a later issue (#1065). It must still
+    // answer, or the webview's `Promise.all` over templates+settings+panel-state
+    // never resolves and bootstrap stalls.
     const router = new WebviewMessageRouter();
     router
         .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
@@ -184,6 +198,23 @@ export function createBridge(
         })
         .on("SetTextClipboardCommand", (message: Command) => {
             void clipboardMediator.writeClipboard((message as SetTextClipboardCommand).text);
+        })
+        // Mirrors `navigateToReferencedModelHandler` on the VS Code host: an
+        // unknown discriminant is rejected with a warning rather than falling
+        // through to "decision" by default — defence in depth against a
+        // malformed webview message ever opening the wrong kind of file.
+        .on("NavigateToReferencedModelCommand", async (message: Command, editorId: string) => {
+            const cmd = message as NavigateToReferencedModelCommand;
+            if (cmd.referenceKind !== "process" && cmd.referenceKind !== "decision") {
+                notifier.logWarning(
+                    `Ignoring NavigateToReferencedModelCommand with unknown kind: ${String(
+                        cmd.referenceKind,
+                    )}`,
+                );
+                return;
+            }
+            const sourceFsPath = store.requireHandle(editorId).documentFsPath();
+            await modelNavigationService.navigate(cmd.referenceId, cmd.referenceKind, sourceFsPath);
         });
 
     rpc.on("session/register", async (params: RegisterParams) => {

--- a/apps/modeler-bridge/src/nodeAdapters.spec.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.spec.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { NoWorkspaceFolderFoundError } from "@miragon/bpmn-modeler-core";
+
 import { NodeWorkspace } from "./nodeAdapters";
 
 /**
@@ -58,6 +60,83 @@ describe("NodeWorkspace.findFiles", () => {
 
     it("returns [] when no root is registered", async () => {
         expect(await new NodeWorkspace().findFiles("**/*.json")).toEqual([]);
+    });
+});
+
+/**
+ * The three workspace-folder methods the navigation locator depends on. Until
+ * #1070 these were unimplemented stubs that threw — the path that runs
+ * `findWorkspaceFolderForDocument` (loose-file detection) and
+ * `getDocumentDirectory` (fs-walk root) must work even when the host registers
+ * a workspace root, since the locator queries them up front. The
+ * `getWorkspaceFolderForDocument` throw-variant is still load-bearing for
+ * `ArtifactService.getWorkspaceRoot`, so its behaviour is pinned here too.
+ */
+describe("NodeWorkspace folder lookups", () => {
+    let root: string;
+
+    beforeAll(async () => {
+        root = await fs.mkdtemp(join(tmpdir(), "miranum-folder-"));
+    });
+
+    afterAll(async () => {
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    function workspace(rootPath = root): NodeWorkspace {
+        const ws = new NodeWorkspace();
+        ws.registerRoot(rootPath);
+        return ws;
+    }
+
+    it("getWorkspaceFolderPaths reflects every registered root", () => {
+        const ws = new NodeWorkspace();
+        ws.registerRoot("/tmp/a");
+        ws.registerRoot("/tmp/b");
+        expect(ws.getWorkspaceFolderPaths().sort()).toEqual(["/tmp/a", "/tmp/b"]);
+    });
+
+    it("getWorkspaceFolderPaths is empty when nothing is registered", () => {
+        expect(new NodeWorkspace().getWorkspaceFolderPaths()).toEqual([]);
+    });
+
+    it("findWorkspaceFolderForDocument returns the enclosing root for an inside path", () => {
+        const ws = workspace();
+        expect(ws.findWorkspaceFolderForDocument(join(root, "sub/file.bpmn"))).toBe(root);
+    });
+
+    it("findWorkspaceFolderForDocument returns undefined for an outside path", () => {
+        const ws = workspace();
+        // A sibling temp dir guarantees no prefix overlap with `root`.
+        expect(ws.findWorkspaceFolderForDocument("/var/empty/file.bpmn")).toBeUndefined();
+    });
+
+    it("findWorkspaceFolderForDocument preserves the file:// scheme of the input", () => {
+        const ws = workspace();
+        expect(ws.findWorkspaceFolderForDocument(`file://${root}/file.bpmn`)).toBe(
+            `file://${root}`,
+        );
+    });
+
+    it("getWorkspaceFolderForDocument still throws when no root encloses the document", () => {
+        const ws = workspace();
+        // ArtifactService relies on this exact error class to trigger its git-root
+        // → doc-dir fallback chain; loosening the throw would silently break it.
+        expect(() => ws.getWorkspaceFolderForDocument("/var/empty/file.bpmn")).toThrow(
+            NoWorkspaceFolderFoundError,
+        );
+    });
+
+    it("getDocumentDirectory returns the parent of a clean path", () => {
+        const ws = new NodeWorkspace();
+        expect(ws.getDocumentDirectory("/tmp/proj/sub/file.bpmn")).toBe("/tmp/proj/sub");
+    });
+
+    it("getDocumentDirectory preserves the file:// scheme of the input", () => {
+        const ws = new NodeWorkspace();
+        expect(ws.getDocumentDirectory("file:///tmp/proj/sub/file.bpmn")).toBe(
+            "file:///tmp/proj/sub",
+        );
     });
 });
 

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -97,14 +97,12 @@ export class NodeWorkspace implements WorkspacePort {
     }
 
     /**
-     * Returns the registered root that encloses `documentDir`, re-prefixed into
-     * `documentDir`'s own scheme space so the caller's downstream string
-     * comparisons (e.g. `ArtifactService`'s containment check) stay consistent.
-     *
-     * @throws {NoWorkspaceFolderFoundError} when no root encloses the document,
-     *   so `ArtifactService.getWorkspaceRoot` falls back to git-root then doc-dir.
+     * Scheme-tolerant root match, shared by the throwing and non-throwing
+     * variants below: returns the enclosing registered root re-prefixed into
+     * `document`'s own scheme space (URI in → URI out, clean in → clean out),
+     * or `undefined` when no root covers it.
      */
-    getWorkspaceFolderForDocument(document: string): string {
+    private enclosingRoot(document: string): string | undefined {
         const hadScheme = document.startsWith("file://");
         const normDoc = toFsPath(document);
         for (const root of this.roots) {
@@ -113,7 +111,19 @@ export class NodeWorkspace implements WorkspacePort {
                 return hadScheme ? "file://" + normRoot : normRoot;
             }
         }
-        throw new NoWorkspaceFolderFoundError();
+        return undefined;
+    }
+
+    /**
+     * @throws {NoWorkspaceFolderFoundError} when no root encloses the document,
+     *   so `ArtifactService.getWorkspaceRoot` falls back to git-root then doc-dir.
+     */
+    getWorkspaceFolderForDocument(document: string): string {
+        const match = this.enclosingRoot(document);
+        if (match === undefined) {
+            throw new NoWorkspaceFolderFoundError();
+        }
+        return match;
     }
 
     /**
@@ -250,17 +260,30 @@ export class NodeWorkspace implements WorkspacePort {
         };
     }
 
-    // Never reached on the element-templates path; the bridge type-checks
-    // `src/**`, so the full interface must be present.
-    findWorkspaceFolderForDocument(): string | undefined {
-        throw new Error("not implemented in bridge");
+    /**
+     * Non-throwing variant of {@link getWorkspaceFolderForDocument} —
+     * `ReferencedModelLocator` uses it to distinguish a workspace-rooted
+     * document (use `findFiles`) from a loose file (walk from its directory).
+     */
+    findWorkspaceFolderForDocument(document: string): string | undefined {
+        return this.enclosingRoot(document);
     }
+
     getWorkspaceFolderPaths(): string[] {
-        throw new Error("not implemented in bridge");
+        return [...this.roots];
     }
-    getDocumentDirectory(): string {
-        throw new Error("not implemented in bridge");
+
+    /**
+     * Returns `posix.dirname` of the document, preserving the input's scheme
+     * space so the locator's loose-file walk root and its candidate paths
+     * compare consistently downstream.
+     */
+    getDocumentDirectory(document: string): string {
+        const hadScheme = document.startsWith("file://");
+        const parent = posix.dirname(toFsPath(document));
+        return hadScheme ? "file://" + parent : parent;
     }
+
     writeFile(): Promise<void> {
         throw new Error("not implemented in bridge");
     }

--- a/package.json
+++ b/package.json
@@ -66,5 +66,5 @@
         "preact": "10.28.4",
         "webpack-cli": "4.10.0"
     },
-    "packageManager": "yarn@4.15.0"
+    "packageManager": "yarn@4.16.0"
 }


### PR DESCRIPTION
**Issue**

Closes #1070 (epic #920, IntelliJ host parity).

**Description**

Makes "Go to referenced model" work on IntelliJ: the navigation brain (`ModelNavigationService` + `ReferencedModelLocator`) is `vscode`-free and already lives in `modeler-core`, and the Kotlin host already implements every RPC it needs (`picker/show`, `notifier/openDocument`, `notifier/show*`/`log`/`progress*`) — only the bridge wiring was missing. This PR implements the three `WorkspacePort` methods on `NodeWorkspace` that the locator uses (`findWorkspaceFolderForDocument`, `getWorkspaceFolderPaths`, `getDocumentDirectory`, sharing a private `enclosingRoot` helper that keeps the URI/clean scheme invariant) and constructs the navigation service in `bridge.ts` with a `NavigateToReferencedModelCommand` router handler that mirrors the VS Code host (unknown-discriminant rejection + warn log). No Kotlin, webview, or shared-types changes.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created