### PR TITLE
feat(intellij): Camunda code completion for the "Edit Script" editor (#1073)

### DIFF
--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -19,6 +19,11 @@ dependencies {
     intellijPlatform {
         // 2024.2+ ships JCEF, which the JCEF-backed editor needs.
         intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
+        // Groovy PSI for the "Edit Script" binding resolver (see
+        // ScriptBindingMembersContributor). The bundled Groovy plugin transitively
+        // brings the Java plugin that provides LightPsiClassBuilder/PsiElementFactory.
+        bundledPlugin("org.intellij.groovy")
+        bundledPlugin("com.intellij.java")
     }
     // Gson does the JSON encode/decode for the host ↔ bridge ↔ webview messages.
     // Hand-built strings are unsafe here: SyncDocumentCommand carries the full

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -19,9 +19,9 @@ dependencies {
     intellijPlatform {
         // 2024.2+ ships JCEF, which the JCEF-backed editor needs.
         intellijIdeaCommunity(providers.gradleProperty("ideaVersion").get())
-        // Groovy PSI for the "Edit Script" binding resolver (see
-        // ScriptBindingMembersContributor). The bundled Groovy plugin transitively
-        // brings the Java plugin that provides LightPsiClassBuilder/PsiElementFactory.
+        // Groovy PSI for the "Edit Script" binding resolver
+        // (ScriptBindingMembersContributor). The Groovy plugin transitively brings
+        // the Java plugin that provides LightPsiClassBuilder/PsiElementFactory.
         bundledPlugin("org.intellij.groovy")
         bundledPlugin("com.intellij.java")
     }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -455,11 +455,14 @@ class CoreProcess(private val project: Project) : Disposable {
                     params.get("tenantId").asString,
                 )
             // Inline-script editor: the host is a dumb surface keyed by scriptId.
+            // `completion` is optional and carries the kind-scoped catalog the
+            // bridge already resolved; fromJson tolerates a missing/null member.
             "script/open" ->
                 scriptEditors.openScript(
                     params.get("scriptId").asString,
                     params.get("fileName").asString,
                     params.get("content").asString,
+                    gson.fromJson(params.get("completion"), ScriptCompletionModel::class.java),
                 )
             "script/close" -> scriptEditors.closeScript(params.get("scriptId").asString)
             "document/write" -> handleWrite(params, id)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptBindingMembersContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptBindingMembersContributor.kt
@@ -1,0 +1,128 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiSubstitutor
+import com.intellij.psi.PsiType
+import com.intellij.psi.ResolveState
+import com.intellij.psi.impl.light.LightPsiClassBuilder
+import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.plugins.groovy.lang.psi.GroovyFile
+import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GrLightMethodBuilder
+import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GrLightVariable
+import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GroovyScriptClass
+import org.jetbrains.plugins.groovy.lang.resolve.NonCodeMembersContributor
+
+/**
+ * Makes the Camunda script bindings (`execution`, `task`, `eventName`, …)
+ * genuinely *resolve* inside a Groovy "Edit Script" tab.
+ *
+ * The bindings are injected at runtime by Camunda's JSR-223 engine, so the
+ * Groovy PSI never sees them — and its type-check inspection
+ * (`GroovyTypeCheckVisitor`) then flags a bare `execution` as an unresolved
+ * implicit method call, and `execution.getVariable(…)` as an unresolved member.
+ * Highlight-filter EPs only gate the *old* "Cannot resolve symbol" checker, not
+ * this one, so the only correct fix is to make the references resolve for real:
+ * we contribute each in-scope bean as a [GrLightVariable] whose *type* is a
+ * synthetic class carrying the bean's catalog methods. Then `execution` resolves
+ * to a variable (clearing the method-call warning) and `execution.getVariable(…)`
+ * resolves off that variable's class (clearing the member warning).
+ *
+ * The light variable carries its type at construction: the binding-specific
+ * `GrBindingVariable.setType` is an unimplemented stub that throws
+ * `UnsupportedOperationException` at runtime (it infers its type from in-file
+ * assignments, of which a binding has none), so [GrLightVariable] — which stores
+ * the type passed to its constructor — is the correct synthetic to use here.
+ *
+ * The catalog is single-sourced: it originates in core, ships over the bridge
+ * with `script/open`, and is attached to the script tab as [SCRIPT_COMPLETION_KEY]
+ * UserData. This class only *renders* that opaque, pre-scoped data as PSI — it
+ * holds no BPMN/Camunda knowledge of its own. Scope is Groovy-only by design
+ * (the surface the user reported); JS/other engines resolve differently.
+ */
+class ScriptBindingMembersContributor : NonCodeMembersContributor() {
+    override fun processDynamicElements(
+        qualifierType: PsiType,
+        aClass: PsiClass?,
+        processor: PsiScopeProcessor,
+        place: PsiElement,
+        state: ResolveState,
+    ) {
+        // Gate twice: the qualifier must be *this* script's class, and that
+        // script file must carry our UserData — so we never leak bindings into
+        // unrelated Groovy files or onto unrelated qualifiers.
+        val scriptClass = aClass as? GroovyScriptClass ?: return
+        val groovyFile = scriptClass.containingFile as? GroovyFile ?: return
+        val model = completionModelFor(groovyFile) ?: return
+
+        val project = groovyFile.project
+        val elementFactory = JavaPsiFacade.getElementFactory(project)
+        val psiManager = groovyFile.manager
+        val resolveScope = place.resolveScope
+
+        for (bean in model.beans) {
+            val type = beanType(bean, groovyFile, elementFactory, psiManager, resolveScope)
+            // navigationElement = groovyFile: Ctrl-click on the binding lands on
+            // the script itself, since it has no real declaration site.
+            val bindingVariable = GrLightVariable(psiManager, bean.name, type, groovyFile)
+            // execute() returns false to stop the scan early (e.g. the resolver
+            // already found the single name it was looking for).
+            if (!processor.execute(bindingVariable, state)) return
+        }
+    }
+
+    /**
+     * The [ScriptCompletionModel] attached to [groovyFile]'s tab, or null if this
+     * isn't one of our script tabs. During resolution the PSI file's own
+     * [com.intellij.openapi.vfs.VirtualFile] is the tracked `LightVirtualFile`;
+     * the `originalFile` fallback covers the in-memory copy IntelliJ resolves
+     * against while completing.
+     */
+    private fun completionModelFor(groovyFile: GroovyFile): ScriptCompletionModel? {
+        groovyFile.virtualFile?.getUserData(SCRIPT_COMPLETION_KEY)?.let { return it }
+        return groovyFile.originalFile.virtualFile?.getUserData(SCRIPT_COMPLETION_KEY)
+    }
+
+    /**
+     * The PSI type to give a binding variable.
+     *
+     * Object beans (with [BeanInfo.methods]) get a synthetic [LightPsiClassBuilder]
+     * named after the bean's type, carrying one method per catalog entry — method
+     * *existence* on the class is what clears the member-call type check; the
+     * param/return labels need not resolve to real classes. Value beans (no
+     * methods, e.g. `eventName: String`) just resolve their declared type by name;
+     * the binding variable still resolves even if the label can't be found, which
+     * is all the bare-reference warning requires.
+     */
+    private fun beanType(
+        bean: BeanInfo,
+        groovyFile: GroovyFile,
+        elementFactory: PsiElementFactory,
+        psiManager: PsiManager,
+        resolveScope: GlobalSearchScope,
+    ): PsiType {
+        if (bean.methods.isEmpty()) {
+            return elementFactory.createTypeByFQClassName(bean.type, resolveScope)
+        }
+
+        val beanClass = LightPsiClassBuilder(groovyFile, bean.type)
+        for (method in bean.methods) {
+            val methodBuilder =
+                GrLightMethodBuilder(psiManager, method.name)
+                    .apply {
+                        addModifier("public")
+                        setContainingClass(beanClass)
+                        setReturnType(method.returnType, resolveScope)
+                    }
+            for (param in method.params) {
+                methodBuilder.addParameter(param.name, param.type)
+            }
+            beanClass.addMethod(methodBuilder)
+        }
+        return elementFactory.createType(beanClass, PsiSubstitutor.EMPTY)
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptBindingMembersContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptBindingMembersContributor.kt
@@ -1,5 +1,6 @@
 package io.miragon.intellij.bpmn
 
+import com.intellij.psi.CommonClassNames
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
@@ -9,6 +10,7 @@ import com.intellij.psi.PsiSubstitutor
 import com.intellij.psi.PsiType
 import com.intellij.psi.ResolveState
 import com.intellij.psi.impl.light.LightPsiClassBuilder
+import com.intellij.psi.scope.ElementClassHint
 import com.intellij.psi.scope.PsiScopeProcessor
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.plugins.groovy.lang.psi.GroovyFile
@@ -16,33 +18,33 @@ import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GrLightMethodBuilder
 import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GrLightVariable
 import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GroovyScriptClass
 import org.jetbrains.plugins.groovy.lang.resolve.NonCodeMembersContributor
+import org.jetbrains.plugins.groovy.lang.resolve.ResolveUtil
 
 /**
- * Makes the Camunda script bindings (`execution`, `task`, `eventName`, …)
- * genuinely *resolve* inside a Groovy "Edit Script" tab.
+ * Makes the symbols available at runtime in a Groovy "Edit Script" tab actually
+ * *resolve*, so the IDE stops reporting them as unknown.
  *
- * The bindings are injected at runtime by Camunda's JSR-223 engine, so the
- * Groovy PSI never sees them — and its type-check inspection
- * (`GroovyTypeCheckVisitor`) then flags a bare `execution` as an unresolved
- * implicit method call, and `execution.getVariable(…)` as an unresolved member.
- * Highlight-filter EPs only gate the *old* "Cannot resolve symbol" checker, not
- * this one, so the only correct fix is to make the references resolve for real:
- * we contribute each in-scope bean as a [GrLightVariable] whose *type* is a
- * synthetic class carrying the bean's catalog methods. Then `execution` resolves
- * to a variable (clearing the method-call warning) and `execution.getVariable(…)`
- * resolves off that variable's class (clearing the member warning).
+ * The script lives in a classpath-less [com.intellij.testFramework.LightVirtualFile]
+ * with no Groovy SDK and no Camunda jars, so the Camunda bindings (`execution`,
+ * `task`, `eventName`) and standard `Script` methods (`println`, `print`) are all
+ * unresolved. An unresolved reference makes Groovy's quick-doc show "No candidates
+ * found for method call …" on hover — which no highlight filter or inspection
+ * suppressor can remove, because it comes from the *documentation* provider. The
+ * only fix is genuine resolution, which we provide here as synthetic PSI:
  *
- * The light variable carries its type at construction: the binding-specific
- * `GrBindingVariable.setType` is an unimplemented stub that throws
- * `UnsupportedOperationException` at runtime (it infers its type from in-file
- * assignments, of which a binding has none), so [GrLightVariable] — which stores
- * the type passed to its constructor — is the correct synthetic to use here.
+ * - **Bindings** (property/variable references): each in-scope bean becomes a
+ *   [GrLightVariable] whose type is a synthetic class carrying the catalog
+ *   methods, so `execution` and `execution.getVariable(…)` both resolve.
+ * - **Script methods** (unqualified method calls): the common `Script`/Groovy
+ *   helpers ([SCRIPT_METHODS]) are contributed onto the script class, so
+ *   `println`/`print` resolve. The IDE bundles no Groovy SDK to resolve them
+ *   against, so we synthesise the handful that scripts actually use; richer
+ *   stdlib coverage would require bundling the Groovy runtime.
  *
- * The catalog is single-sourced: it originates in core, ships over the bridge
- * with `script/open`, and is attached to the script tab as [SCRIPT_COMPLETION_KEY]
- * UserData. This class only *renders* that opaque, pre-scoped data as PSI — it
- * holds no BPMN/Camunda knowledge of its own. Scope is Groovy-only by design
- * (the surface the user reported); JS/other engines resolve differently.
+ * The catalog originates in core and arrives over the bridge as
+ * [SCRIPT_COMPLETION_KEY] UserData; this only renders it as PSI, scoped to our own
+ * tabs. Greying/applicability *highlights* on anything still unresolved are
+ * handled separately by [ScriptHighlightFilter] / [ScriptInspectionSuppressor].
  */
 class ScriptBindingMembersContributor : NonCodeMembersContributor() {
     override fun processDynamicElements(
@@ -52,35 +54,48 @@ class ScriptBindingMembersContributor : NonCodeMembersContributor() {
         place: PsiElement,
         state: ResolveState,
     ) {
-        // Gate twice: the qualifier must be *this* script's class, and that
-        // script file must carry our UserData — so we never leak bindings into
-        // unrelated Groovy files or onto unrelated qualifiers.
+        // Gate: the qualifier must be *this* script's class, and the script file
+        // must carry our UserData — never leak into unrelated Groovy files.
         val scriptClass = aClass as? GroovyScriptClass ?: return
         val groovyFile = scriptClass.containingFile as? GroovyFile ?: return
         val model = completionModelFor(groovyFile) ?: return
 
-        val project = groovyFile.project
-        val elementFactory = JavaPsiFacade.getElementFactory(project)
+        val elementFactory = JavaPsiFacade.getElementFactory(groovyFile.project)
         val psiManager = groovyFile.manager
         val resolveScope = place.resolveScope
+        val classHint = processor.getHint(ElementClassHint.KEY)
 
-        for (bean in model.beans) {
-            val type = beanType(bean, groovyFile, elementFactory, psiManager, resolveScope)
-            // navigationElement = groovyFile: Ctrl-click on the binding lands on
-            // the script itself, since it has no real declaration site.
-            val bindingVariable = GrLightVariable(psiManager, bean.name, type, groovyFile)
-            // execute() returns false to stop the scan early (e.g. the resolver
-            // already found the single name it was looking for).
-            if (!processor.execute(bindingVariable, state)) return
+        // A processor resolving a variable/property reference (e.g. bare
+        // `execution`, or the `execution` qualifier of `execution.getVariable`).
+        if (ResolveUtil.shouldProcessProperties(classHint)) {
+            for (bean in model.beans) {
+                val type = beanType(bean, groovyFile, elementFactory, psiManager, resolveScope)
+                // navigationElement = groovyFile: the binding has no real
+                // declaration site, so Ctrl-click lands on the script itself.
+                val binding = GrLightVariable(psiManager, bean.name, type, groovyFile)
+                if (!processor.execute(binding, state)) return
+            }
+        }
+
+        // A processor resolving an unqualified method call (e.g. `println hello`).
+        if (ResolveUtil.shouldProcessMethods(classHint)) {
+            for (scriptMethod in SCRIPT_METHODS) {
+                val method =
+                    GrLightMethodBuilder(psiManager, scriptMethod.name).apply {
+                        addModifier("public")
+                        setContainingClass(scriptClass)
+                        setReturnType(scriptMethod.returnType, resolveScope)
+                        scriptMethod.paramNames.forEach { addParameter(it, CommonClassNames.JAVA_LANG_OBJECT) }
+                    }
+                if (!processor.execute(method, state)) return
+            }
         }
     }
 
     /**
      * The [ScriptCompletionModel] attached to [groovyFile]'s tab, or null if this
-     * isn't one of our script tabs. During resolution the PSI file's own
-     * [com.intellij.openapi.vfs.VirtualFile] is the tracked `LightVirtualFile`;
-     * the `originalFile` fallback covers the in-memory copy IntelliJ resolves
-     * against while completing.
+     * isn't one of our script tabs. The `originalFile` fallback covers the
+     * in-memory copy IntelliJ resolves against while completing.
      */
     private fun completionModelFor(groovyFile: GroovyFile): ScriptCompletionModel? {
         groovyFile.virtualFile?.getUserData(SCRIPT_COMPLETION_KEY)?.let { return it }
@@ -88,15 +103,13 @@ class ScriptBindingMembersContributor : NonCodeMembersContributor() {
     }
 
     /**
-     * The PSI type to give a binding variable.
-     *
-     * Object beans (with [BeanInfo.methods]) get a synthetic [LightPsiClassBuilder]
-     * named after the bean's type, carrying one method per catalog entry — method
-     * *existence* on the class is what clears the member-call type check; the
-     * param/return labels need not resolve to real classes. Value beans (no
-     * methods, e.g. `eventName: String`) just resolve their declared type by name;
-     * the binding variable still resolves even if the label can't be found, which
-     * is all the bare-reference warning requires.
+     * The PSI type for a binding variable. Object beans get a synthetic class
+     * carrying their catalog methods (so member calls resolve); value beans
+     * (`eventName: String`) resolve their declared type by name. Params are typed
+     * [CommonClassNames.JAVA_LANG_OBJECT] — the catalog's bare labels ("String")
+     * don't resolve in this classpath-less file, which would make every call read
+     * as "cannot be applied"; Object accepts any argument and the readable
+     * signature is shown by [ScriptCompletionContributor].
      */
     private fun beanType(
         bean: BeanInfo,
@@ -112,17 +125,34 @@ class ScriptBindingMembersContributor : NonCodeMembersContributor() {
         val beanClass = LightPsiClassBuilder(groovyFile, bean.type)
         for (method in bean.methods) {
             val methodBuilder =
-                GrLightMethodBuilder(psiManager, method.name)
-                    .apply {
-                        addModifier("public")
-                        setContainingClass(beanClass)
-                        setReturnType(method.returnType, resolveScope)
-                    }
-            for (param in method.params) {
-                methodBuilder.addParameter(param.name, param.type)
-            }
+                GrLightMethodBuilder(psiManager, method.name).apply {
+                    addModifier("public")
+                    setContainingClass(beanClass)
+                    setReturnType(method.returnType, resolveScope)
+                    method.params.forEach { addParameter(it.name, CommonClassNames.JAVA_LANG_OBJECT) }
+                }
             beanClass.addMethod(methodBuilder)
         }
         return elementFactory.createType(beanClass, PsiSubstitutor.EMPTY)
+    }
+
+    /** Name + return type + parameter names of a synthesised script method. */
+    private data class ScriptMethod(
+        val name: String,
+        val returnType: String,
+        val paramNames: List<String>,
+    )
+
+    private companion object {
+        /**
+         * The Groovy `Script`/`DefaultGroovyMethods` helpers scripts use most. The
+         * IDE bundles no Groovy SDK to resolve these against, so we synthesise them
+         * to clear the "No candidates" quick-doc on `println`/`print`.
+         */
+        val SCRIPT_METHODS = listOf(
+            ScriptMethod("println", CommonClassNames.JAVA_LANG_VOID, listOf("value")),
+            ScriptMethod("println", CommonClassNames.JAVA_LANG_VOID, emptyList()),
+            ScriptMethod("print", CommonClassNames.JAVA_LANG_VOID, listOf("value")),
+        )
     }
 }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
@@ -1,0 +1,62 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Host-side mirror of the `completion` payload the bridge ships with
+ * `script/open`, plus the plumbing that lets [ScriptCompletionContributor] find
+ * it again.
+ *
+ * The catalog is *not* authored here: `libs/modeler-core/.../scriptApi.ts` stays
+ * the single source of truth. The bridge resolves the kind-scoped beans/methods
+ * and serialises them into these Gson-friendly shapes, so the host carries no
+ * BPMN/Camunda knowledge — only the rendering of an opaque, pre-scoped catalog.
+ */
+
+/** Root of the `script/open.completion` payload: the beans in scope for this script's kind. */
+data class ScriptCompletionModel(val beans: List<BeanInfo>)
+
+/**
+ * A global bean injected into the script context (e.g. `execution`). [methods]
+ * is empty for value beans like `eventName: String`, which have no member
+ * completion — matching `methodsForBean` on the core side.
+ */
+data class BeanInfo(
+    val name: String,
+    val type: String,
+    val description: String,
+    val methods: List<MethodInfo>,
+)
+
+/** A method callable on a bean's type (e.g. `execution.setVariable`). */
+data class MethodInfo(
+    val name: String,
+    val returnType: String,
+    val description: String,
+    val params: List<ParamInfo>,
+)
+
+/** A single method parameter — name + Java-flavoured type label, for the signature. */
+data class ParamInfo(val name: String, val type: String)
+
+/**
+ * Attaches the kind-scoped catalog to the script's [VirtualFile] so the
+ * completion contributor can recover it. This UserData is also how the
+ * contributor tells *our* inline-script tabs apart from any other open
+ * `.js`/`.groovy` file — absence of the key means "not our tab, stay silent".
+ */
+val SCRIPT_COMPLETION_KEY: Key<ScriptCompletionModel> = Key.create("miranum.script.completion")
+
+private val MEMBER_ACCESS = Regex("([A-Za-z_][A-Za-z0-9_]*)\\.\\s*$")
+
+/**
+ * Returns the bean name immediately preceding a trailing `.` on [linePrefix],
+ * or null if the line doesn't end in `<identifier>.`.
+ *
+ * Port of `matchMemberAccess` in core's `scriptCompletion.ts`. Kind parsing is
+ * deliberately *not* ported: the bridge already resolved the kind and shipped
+ * only the in-scope beans.
+ */
+fun matchMemberAccess(linePrefix: String): String? =
+    MEMBER_ACCESS.find(linePrefix)?.groupValues?.get(1)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
@@ -1,0 +1,112 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.template.TemplateManager
+import com.intellij.codeInsight.template.impl.ConstantNode
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.util.TextRange
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.util.ProcessingContext
+
+/**
+ * The IntelliJ counterpart of VS Code's `registerCompletionItemProvider` for
+ * inline Camunda scripts. VS Code keys its provider by language id + the
+ * `bpmn-script://` scheme; IntelliJ has no scheme equivalent, so this PSI-based
+ * `CompletionContributor` fires for *every* file and scopes itself by checking
+ * for the [SCRIPT_COMPLETION_KEY] UserData that [ScriptEditorManager] attaches to
+ * our `LightVirtualFile` tabs — absence of the key means "not our script, stay
+ * silent".
+ *
+ * The catalog itself is authored once in core and shipped with `script/open`;
+ * this class only renders it, mirroring the two VS Code modes: root-level bean
+ * names, and a bean's methods after a `.`.
+ */
+class ScriptCompletionContributor : CompletionContributor() {
+    init {
+        // `language="any"` in plugin.xml + this catch-all pattern means we fire
+        // regardless of the script's inferred FileType (it may even be
+        // PLAIN_TEXT when no JS/Python plugin is installed); the UserData check
+        // below is what actually scopes us to Miranum script tabs.
+        extend(CompletionType.BASIC, PlatformPatterns.psiElement(), ScriptCompletionProvider())
+    }
+
+    private class ScriptCompletionProvider : CompletionProvider<CompletionParameters>() {
+        override fun addCompletions(
+            parameters: CompletionParameters,
+            context: ProcessingContext,
+            result: CompletionResultSet,
+        ) {
+            val model =
+                parameters.originalFile.virtualFile?.getUserData(SCRIPT_COMPLETION_KEY) ?: return
+
+            val document = parameters.editor.document
+            val offset = parameters.offset
+            val lineStart = document.getLineStartOffset(document.getLineNumber(offset))
+            val linePrefix = document.getText(TextRange(lineStart, offset))
+
+            val bean = matchMemberAccess(linePrefix)
+            if (bean != null) {
+                // Member mode: only the matched bean's methods. An unknown bean
+                // (e.g. a user's own variable) yields nothing, never the root beans.
+                model.beans.firstOrNull { it.name == bean }
+                    ?.methods
+                    ?.forEach { result.addElement(methodLookup(it)) }
+                return
+            }
+
+            // Root mode: the in-scope bean names.
+            model.beans.forEach { result.addElement(beanLookup(it)) }
+        }
+
+        /** Bean as a variable-icon lookup: `name`, type on the right, description greyed. */
+        private fun beanLookup(bean: BeanInfo) =
+            LookupElementBuilder.create(bean.name)
+                .withIcon(AllIcons.Nodes.Variable)
+                .withTypeText(bean.type)
+                .appendTailText("  ${bean.description}", true)
+
+        /**
+         * Method as a method-icon lookup: `name`, `(params)` tail, return type on
+         * the right, description greyed. Accepting it inserts `name(…)` and starts
+         * a live [com.intellij.codeInsight.template.Template] so the parameters are
+         * tab-through editable — the IntelliJ analogue of VS Code's `SnippetString`
+         * `${1:param}` placeholders.
+         */
+        private fun methodLookup(method: MethodInfo) =
+            LookupElementBuilder.create(method.name)
+                .withIcon(AllIcons.Nodes.Method)
+                .withTailText(signatureOf(method), true)
+                .withTypeText(method.returnType)
+                .appendTailText("  ${method.description}", true)
+                .withInsertHandler { ctx, _ ->
+                    val templateManager = TemplateManager.getInstance(ctx.project)
+                    val template = templateManager.createTemplate("", "")
+                    // The script editor has no language reformat rules to honour
+                    // (it may be PLAIN_TEXT); keep our exact `(a, b)` spacing.
+                    template.setToReformat(false)
+                    template.addTextSegment("(")
+                    method.params.forEachIndexed { index, param ->
+                        if (index > 0) template.addTextSegment(", ")
+                        // ConstantNode seeds each stop with the param name as the
+                        // selected placeholder text, so Tab cycles through them.
+                        template.addVariable(
+                            param.name,
+                            ConstantNode(param.name),
+                            ConstantNode(param.name),
+                            true,
+                        )
+                    }
+                    template.addTextSegment(")")
+                    template.addEndVariable()
+                    templateManager.startTemplate(ctx.editor, template)
+                }
+
+        private fun signatureOf(method: MethodInfo) =
+            method.params.joinToString(", ", "(", ")") { "${it.name}: ${it.type}" }
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptEditorManager.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptEditorManager.kt
@@ -68,8 +68,18 @@ class ScriptEditorManager(
      * Opens a script tab, or reveals the existing one. A re-open never rewrites
      * content: the same [scriptId] maps to the live tab, so in-flight edits the
      * user hasn't synced yet are preserved.
+     *
+     * @param completion Kind-scoped bean/method catalog, attached to the file as
+     *   UserData so [ScriptCompletionContributor] can drive autocomplete and tell
+     *   our script tabs apart from other open files. A re-open keeps the catalog
+     *   already on the tracked file (UserData persists across the reveal).
      */
-    fun openScript(scriptId: String, fileName: String, content: String) {
+    fun openScript(
+        scriptId: String,
+        fileName: String,
+        content: String,
+        completion: ScriptCompletionModel?,
+    ) {
         ApplicationManager.getApplication().invokeLater {
             if (project.isDisposed) return@invokeLater
             val manager = FileEditorManager.getInstance(project)
@@ -82,6 +92,8 @@ class ScriptEditorManager(
             // The filename's extension is what drives FileType inference (hence
             // highlighting); the content is fixed here, before the listener below.
             val file = LightVirtualFile(fileName, content)
+            // Attach before opening so the contributor sees it on the first keystroke.
+            file.putUserData(SCRIPT_COMPLETION_KEY, completion)
             manager.openFile(file, true)
 
             val document = FileDocumentManager.getInstance().getDocument(file)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptHighlightFilter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptHighlightFilter.kt
@@ -1,0 +1,39 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
+import com.intellij.codeInsight.daemon.impl.HighlightInfoFilter
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.psi.PsiFile
+
+/**
+ * Drops the Groovy *annotator's* "Cannot resolve symbol" highlights in our inline
+ * "Edit Script" tabs.
+ *
+ * The script lives in a classpath-less [com.intellij.testFramework.LightVirtualFile],
+ * so any symbol the synthetic resolver doesn't cover (`new Date()`, `"x".trim()`, …)
+ * reads as unresolved and gets greyed out. That greying comes from the highlight
+ * *visitor* at exactly [HighlightSeverity.INFORMATION] (no inspection id), which
+ * routes through [HighlightInfoFilter] — unlike the [ScriptInspectionSuppressor]-handled
+ * inspections, which bypass filtering.
+ *
+ * We drop *only* INFORMATION-severity highlights on our own tabs (gated by
+ * [SCRIPT_COMPLETION_KEY]). The narrower band matters: Groovy emits its *semantic*
+ * highlighting (resolved methods/fields/locals colored distinctly) at
+ * `SYMBOL_TYPE_SEVERITY`, whose numeric value (2) sits *below* INFORMATION (10), so
+ * those colors now survive — an earlier blanket "drop everything below ERROR" threw
+ * them away. Genuine parse/syntax errors are ERROR and still surface; inspection
+ * warnings are handled by [ScriptInspectionSuppressor].
+ */
+class ScriptHighlightFilter : HighlightInfoFilter {
+    /** Return false to drop a highlight. */
+    override fun accept(highlightInfo: HighlightInfo, file: PsiFile?): Boolean {
+        if (file == null) return true
+        // originalFile fallback: the daemon often highlights an in-memory copy
+        // of the file whose UserData lives on the original's VirtualFile.
+        val virtualFile = file.virtualFile ?: file.originalFile?.virtualFile ?: return true
+        if (virtualFile.getUserData(SCRIPT_COMPLETION_KEY) == null) return true
+        // Drop the unresolved-symbol greying (INFORMATION) but keep semantic
+        // colors (SYMBOL_TYPE_SEVERITY = 2, below INFORMATION) and real errors.
+        return highlightInfo.severity != HighlightSeverity.INFORMATION
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptInspectionSuppressor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptInspectionSuppressor.kt
@@ -1,0 +1,40 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.codeInspection.InspectionSuppressor
+import com.intellij.codeInspection.SuppressQuickFix
+import com.intellij.psi.PsiElement
+
+/**
+ * Suppresses Groovy's resolution/type-check *inspections* in our inline "Edit
+ * Script" tabs.
+ *
+ * The bindings injected at runtime (`execution`, `task`, …) have no PSI
+ * declaration, so `GroovyAssignabilityCheck` reports "No candidates found for
+ * method call" / "cannot be applied", and `GrUnresolvedAccess` the unresolved
+ * references. These come from the inspection pass, which — unlike the annotator
+ * highlights [ScriptHighlightFilter] drops — does *not* consult HighlightInfoFilter,
+ * so suppressing at the inspection level is the only way to silence them. The IDE
+ * cannot know a Camunda script's runtime classpath, so the analysis is pure noise
+ * here (the VS Code host doesn't type-check these scripts at all). Scoped to our
+ * own tabs via [SCRIPT_COMPLETION_KEY].
+ */
+class ScriptInspectionSuppressor : InspectionSuppressor {
+    override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
+        if (toolId !in SUPPRESSED_INSPECTIONS) return false
+        val file = element.containingFile ?: return false
+        val virtualFile = file.virtualFile ?: file.originalFile?.virtualFile ?: return false
+        return virtualFile.getUserData(SCRIPT_COMPLETION_KEY) != null
+    }
+
+    override fun getSuppressActions(element: PsiElement?, toolId: String): Array<SuppressQuickFix> =
+        SuppressQuickFix.EMPTY_ARRAY
+
+    private companion object {
+        /**
+         * `GroovyAssignabilityCheck` emits "cannot be applied" / "no candidates
+         * found for method call"; `GrUnresolvedAccess` the unresolved-reference
+         * warnings. Both target runtime symbols the static analysis can't see.
+         */
+        val SUPPRESSED_INSPECTIONS = setOf("GroovyAssignabilityCheck", "GrUnresolvedAccess")
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptSemanticHighlighter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptSemanticHighlighter.kt
@@ -1,0 +1,87 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiVariable
+import org.jetbrains.plugins.groovy.highlighter.GroovySyntaxHighlighter
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression
+import org.jetbrains.plugins.groovy.lang.psi.impl.synthetic.GrLightVariable
+
+/**
+ * Restores *semantic* colouring (resolved fields/methods/locals tinted per the
+ * editor scheme) in our inline "Edit Script" tabs.
+ *
+ * Groovy's own semantic-highlight pass ([org.jetbrains.plugins.groovy.annotator.GrReferenceHighlighter])
+ * never runs here: its `shouldHighlight` gate requires the file to be a project
+ * source file, a scratch file, or a recognised script type, and our tab is a bare
+ * in-memory [com.intellij.testFramework.LightVirtualFile] — none of those. So the
+ * bindings and method calls render in the default foreground, with only lexer
+ * colours (keywords/strings/numbers) showing. This annotator fills that gap by
+ * resolving each reference and applying the matching [GroovySyntaxHighlighter]
+ * colour key itself.
+ *
+ * Only symbols that actually resolve are tinted — the Camunda bindings and
+ * synthesised script methods supplied by [ScriptBindingMembersContributor]. The
+ * Camunda bindings (`execution`, `task`, …) are coloured as fields so they visibly
+ * stand out as the script's injected context. Symbols with no classpath here
+ * (`new Date()`, arbitrary stdlib) resolve to nothing and are simply left at their
+ * lexer colour — never greyed, since [ScriptHighlightFilter] drops that.
+ *
+ * Uses [HighlightSeverity.TEXT_ATTRIBUTES] (the canonical "apply these colours,
+ * report nothing" severity), which sits above INFORMATION and so survives
+ * [ScriptHighlightFilter]'s drop of the unresolved-symbol greying. Scoped to our
+ * own tabs via [SCRIPT_COMPLETION_KEY].
+ */
+class ScriptSemanticHighlighter : Annotator {
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (element !is GrReferenceExpression) return
+
+        val file = element.containingFile ?: return
+        val virtualFile = file.virtualFile ?: file.originalFile?.virtualFile ?: return
+        if (virtualFile.getUserData(SCRIPT_COMPLETION_KEY) == null) return
+
+        // Colour the identifier token only, not the whole qualified expression —
+        // the qualifier is its own GrReferenceExpression and is visited separately.
+        val nameElement = element.referenceNameElement ?: return
+        val colorKey = colorKeyFor(element.resolve() ?: return) ?: return
+
+        holder.newSilentAnnotation(HighlightSeverity.TEXT_ATTRIBUTES)
+            .range(nameElement)
+            .textAttributes(colorKey)
+            .create()
+    }
+
+    /**
+     * The scheme colour key for a resolved target, or null to leave it untinted.
+     * [GrLightVariable] is checked before [PsiVariable]: our bindings are light
+     * variables, but we colour them as fields so they read as injected context
+     * rather than ordinary locals.
+     */
+    private fun colorKeyFor(resolved: PsiElement): TextAttributesKey? = when (resolved) {
+        is PsiMethod ->
+            if (resolved.hasModifierProperty(PsiModifier.STATIC)) {
+                GroovySyntaxHighlighter.STATIC_METHOD_ACCESS
+            } else {
+                GroovySyntaxHighlighter.METHOD_CALL
+            }
+
+        is GrLightVariable -> GroovySyntaxHighlighter.INSTANCE_FIELD
+
+        is PsiField ->
+            if (resolved.hasModifierProperty(PsiModifier.STATIC)) {
+                GroovySyntaxHighlighter.STATIC_FIELD
+            } else {
+                GroovySyntaxHighlighter.INSTANCE_FIELD
+            }
+
+        is PsiVariable -> GroovySyntaxHighlighter.LOCAL_VARIABLE
+
+        else -> null
+    }
+}

--- a/apps/intellij-plugin/src/main/resources/META-INF/miranum-groovy.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/miranum-groovy.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="org.intellij.groovy">
+        <!-- Resolves runtime-injected Camunda bindings in our Groovy script tabs. -->
+        <membersContributor
+            implementation="io.miragon.intellij.bpmn.ScriptBindingMembersContributor"/>
+    </extensions>
+</idea-plugin>

--- a/apps/intellij-plugin/src/main/resources/META-INF/miranum-groovy.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/miranum-groovy.xml
@@ -1,7 +1,24 @@
 <idea-plugin>
     <extensions defaultExtensionNs="org.intellij.groovy">
-        <!-- Resolves runtime-injected Camunda bindings in our Groovy script tabs. -->
+        <!-- Resolves the runtime-injected Camunda bindings and common script
+             methods in our inline script tabs (clears the "No candidates"
+             quick-doc on hover). See ScriptBindingMembersContributor. -->
         <membersContributor
             implementation="io.miragon.intellij.bpmn.ScriptBindingMembersContributor"/>
+    </extensions>
+    <extensions defaultExtensionNs="com.intellij">
+        <!-- Belt-and-braces: suppresses Groovy's assignability/unresolved
+             inspections on our tabs for anything left unresolved (they bypass
+             HighlightInfoFilter). See ScriptInspectionSuppressor. -->
+        <lang.inspectionSuppressor
+            language="Groovy"
+            implementationClass="io.miragon.intellij.bpmn.ScriptInspectionSuppressor"/>
+
+        <!-- Semantic colouring for our script tabs: Groovy's native reference
+             highlighter is gated off for in-memory files, so we tint resolved
+             bindings/methods ourselves. See ScriptSemanticHighlighter. -->
+        <annotator
+            language="Groovy"
+            implementationClass="io.miragon.intellij.bpmn.ScriptSemanticHighlighter"/>
     </extensions>
 </idea-plugin>

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,14 @@
             displayName="Miranum BPMN Modeler"
             instance="io.miragon.intellij.bpmn.MiranumSettingsConfigurable"/>
 
+        <!-- Camunda IntelliSense for the inline "Edit Script" editor. `language="any"`
+             fires the contributor for every file type (the script tab may be
+             PLAIN_TEXT when no JS/Python plugin is installed); it scopes itself to
+             Miranum script tabs via the SCRIPT_COMPLETION_KEY UserData. -->
+        <completion.contributor
+            language="any"
+            implementationClass="io.miragon.intellij.bpmn.ScriptCompletionContributor"/>
+
         <!-- Camunda 7/8 deployment panel: a JCEF tool window hosting the deployment
              webview, driven by the shared core over the bridge (the IntelliJ
              counterpart of the VS Code deployment sidebar). -->

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,15 @@
 
     <depends>com.intellij.modules.platform</depends>
 
+    <!--
+        Optional: when the bundled Groovy plugin is present, load the Groovy-only
+        binding resolver (miranum-groovy.xml) that makes injected script bindings
+        (execution/task/eventName) genuinely resolve in a Groovy "Edit Script" tab,
+        clearing Groovy's type-check warnings. Absent Groovy, the config file is
+        skipped and the existing language="any" completion is unaffected.
+    -->
+    <depends optional="true" config-file="miranum-groovy.xml">org.intellij.groovy</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <fileEditorProvider implementation="io.miragon.intellij.bpmn.BpmnFileEditorProvider"/>
 

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -13,11 +13,11 @@
     <depends>com.intellij.modules.platform</depends>
 
     <!--
-        Optional: when the bundled Groovy plugin is present, load the Groovy-only
-        binding resolver (miranum-groovy.xml) that makes injected script bindings
-        (execution/task/eventName) genuinely resolve in a Groovy "Edit Script" tab,
-        clearing Groovy's type-check warnings. Absent Groovy, the config file is
-        skipped and the existing language="any" completion is unaffected.
+        Optional: when the Groovy plugin is present, load the Groovy-only script-tab
+        support (miranum-groovy.xml) — the binding resolver, the semantic-colour
+        annotator, and the inspection suppressor for our inline "Edit Script" tabs.
+        Absent Groovy, the config file is skipped and the rest of the plugin is
+        unaffected.
     -->
     <depends optional="true" config-file="miranum-groovy.xml">org.intellij.groovy</depends>
 
@@ -72,6 +72,13 @@
         <completion.contributor
             language="any"
             implementationClass="io.miragon.intellij.bpmn.ScriptCompletionContributor"/>
+
+        <!-- Drops the Groovy annotator's "Cannot resolve symbol" greying on our
+             inline script tabs for anything still unresolved. The bindings/script
+             methods are resolved by the Groovy membersContributor in
+             miranum-groovy.xml; this is the highlight safety net. -->
+        <daemon.highlightInfoFilter
+            implementation="io.miragon.intellij.bpmn.ScriptHighlightFilter"/>
 
         <!-- Camunda 7/8 deployment panel: a JCEF tool window hosting the deployment
              webview, driven by the shared core over the bridge (the IntelliJ

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -17,7 +17,9 @@
  */
 
 import {
+    beansFor,
     EditorSessionStore,
+    methodsForBean,
     NotifierPort,
     PickerPort,
     ScriptLanguage,
@@ -96,11 +98,26 @@ export class BridgeScriptEditor {
 
         // `fileName` carries the extension so the host infers the FileType for
         // highlighting; `content` is honoured only on first open (see above).
+        // `completion` ships the kind-scoped bean/method catalog resolved *here*
+        // so the thin Kotlin host never needs to know which beans belong to which
+        // kind — it just renders what it is handed (VS Code's
+        // `registerCompletionItemProvider` has no PSI-based analogue, so the host
+        // drives a `CompletionContributor` off this payload instead).
         this.rpc.notify("script/open", {
             scriptId,
             fileName: uri.filename,
             languageId: lang.languageId,
             content: cmd.content,
+            completion: {
+                beans: beansFor(cmd.kind).map((bean) => ({
+                    name: bean.name,
+                    type: bean.type,
+                    description: bean.description,
+                    // Empty for value beans (e.g. `eventName: String`) — correct,
+                    // they have no member completion.
+                    methods: methodsForBean(bean),
+                })),
+            },
         });
     }
 


### PR DESCRIPTION
**Issue**

Closes #1073 (epic #920, IntelliJ host parity).

**Description**

Adds Camunda IntelliSense to the inline "Edit Script" editor on the IntelliJ host. Since VS Code's `registerCompletionItemProvider` has no PSI-based analogue, the bridge resolves the kind-scoped bean/method catalog from core and ships it with `script/open`, and a new Kotlin `CompletionContributor` renders it — offering root-level beans and a bean's methods after a `.`, with method accepts inserting a tab-through parameter template (signature, return type, and description shown inline). The catalog stays single-sourced in `scriptApi.ts`; the host attaches it to the script's `LightVirtualFile` as UserData, which also scopes the contributor to our tabs only. Verified by offline `:compileKotlin` against the real SDK, a bridge build, and the unchanged VS Code `ScriptCompletionProvider` tests (13/13 green).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created