### PR TITLE
ci: drop release trigger from deploy-docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,11 +1,5 @@
 name: Deploy Docs
 
-# Releases must NOT trigger this workflow: release events run from the tag ref,
-# which the github-pages environment rejects (only branches main/issue-918 are
-# allowed) and which would deploy docs built from the tag commit — missing the
-# updatePlugins.xml that the publish workflows regenerate and push to main
-# afterwards. Those pushes land in docs/** and trigger this workflow via the
-# path filter, so the push-to-main path already covers every docs change.
 on:
   push:
     branches: [main]

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,13 +1,17 @@
 name: Deploy Docs
 
+# Releases must NOT trigger this workflow: release events run from the tag ref,
+# which the github-pages environment rejects (only branches main/issue-918 are
+# allowed) and which would deploy docs built from the tag commit — missing the
+# updatePlugins.xml that the publish workflows regenerate and push to main
+# afterwards. Those pushes land in docs/** and trigger this workflow via the
+# path filter, so the push-to-main path already covers every docs change.
 on:
   push:
     branches: [main]
     paths:
       - 'docs/**'
       - '.github/workflows/deploy-docs.yml'
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
**Issue**

The IntelliJ release pipeline produced a spurious failed *Deploy Docs* run (27330924851). `deploy-docs.yml` had a latent `release: types: [published]` trigger that fired for the first time once the new prepare workflow began creating releases with `RELEASE_PAT` instead of the default `GITHUB_TOKEN`.

**Description**

Removes the `release` trigger from `deploy-docs.yml`. Release events run from the tag ref, which the `github-pages` environment rejects (only `main`/`issue-918` are allowed) and which would deploy docs built from the tag commit — missing the `updatePlugins.xml` that the publish workflows regenerate and push to `main` afterwards. The push-to-`main` path filter already covers every docs change, so the correct deployment still happens. A comment on the `on:` block documents why releases must not trigger this workflow.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created