### PR TITLE
feat(intellij): distribute plugin via GitHub Releases + Pages

### DIFF
--- a/.github/scripts/generate-update-plugins-xml.mjs
+++ b/.github/scripts/generate-update-plugins-xml.mjs
@@ -18,8 +18,11 @@
 
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const REPO_ROOT = resolve(new URL("../..", import.meta.url).pathname);
+// fileURLToPath decodes percent-encoding and handles Windows drive paths;
+// `new URL(...).pathname` mangles spaces and prepends a slash on Windows.
+const REPO_ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
 const PLUGIN_XML = resolve(
     REPO_ROOT,
     "apps/intellij-plugin/src/main/resources/META-INF/plugin.xml",

--- a/.github/scripts/generate-update-plugins-xml.mjs
+++ b/.github/scripts/generate-update-plugins-xml.mjs
@@ -1,0 +1,145 @@
+/**
+ * Generates docs/public/updatePlugins.xml — the JetBrains "custom plugin
+ * repository" descriptor IntelliJ polls to discover and update the Miragon
+ * BPMN Modeler plugin when distributed outside the Marketplace.
+ *
+ * Pulls metadata (name, vendor, description, since-build) from the live
+ * sources of truth (plugin.xml + build.gradle.kts) so the descriptor cannot
+ * drift from what the IDE actually installs. Version + download URL must be
+ * passed in — they are decided by the release pipeline.
+ *
+ * Designed to run in GitHub Actions with Node 20+; no dependencies.
+ *
+ * Usage:
+ *   node .github/scripts/generate-update-plugins-xml.mjs \
+ *     --version 0.1.1 \
+ *     --download-url https://github.com/Miragon/bpmn-modeler/releases/download/intellij-v0.1.1/bpmn-modeler-intellij-plugin-0.1.1.zip
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const REPO_ROOT = resolve(new URL("../..", import.meta.url).pathname);
+const PLUGIN_XML = resolve(
+    REPO_ROOT,
+    "apps/intellij-plugin/src/main/resources/META-INF/plugin.xml",
+);
+const BUILD_GRADLE = resolve(REPO_ROOT, "apps/intellij-plugin/build.gradle.kts");
+const OUTPUT = resolve(REPO_ROOT, "docs/public/updatePlugins.xml");
+
+/**
+ * Parses CLI args of the form `--key value` into a plain object. Throws if a
+ * required arg is missing — the script is invoked from CI and silent
+ * defaulting would publish a malformed descriptor.
+ *
+ * @returns {{version: string, downloadUrl: string}}
+ */
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const out = {};
+    for (let i = 0; i < args.length; i++) {
+        const key = args[i];
+        if (!key.startsWith("--")) continue;
+        const value = args[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+            throw new Error(`Missing value for argument ${key}`);
+        }
+        out[key.slice(2)] = value;
+        i++;
+    }
+    if (!out.version) throw new Error("Missing --version");
+    if (!out["download-url"]) throw new Error("Missing --download-url");
+    return { version: out.version, downloadUrl: out["download-url"] };
+}
+
+/**
+ * Reads a tag's text content from plugin.xml. The descriptor file is small
+ * and well-formed by us, so a focused regex beats pulling in an XML parser.
+ *
+ * @param {string} xml plugin.xml content.
+ * @param {string} tag Tag name (without angle brackets).
+ * @returns {string} The trimmed text content.
+ */
+function readTagText(xml, tag) {
+    const match = xml.match(new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`));
+    if (!match) throw new Error(`Tag <${tag}> not found in plugin.xml`);
+    return match[1].trim();
+}
+
+/**
+ * Extracts the contents of a CDATA section (or returns the raw text if no
+ * CDATA wrapper is present). Used for <description>, which is authored as
+ * CDATA in plugin.xml.
+ *
+ * @param {string} text Raw inner text of a tag.
+ * @returns {string} CDATA payload, trimmed.
+ */
+function unwrapCdata(text) {
+    const match = text.match(/<!\[CDATA\[([\s\S]*?)\]\]>/);
+    return (match ? match[1] : text).trim();
+}
+
+/**
+ * Reads the `sinceBuild = "NNN"` from build.gradle.kts. That literal is the
+ * source of truth Gradle injects into plugin.xml via patchPluginXml, so we
+ * read it here rather than re-parsing the patched jar.
+ *
+ * @param {string} gradle build.gradle.kts content.
+ * @returns {string} The sinceBuild number (e.g. "242").
+ */
+function readSinceBuild(gradle) {
+    const match = gradle.match(/sinceBuild\s*=\s*"(\d+)"/);
+    if (!match) throw new Error('sinceBuild = "..." not found in build.gradle.kts');
+    return match[1];
+}
+
+/**
+ * XML-escapes the five reserved characters. The version + URL come from CI
+ * inputs, so even if they only ever contain safe chars today, escaping
+ * prevents a future change to the tag scheme from emitting broken XML.
+ *
+ * @param {string} value Raw value.
+ * @returns {string} XML-attribute-safe value.
+ */
+function xmlEscape(value) {
+    return value
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&apos;");
+}
+
+function main() {
+    const { version, downloadUrl } = parseArgs();
+
+    const pluginXml = readFileSync(PLUGIN_XML, "utf-8");
+    const gradle = readFileSync(BUILD_GRADLE, "utf-8");
+
+    const pluginId = readTagText(pluginXml, "id");
+    const name = readTagText(pluginXml, "name");
+    const vendor = readTagText(pluginXml, "vendor");
+    const description = unwrapCdata(readTagText(pluginXml, "description"));
+    const sinceBuild = readSinceBuild(gradle);
+
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<plugins>
+  <plugin id="${xmlEscape(pluginId)}"
+          url="${xmlEscape(downloadUrl)}"
+          version="${xmlEscape(version)}">
+    <idea-version since-build="${xmlEscape(sinceBuild)}"/>
+    <name>${xmlEscape(name)}</name>
+    <vendor>${xmlEscape(vendor)}</vendor>
+    <description><![CDATA[
+${description}
+    ]]></description>
+  </plugin>
+</plugins>
+`;
+
+    mkdirSync(dirname(OUTPUT), { recursive: true });
+    writeFileSync(OUTPUT, xml, "utf-8");
+    console.log(`Wrote ${OUTPUT} (version ${version}, since-build ${sinceBuild}).`);
+}
+
+main();

--- a/.github/workflows/prepare-release-intellij.yml
+++ b/.github/workflows/prepare-release-intellij.yml
@@ -97,6 +97,11 @@ jobs:
         if: success() && inputs.dry-run == false && github.ref == 'refs/heads/main'
         uses: softprops/action-gh-release@v3
         with:
+          # Default GITHUB_TOKEN-created releases do NOT emit a
+          # `release: published` event, so the publish-intellij.yml chain would
+          # never fire. The PAT makes the release look user-authored, restoring
+          # the trigger.
+          token: ${{ secrets.RELEASE_PAT }}
           tag_name: intellij-v${{ steps.version.outputs.version }}
           name: IntelliJ Plugin v${{ steps.version.outputs.version }}
           generate_release_notes: true

--- a/.github/workflows/prepare-release-intellij.yml
+++ b/.github/workflows/prepare-release-intellij.yml
@@ -1,0 +1,102 @@
+name: Prepare Release IntelliJ Plugin
+
+# Bumps the IntelliJ plugin version in apps/intellij-plugin/build.gradle.kts,
+# commits and tags the bump, then creates a GitHub Release.
+# Publishing (building + uploading the ZIP + refreshing updatePlugins.xml) is
+# handled by publish-intellij.yml on release: published.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      dry-run:
+        description: 'Dry run (no commit, tag, or release)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bpmn-modeler-intellij-prepare-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
+
+      # The IntelliJ plugin version lives only in build.gradle.kts (line 9);
+      # patchPluginXml injects it into plugin.xml at build time. Bumping the
+      # Gradle literal is therefore the single point of change.
+      - name: Bump version
+        id: version
+        run: |
+          GRADLE_FILE="apps/intellij-plugin/build.gradle.kts"
+          CURRENT=$(grep -E '^version = "' "$GRADLE_FILE" | sed -E 's/version = "(.*)"/\1/')
+          if [ -z "$CURRENT" ]; then
+            echo "Failed to extract current version from $GRADLE_FILE" && exit 1
+          fi
+          echo "Current version: $CURRENT"
+          NEW_VERSION=$(node -e "
+            const [major, minor, patch] = process.argv[1].split('.').map(Number);
+            const type = process.argv[2];
+            if (type === 'major') console.log(\`\${major + 1}.0.0\`);
+            else if (type === 'minor') console.log(\`\${major}.\${minor + 1}.0\`);
+            else console.log(\`\${major}.\${minor}.\${patch + 1}\`);
+          " "$CURRENT" "${{ inputs.release-type }}")
+          echo "New version: $NEW_VERSION"
+          # In-place edit; the anchored regex prevents matching any other
+          # `version = "..."` literal that might appear in the file.
+          sed -i -E "s/^version = \"$CURRENT\"$/version = \"$NEW_VERSION\"/" "$GRADLE_FILE"
+          grep -q "^version = \"$NEW_VERSION\"$" "$GRADLE_FILE" || {
+            echo "Failed to write new version to $GRADLE_FILE" && exit 1
+          }
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag does not exist
+        run: |
+          TAG="intellij-v${{ steps.version.outputs.version }}"
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; aborting." && exit 1
+          fi
+
+      - name: Commit and tag
+        if: success() && inputs.dry-run == false && github.ref == 'refs/heads/main'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          git add apps/intellij-plugin/build.gradle.kts
+          git commit -m "chore(release): bump intellij plugin to ${NEW_VERSION}"
+          git push origin HEAD
+          git tag -a "intellij-v${NEW_VERSION}" -m "release intellij-v${NEW_VERSION}"
+          git push origin "intellij-v${NEW_VERSION}"
+
+      - name: Create GitHub Release
+        if: success() && inputs.dry-run == false && github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: intellij-v${{ steps.version.outputs.version }}
+          name: IntelliJ Plugin v${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -174,7 +174,11 @@ jobs:
           git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
           cp -f docs/public/updatePlugins.xml /tmp/updatePlugins.xml
           git fetch origin main
-          git checkout main
+          # The regenerated XML differs from the tag's tracked copy, so a plain
+          # `git checkout main` aborts with "local changes would be
+          # overwritten" on any re-publish of an older tag. The file is already
+          # stashed to /tmp, so discarding the worktree change with -f is safe.
+          git checkout -f main
           git pull --ff-only origin main
           mkdir -p docs/public
           cp -f /tmp/updatePlugins.xml docs/public/updatePlugins.xml

--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -1,0 +1,187 @@
+name: Publish IntelliJ Plugin
+
+# Triggered by prepare-release-intellij.yml when it publishes an
+# `intellij-v*` GitHub Release. Cross-compiles the modeler-bridge for all
+# 5 supported platforms, builds the plugin ZIP with every binary staged,
+# uploads it to the release, then regenerates docs/public/updatePlugins.xml
+# so the JetBrains custom-repository descriptor served via GitHub Pages
+# advertises the new version. Pushing the regenerated XML to main triggers
+# deploy-docs.yml automatically.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. intellij-v0.1.1) — workflow_dispatch only'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: bpmn-modeler-intellij-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    # `release: published` fires for every release in this repo; gate on the
+    # intellij-v* prefix so the VS Code / standalone releases don't trigger
+    # an IntelliJ build.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'intellij-v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          else
+            TAG="${{ inputs.tag }}"
+          fi
+          if [[ "$TAG" != intellij-v* ]]; then
+            echo "Tag '$TAG' is not an intellij-v* tag; aborting." && exit 1
+          fi
+          VERSION="${TAG#intellij-v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+          token: ${{ secrets.RELEASE_PAT }}
+
+      - name: Check pinned dependencies
+        uses: Miragon/pin-npm-dependencies@v1
+
+      - name: Corepack enable
+        run: corepack enable
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: yarn
+
+      # JDK 21 matches kotlin.jvmToolchain(21) in build.gradle.kts — otherwise
+      # Gradle downloads its own toolchain on every run.
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # Bun is needed for cross-compiling the bridge to all 5 targets. The
+      # `latest` channel tracks releases ≥ 1.1.5 which supports `--target`.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies (focused)
+        run: yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-webview @miragon/bpmn-modeler-deployment-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-core @miragon/bpmn-modeler-bridge @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-clipboard @miragon/bpmn-modeler-i18n @miragon/bpmn-modeler-element-template-chooser
+
+      # The Gradle build only stages already-built artefacts; the JS/Bun side
+      # produces them. Build order: shared libs → webview bundles → bridge.
+      - name: Build shared libraries
+        run: yarn build:libs
+
+      - name: Build bpmn-webview
+        run: yarn build:bpmn-webview
+
+      - name: Build deployment-webview
+        run: yarn build:deployment-webview
+
+      - name: Cross-compile bridge for all platforms
+        run: yarn workspace @miragon/bpmn-modeler-bridge compile:all
+
+      - name: Build plugin ZIP (all platforms)
+        working-directory: apps/intellij-plugin
+        run: ./gradlew buildPlugin -PbundleAllPlatforms --no-daemon
+
+      - name: Locate plugin ZIP
+        id: zip
+        run: |
+          ZIP=$(ls apps/intellij-plugin/build/distributions/*.zip | head -n 1)
+          if [ -z "$ZIP" ]; then
+            echo "No plugin ZIP produced by buildPlugin." && exit 1
+          fi
+          echo "path=${ZIP}" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$ZIP")" >> "$GITHUB_OUTPUT"
+
+      # #1093 acceptance criterion: log per-platform binary size and total
+      # ZIP size so we can spot if Bun's runtime bloats the artefact.
+      - name: Record artefact sizes
+        run: |
+          {
+            echo "## IntelliJ plugin ZIP"
+            echo
+            echo "- Tag: \`${{ steps.tag.outputs.tag }}\`"
+            echo "- Version: \`${{ steps.tag.outputs.version }}\`"
+            ZIP="${{ steps.zip.outputs.path }}"
+            ZIP_SIZE=$(du -h "$ZIP" | awk '{print $1}')
+            echo "- ZIP: \`$(basename "$ZIP")\` ($ZIP_SIZE)"
+            echo
+            echo "### Per-platform bridge binary sizes"
+            echo
+            echo "| Platform | Binary | Size |"
+            echo "|----------|--------|------|"
+            for d in apps/modeler-bridge/dist/*/; do
+              platform=$(basename "$d")
+              for f in "$d"modeler-bridge*; do
+                if [ -f "$f" ]; then
+                  size=$(du -h "$f" | awk '{print $1}')
+                  echo "| $platform | $(basename "$f") | $size |"
+                fi
+              done
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload ZIP to release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" "${{ steps.zip.outputs.path }}" --clobber
+
+      # Regenerate the custom-repository descriptor. The download URL is
+      # composed from the tag and the ZIP filename so the IDE polls the
+      # exact asset we just uploaded.
+      - name: Regenerate updatePlugins.xml
+        run: |
+          DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/${{ steps.zip.outputs.name }}"
+          node .github/scripts/generate-update-plugins-xml.mjs \
+            --version "${{ steps.tag.outputs.version }}" \
+            --download-url "$DOWNLOAD_URL"
+
+      # Push the regenerated XML to main so deploy-docs.yml picks it up and
+      # republishes Pages. The IDE polls the Pages URL — no XML refresh, no
+      # update notification. We stash the generated file across the branch
+      # switch because the working tree is currently on the release tag.
+      - name: Commit updatePlugins.xml to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
+          cp -f docs/public/updatePlugins.xml /tmp/updatePlugins.xml
+          git fetch origin main
+          git checkout main
+          git pull --ff-only origin main
+          mkdir -p docs/public
+          cp -f /tmp/updatePlugins.xml docs/public/updatePlugins.xml
+          git add docs/public/updatePlugins.xml
+          if git diff --cached --quiet; then
+            echo "updatePlugins.xml is unchanged on main; nothing to commit."
+          else
+            git commit -m "chore(release): refresh updatePlugins.xml for intellij-v${{ steps.tag.outputs.version }}"
+            git push origin main
+          fi

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -54,14 +54,39 @@ val webviewDist = layout.projectDirectory.dir("../../dist/webview-staging/bpmn-w
 val deploymentWebviewDist =
     layout.projectDirectory.dir("../../dist/webview-staging/deployment-webview")
 val bridgeBinary = layout.projectDirectory.file("../../apps/modeler-bridge/dist/modeler-bridge")
+val bridgeDistRoot = layout.projectDirectory.dir("../../apps/modeler-bridge/dist")
 val stagedResourcesRoot = layout.buildDirectory.dir("modeler-resources")
+
+/**
+ * Release distribution mode: when set, stage every per-platform bridge binary
+ * under `bin/<os>-<arch>/` so the published ZIP runs on any host. Default
+ * (host-only) keeps `runIde` and local dev cycles fast — they only need the
+ * one binary that matches the developer's machine.
+ */
+val bundleAllPlatforms = providers.gradleProperty("bundleAllPlatforms").isPresent
+
+/**
+ * The 5 platforms shipped in a release ZIP. Tuples are
+ * (`<os>-<arch>` resource dir, source binary filename produced by Bun).
+ * Bun appends `.exe` to the windows-x64 target; the runtime resolver
+ * (CoreProcess.resolveBridgeBinary) mirrors this — see step 3 of the
+ * distribution plan.
+ */
+val releaseBridgeTargets =
+    listOf(
+        "darwin-arm64" to "modeler-bridge",
+        "darwin-x64" to "modeler-bridge",
+        "linux-x64" to "modeler-bridge",
+        "linux-arm64" to "modeler-bridge",
+        "windows-x64" to "modeler-bridge.exe",
+    )
 
 /**
  * The `<os>-<arch>` directory the bridge binary is staged under and the runtime
  * (CoreProcess) resolves at launch. The Bun `--compile --target` flag decides
- * the binary's real platform; this PR stages only the host target, so the build
- * machine must match the publish target. A release pipeline loops `--target` and
- * stages each platform under its own directory.
+ * the binary's real platform; default (host-only) build stages the host target,
+ * so the build machine must match the publish target. The release pipeline sets
+ * `-PbundleAllPlatforms` to stage every platform under its own directory.
  */
 fun hostPlatformDir(): String {
     val os = System.getProperty("os.name").lowercase()
@@ -110,18 +135,43 @@ val copyDeploymentWebview =
 
 val copyBridge =
     tasks.register<Copy>("copyBridge") {
-        description = "Stages the pre-built Node-free modeler-core bridge binary into plugin resources (extracted and spawned at runtime)."
-        doFirst {
-            if (!bridgeBinary.asFile.exists()) {
-                throw GradleException(
-                    "Modeler bridge binary not found at ${bridgeBinary.asFile}.\n" +
-                        "Run `corepack yarn workspace @miragon/bpmn-modeler-bridge compile` from the repo root first.",
-                )
+        description = "Stages the pre-built Node-free modeler-core bridge binary(ies) into plugin resources (extracted and spawned at runtime)."
+        if (bundleAllPlatforms) {
+            // Release mode: every per-platform binary must exist, otherwise the
+            // shipped ZIP would silently lack a platform.
+            doFirst {
+                val missing =
+                    releaseBridgeTargets.filter { (dir, name) ->
+                        !bridgeDistRoot.file("$dir/$name").asFile.exists()
+                    }
+                if (missing.isNotEmpty()) {
+                    throw GradleException(
+                        "Missing bridge binaries for: ${missing.joinToString { it.first }}.\n" +
+                            "Run `corepack yarn workspace @miragon/bpmn-modeler-bridge compile:all` from the repo root first.",
+                    )
+                }
             }
+            releaseBridgeTargets.forEach { (platformDir, binaryName) ->
+                from(bridgeDistRoot.file("$platformDir/$binaryName")) {
+                    // Preserve the source filename (`.exe` for windows) so the
+                    // runtime resolver finds the right artefact per platform.
+                    into("bin/$platformDir")
+                }
+            }
+            into(stagedResourcesRoot)
+        } else {
+            doFirst {
+                if (!bridgeBinary.asFile.exists()) {
+                    throw GradleException(
+                        "Modeler bridge binary not found at ${bridgeBinary.asFile}.\n" +
+                            "Run `corepack yarn workspace @miragon/bpmn-modeler-bridge compile` from the repo root first.",
+                    )
+                }
+            }
+            from(bridgeBinary)
+            // Lands at `/bin/<os>-<arch>/modeler-bridge` on the classpath (CoreProcess reads it there).
+            into(stagedResourcesRoot.map { it.dir("bin/${hostPlatformDir()}") })
         }
-        from(bridgeBinary)
-        // Lands at `/bin/<os>-<arch>/modeler-bridge` on the classpath (CoreProcess reads it there).
-        into(stagedResourcesRoot.map { it.dir("bin/${hostPlatformDir()}") })
     }
 
 sourceSets.named("main") {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -737,14 +737,21 @@ class CoreProcess(private val project: Project) : Disposable {
         cachedBinary?.let { return it }
 
         val platform = platformDir()
-        val resource = "/bin/$platform/$BRIDGE_BINARY_NAME"
+        // Windows refuses to launch an executable without the `.exe` suffix on
+        // both the staged resource and the extracted temp file. Bun's
+        // `--target=bun-windows-x64` produces `modeler-bridge.exe` and Gradle
+        // stages it under the same name, so we mirror that here.
+        val isWindows = platform.startsWith("windows")
+        val binaryName = if (isWindows) "$BRIDGE_BINARY_NAME.exe" else BRIDGE_BINARY_NAME
+        val resource = "/bin/$platform/$binaryName"
         val stream =
             javaClass.getResourceAsStream(resource)
                 ?: error(
                     "No bundled modeler bridge for platform '$platform' ($resource). " +
                         "Build it with `corepack yarn workspace @miragon/bpmn-modeler-bridge compile`.",
                 )
-        val temp = Files.createTempFile("modeler-bridge", "")
+        val tempSuffix = if (isWindows) ".exe" else ""
+        val temp = Files.createTempFile("modeler-bridge", tempSuffix)
         stream.use { Files.copy(it, temp, StandardCopyOption.REPLACE_EXISTING) }
         temp.toFile().setExecutable(true, true)
         temp.toFile().deleteOnExit()

--- a/apps/modeler-bridge/package.json
+++ b/apps/modeler-bridge/package.json
@@ -13,6 +13,12 @@
     "scripts": {
         "typecheck": "tsc -p tsconfig.app.json --noEmit",
         "compile": "bun build --compile --target=bun-darwin-arm64 src/server.ts --outfile dist/modeler-bridge",
+        "compile:darwin-arm64": "bun build --compile --target=bun-darwin-arm64 src/server.ts --outfile dist/darwin-arm64/modeler-bridge",
+        "compile:darwin-x64": "bun build --compile --target=bun-darwin-x64 src/server.ts --outfile dist/darwin-x64/modeler-bridge",
+        "compile:linux-x64": "bun build --compile --target=bun-linux-x64 src/server.ts --outfile dist/linux-x64/modeler-bridge",
+        "compile:linux-arm64": "bun build --compile --target=bun-linux-arm64 src/server.ts --outfile dist/linux-arm64/modeler-bridge",
+        "compile:windows-x64": "bun build --compile --target=bun-windows-x64 src/server.ts --outfile dist/windows-x64/modeler-bridge.exe",
+        "compile:all": "npm-run-all -p compile:darwin-arm64 compile:darwin-x64 compile:linux-x64 compile:linux-arm64 compile:windows-x64",
         "build": "npm-run-all -s typecheck compile",
         "start": "bun run src/server.ts",
         "test": "vitest run --coverage"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,6 +19,7 @@ export default withMermaid(defineConfig({
         logo: "/miragon-favicon.png",
         nav: [
             { text: "VS Code", link: "/vscode/getting-started" },
+            { text: "IntelliJ", link: "/intellij/getting-started" },
             { text: "Standalone", link: "/standalone/getting-started" },
             { text: "Features", link: "/vscode/features/" },
         ],
@@ -29,6 +30,12 @@ export default withMermaid(defineConfig({
                     items: [
                         { text: "Installation & Quick Start", link: "/vscode/getting-started" },
                         { text: "Configuration", link: "/vscode/configuration" },
+                    ],
+                },
+                {
+                    text: "IntelliJ (Preview)",
+                    items: [
+                        { text: "Getting Started", link: "/intellij/getting-started" },
                     ],
                 },
                 {

--- a/docs/intellij/getting-started.md
+++ b/docs/intellij/getting-started.md
@@ -1,0 +1,52 @@
+# Getting Started (IntelliJ)
+
+The Miragon BPMN Modeler is also available for IntelliJ IDEA (and the other
+IntelliJ-based JetBrains IDEs ≥ 2024.2). It opens `.bpmn` files in a JCEF
+(embedded Chromium) editor that renders the same bpmn-js modeler used by the
+VS Code extension and the standalone app.
+
+The plugin is currently distributed **outside the JetBrains Marketplace**, via
+a *custom plugin repository* hosted on GitHub Pages. Install is a one-time setup
+plus the regular *Install Plugin* flow.
+
+## Requirements
+
+- IntelliJ IDEA Community / Ultimate **2024.2** or newer (any 2024.2+ IDE based
+  on the IntelliJ Platform works — PyCharm, WebStorm, GoLand, …).
+- A platform with a bundled bridge binary:
+  macOS arm64 / x64, Linux x64 / arm64, Windows x64.
+
+No Node.js install is required — the plugin ships a self-contained bridge
+binary for each supported platform.
+
+## Install
+
+1. Open *Settings → Plugins*.
+2. Click the gear icon (⚙) next to *Installed* and choose *Manage Plugin
+   Repositories…*.
+3. Add the custom repository URL:
+
+   ```
+   https://miragon.github.io/bpmn-modeler/updatePlugins.xml
+   ```
+
+4. Close the dialog. In the *Marketplace* tab, search for
+   **Miragon BPMN Modeler** and click *Install*.
+5. Restart the IDE when prompted.
+
+Updates are delivered through the same mechanism: the IDE polls the custom
+repository on its normal schedule and offers the new version under
+*Settings → Plugins → Updates*.
+
+## Open a diagram
+
+Create or open any `.bpmn` file in your project — the modeler opens
+automatically as the default editor for that file type.
+
+## Where to next
+
+- [VS Code Getting Started](/vscode/getting-started) — same modeling features,
+  different host.
+- [Features overview](/vscode/features/) — feature documentation is hosted
+  under `/vscode/` but the underlying capabilities apply to the IntelliJ
+  plugin too (the modeling engine is shared).


### PR DESCRIPTION
**Issue**

Closes #1093 (multi-platform Bun binary compilation for the modeler bridge — absorbed because the distribution work is impossible without it).

**Description**

Ships the IntelliJ plugin outside the JetBrains Marketplace via GitHub: Releases host the ZIP, GitHub Pages serves a custom \`updatePlugins.xml\` at \`https://miragon.github.io/bpmn-modeler/updatePlugins.xml\` (placed in \`docs/public/\` so VitePress publishes it). Adds \`prepare-release-intellij.yml\` (bumps version in \`build.gradle.kts\`, tags \`intellij-v*\`) and \`publish-intellij.yml\` (cross-compiles bridge for all 5 targets, builds ZIP with \`-PbundleAllPlatforms\`, uploads to release, regenerates + commits the XML). \`CoreProcess.resolveBridgeBinary()\` now appends \`.exe\` on Windows for both the staged resource and extracted temp file; default \`runIde\` path still uses host-only staging. Users install once via *Manage Plugin Repositories…* — install docs added at \`docs/intellij/getting-started.md\`. Manual setup left to maintainer: confirm Pages → Actions source, \`RELEASE_PAT\` has \`contents: write\`, verify the Pages URL after first publish.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created