### PR TITLE
fix(intellij): remove until-build upper bound so plugin installs on newer IDEs

### DIFF
--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -40,6 +40,10 @@ intellijPlatform {
         ideaVersion {
             // 242 == 2024.2; the editor API and bundled JCEF used here are stable from here on.
             sinceBuild = "242"
+            // The Gradle plugin defaults untilBuild to "242.*" when unset, which
+            // rejects every IDE newer than 2024.2 at install time. Null removes
+            // the upper bound entirely (the documented opt-out).
+            untilBuild = provider { null }
         }
     }
 }


### PR DESCRIPTION
**Issue**

Installing the published IntelliJ plugin (v0.1.1) fails on IDEs newer than 2024.2 with "requires build 242.* or older but the current build is IU-261.25134.95".

**Description**

The IntelliJ Platform Gradle Plugin 2.x defaults `untilBuild` to `"242.*"` when only `sinceBuild` is set, stamping an upper bound into the shipped `plugin.xml` that rejects newer IDEs at install time. This sets `untilBuild = provider { null }` to remove the upper bound, matching the intended "2024.2 or newer" support. Verified via `./gradlew patchPluginXml` — the patched descriptor now emits `<idea-version since-build="242" />` with no `until-build`. Shipping to users still requires a new release (0.1.2) to replace the already-published ZIP.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
