### PR TITLE
feat(scriptTask): process-variable IntelliSense for inline BPMN scripts

### DIFF
--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -176,6 +176,17 @@ export class BpmnModeler {
     }
 
     /**
+     * Returns the live moddle definitions tree (`bpmn:Definitions` root) so
+     * callers can walk the in-memory model — e.g. to extract process variables
+     * for script IntelliSense — without round-tripping through XML.
+     *
+     * @throws {NoModelerError} If the modeler has not been created yet.
+     */
+    getDefinitions(): any {
+        return this.getModeler().getDefinitions();
+    }
+
+    /**
      * Creates a new, empty BPMN diagram in the modeler.
      *
      * @returns {@link ImportXMLResult} with any warnings produced during import.

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -32,8 +32,10 @@ import {
     TextClipboardQuery,
     UpdateScriptContentQuery,
     UpdateScriptFormatQuery,
+    UpdateScriptVariablesCommand,
     asyncDebounce,
     createResolver,
+    extractProcessVariables,
     formatErrors,
 } from "@miragon/bpmn-modeler-shared";
 import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-modeler-clipboard";
@@ -214,9 +216,31 @@ window.onload = async function () {
                     data.eventName,
                     data.scriptFormat,
                     data.content,
+                    extractProcessVariables(bpmnModeler.getDefinitions()),
                 ),
             );
         });
+
+        // Publish the process-variable model to the host so open script editors
+        // get live variable completion. The chain is a feedback loop, not an echo
+        // loop — a keystroke in a script edits the moddle, which fires
+        // commandStack.changed, which re-extracts — so it is gated twice: the
+        // 300ms debounce collapses per-keystroke bursts, and the JSON compare
+        // suppresses re-publishes when the extracted model is unchanged.
+        let lastVariablesJson = "";
+        const sendVariables = asyncDebounce(async () => {
+            const variables = extractProcessVariables(bpmnModeler.getDefinitions());
+            const json = JSON.stringify(variables);
+            if (json === lastVariablesJson) {
+                return;
+            }
+            lastVariablesJson = json;
+            vscode.postMessage(new UpdateScriptVariablesCommand(variables));
+        }, 300);
+        bpmnModeler.onCommandStackChanged(() => void sendVariables());
+        // commandStack.changed doesn't fire on import, and a webview reload starts
+        // with an empty host-side store, so seed it unconditionally on every load.
+        void sendVariables();
     }
 
     console.debug("[DEBUG] Modeler is initialized...");

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -491,6 +491,16 @@ class CoreProcess(private val project: Project) : Disposable {
                     gson.fromJson(params.get("completion"), ScriptCompletionModel::class.java),
                 )
             "script/close" -> scriptEditors.closeScript(params.get("scriptId").asString)
+            // Live variable model push: swap the script tab's completion catalog
+            // so the next completion invocation sees the current variables.
+            "script/updateVariables" ->
+                scriptEditors.updateVariables(
+                    params.get("scriptId").asString,
+                    gson.fromJson(
+                        params.get("variables"),
+                        Array<VariableInfo>::class.java,
+                    ).orEmpty().toList(),
+                )
             "document/write" -> handleWrite(params, id)
             "document/save" -> handleSave(params, id)
             "picker/show" -> handlePick(params, id)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptBindingMembersContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptBindingMembersContributor.kt
@@ -75,6 +75,22 @@ class ScriptBindingMembersContributor : NonCodeMembersContributor() {
                 val binding = GrLightVariable(psiManager, bean.name, type, groovyFile)
                 if (!processor.execute(binding, state)) return
             }
+
+            // Process variables resolve as untyped Object bindings: enough to stop
+            // Groovy flagging a completed variable name as unresolved, without
+            // claiming member knowledge we don't have yet (typed bindings are a
+            // later phase). Bean names already contributed above take precedence.
+            val beanNames = model.beans.map { it.name }.toSet()
+            val objectType =
+                elementFactory.createTypeByFQClassName(
+                    CommonClassNames.JAVA_LANG_OBJECT,
+                    resolveScope,
+                )
+            for (variable in model.variables.orEmpty()) {
+                if (variable.name in beanNames) continue
+                val binding = GrLightVariable(psiManager, variable.name, objectType, groovyFile)
+                if (!processor.execute(binding, state)) return
+            }
         }
 
         // A processor resolving an unqualified method call (e.g. `println hello`).

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
@@ -14,8 +14,30 @@ import com.intellij.openapi.vfs.VirtualFile
  * BPMN/Camunda knowledge — only the rendering of an opaque, pre-scoped catalog.
  */
 
-/** Root of the `script/open.completion` payload: the beans in scope for this script's kind. */
-data class ScriptCompletionModel(val beans: List<BeanInfo>)
+/**
+ * Root of the `script/open.completion` payload: the beans in scope for this
+ * script's kind, plus the process variables extracted from the model.
+ *
+ * [variables] **must** be nullable: Gson instantiates this class via Unsafe and
+ * leaves a missing JSON member null even on a non-null Kotlin type, so an open
+ * payload from an older bridge (no `variables` key) would otherwise carry a
+ * deceptive non-null default. A nullable field makes the absence explicit.
+ */
+data class ScriptCompletionModel(
+    val beans: List<BeanInfo>,
+    val variables: List<VariableInfo>? = null,
+)
+
+/**
+ * A process variable surfaced by the model's static extraction. [origin] and
+ * [typeHint] are nullable for the same Gson reason as above and because the
+ * core only sets `typeHint` when it knows one (e.g. a form field's type).
+ */
+data class VariableInfo(
+    val name: String,
+    val origin: String?,
+    val typeHint: String?,
+)
 
 /**
  * A global bean injected into the script context (e.g. `execution`). [methods]
@@ -60,3 +82,23 @@ private val MEMBER_ACCESS = Regex("([A-Za-z_][A-Za-z0-9_]*)\\.\\s*$")
  */
 fun matchMemberAccess(linePrefix: String): String? =
     MEMBER_ACCESS.find(linePrefix)?.groupValues?.get(1)
+
+// `getVariable("…` / `setVariableLocal('…` with an unterminated string argument
+// at the end of the line — the `$` anchor scopes the match to the cursor.
+private val VARIABLE_STRING_ARG =
+    Regex("""((?:get|set|has|remove)Variable(?:Local)?)\s*\(\s*["']([^"'\\]*)$""")
+
+/** The method name + partial variable name when the cursor sits inside a `getVariable("…` argument. */
+data class VariableStringArg(val methodName: String, val partial: String)
+
+/**
+ * Returns the method name and partial variable name when [linePrefix] ends
+ * inside the string argument of a `getVariable`/`setVariable`/… call, else null.
+ *
+ * Port of `matchVariableStringArg` in core's `scriptCompletion.ts`; drives the
+ * host's variable-name completion mode.
+ */
+fun matchVariableStringArg(linePrefix: String): VariableStringArg? {
+    val match = VARIABLE_STRING_ARG.find(linePrefix) ?: return null
+    return VariableStringArg(match.groupValues[1], match.groupValues[2])
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
@@ -49,6 +49,16 @@ class ScriptCompletionContributor : CompletionContributor() {
             val lineStart = document.getLineStartOffset(document.getLineNumber(offset))
             val linePrefix = document.getText(TextRange(lineStart, offset))
 
+            // Variable mode: the cursor is inside a `getVariable("…` argument.
+            // Re-anchor the prefix matcher to the partial typed since the quote
+            // (IntelliJ's default prefix would be empty at a non-identifier caret).
+            val variableArg = matchVariableStringArg(linePrefix)
+            if (variableArg != null) {
+                val prefixed = result.withPrefixMatcher(variableArg.partial)
+                model.variables.orEmpty().forEach { prefixed.addElement(variableLookup(it)) }
+                return
+            }
+
             val bean = matchMemberAccess(linePrefix)
             if (bean != null) {
                 // Member mode: only the matched bean's methods. An unknown bean
@@ -59,8 +69,13 @@ class ScriptCompletionContributor : CompletionContributor() {
                 return
             }
 
-            // Root mode: the in-scope bean names.
+            // Root mode: in-scope bean names, then process variables (beans win
+            // any name clash, matching the VS Code provider).
             model.beans.forEach { result.addElement(beanLookup(it)) }
+            val beanNames = model.beans.map { it.name }.toSet()
+            model.variables.orEmpty()
+                .filter { it.name !in beanNames }
+                .forEach { result.addElement(variableLookup(it)) }
         }
 
         /** Bean as a variable-icon lookup: `name`, type on the right, description greyed. */
@@ -69,6 +84,13 @@ class ScriptCompletionContributor : CompletionContributor() {
                 .withIcon(AllIcons.Nodes.Variable)
                 .withTypeText(bean.type)
                 .appendTailText("  ${bean.description}", true)
+
+        /** Process variable as a variable-icon lookup: typeHint (or a generic label) right, origin greyed. */
+        private fun variableLookup(variable: VariableInfo) =
+            LookupElementBuilder.create(variable.name)
+                .withIcon(AllIcons.Nodes.Variable)
+                .withTypeText(variable.typeHint ?: "process variable")
+                .appendTailText(variable.origin?.let { "  $it" }.orEmpty(), true)
 
         /**
          * Method as a method-icon lookup: `name`, `(params)` tail, return type on

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptEditorManager.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptEditorManager.kt
@@ -117,6 +117,18 @@ class ScriptEditorManager(
         }
     }
 
+    /**
+     * Replaces the process-variable model on a tracked script tab so completion
+     * goes live without reopening. The contributor reads [SCRIPT_COMPLETION_KEY]
+     * fresh on every invocation, so swapping the UserData here is immediately
+     * effective. No-op for an untracked script or one opened without a catalog.
+     */
+    fun updateVariables(scriptId: String, variables: List<VariableInfo>) {
+        val tracked = scripts[scriptId] ?: return
+        val current = tracked.file.getUserData(SCRIPT_COMPLETION_KEY) ?: return
+        tracked.file.putUserData(SCRIPT_COMPLETION_KEY, current.copy(variables = variables))
+    }
+
     /** Closes a script tab on the core's behalf (BPMN editor disposed); no user-close echo. */
     fun closeScript(scriptId: String) {
         val tracked = scripts[scriptId] ?: return

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -62,6 +62,7 @@ interface OpenCommand {
     eventName: string | undefined;
     scriptFormat: string;
     content: string;
+    variables?: { name: string; origin: string; confidence: string }[];
 }
 
 describe("bridge script editor (real core over a fake transport)", () => {
@@ -195,6 +196,53 @@ describe("bridge script editor (real core over a fake transport)", () => {
         expect(update.params.message.kind).toBe("execution-listener");
         expect(update.params.message.listenerIndex).toBe(0);
         expect(update.params.message.content).toBe("console.log('hi')");
+    });
+
+    it("carries the seeded variables in the script/open completion payload", async () => {
+        const { rpc, frames, editorId } = await setup();
+        const variables = [{ name: "amount", origin: "form field", confidence: "declared" }];
+
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+            variables,
+        });
+
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        expect(open.params.completion.variables).toEqual(variables);
+    });
+
+    it("pushes script/updateVariables for that editor's open scripts only", async () => {
+        const { rpc, frames, editorId } = await setup();
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+        });
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        const scriptId = open.params.scriptId;
+
+        const variables = [{ name: "total", origin: "output mapping", confidence: "declared" }];
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: {
+                    editorId,
+                    message: { type: "UpdateScriptVariablesCommand", variables },
+                },
+            }),
+        );
+
+        const update = await waitForFrame(frames, (f) => f.method === "script/updateVariables");
+        expect(update.params.scriptId).toBe(scriptId);
+        expect(update.params.variables).toEqual(variables);
     });
 
     it("closes the editor's open script tabs on session/dispose", async () => {

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -23,7 +23,8 @@
  *                                secretStore/*
  *   Core → Host (notifications): editor/postMessage, diff/postMessage,
  *                                deployment/postMessage, deploymentState/save*,
- *                                notifier/*, statusBar/*, script/open, script/close
+ *                                notifier/*, statusBar/*, script/open, script/close,
+ *                                script/updateVariables
  *
  * DMN is deliberately out of scope here — it has no IntelliJ editor yet; this
  * covers the BPMN editor, diff and deployment. The
@@ -41,6 +42,7 @@ import {
     SetClipboardCommand,
     SetTextClipboardCommand,
     SyncDocumentCommand,
+    UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
 import {
     ArtifactService,
@@ -291,6 +293,14 @@ export function createBridge(
         })
         .on("OpenScriptEditorCommand", (message: Command, editorId: string) => {
             void scriptEditor.open(message as OpenScriptEditorCommand, editorId);
+        })
+        // Live process-variable model update → push to every open script tab of
+        // this editor so completion stays current without reopening.
+        .on("UpdateScriptVariablesCommand", (message: Command, editorId: string) => {
+            scriptEditor.updateVariables(
+                editorId,
+                (message as UpdateScriptVariablesCommand).variables,
+            );
         });
 
     rpc.on("session/register", async (params: RegisterParams) => {

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -30,6 +30,7 @@ import {
     ScriptKind,
     UpdateScriptContentQuery,
     UpdateScriptFormatQuery,
+    VariableDef,
 } from "@miragon/bpmn-modeler-shared";
 
 import { Rpc } from "./rpc";
@@ -50,6 +51,11 @@ interface TrackedScript {
  */
 export class BridgeScriptEditor {
     private readonly scripts = new Map<string, TrackedScript>();
+
+    // Latest process-variable model per editor. Seeded on open and replaced on
+    // every `UpdateScriptVariablesCommand`; read both into the `script/open`
+    // payload and the per-script `script/updateVariables` push.
+    private readonly variablesByEditor = new Map<string, VariableDef[]>();
 
     constructor(
         private readonly store: EditorSessionStore,
@@ -96,13 +102,18 @@ export class BridgeScriptEditor {
             listenerIndex: cmd.listenerIndex,
         });
 
+        // Seed the editor's variable model from the open command so the host has
+        // variable completion before the first live update arrives.
+        this.variablesByEditor.set(editorId, cmd.variables ?? []);
+
         // `fileName` carries the extension so the host infers the FileType for
         // highlighting; `content` is honoured only on first open (see above).
         // `completion` ships the kind-scoped bean/method catalog resolved *here*
         // so the thin Kotlin host never needs to know which beans belong to which
         // kind — it just renders what it is handed (VS Code's
         // `registerCompletionItemProvider` has no PSI-based analogue, so the host
-        // drives a `CompletionContributor` off this payload instead).
+        // drives a `CompletionContributor` off this payload instead). `variables`
+        // rides alongside so the host can complete process-variable names too.
         this.rpc.notify("script/open", {
             scriptId,
             fileName: uri.filename,
@@ -117,8 +128,23 @@ export class BridgeScriptEditor {
                     // they have no member completion.
                     methods: methodsForBean(bean),
                 })),
+                variables: this.variablesByEditor.get(editorId) ?? [],
             },
         });
+    }
+
+    /**
+     * Replaces an editor's process-variable model and pushes it to every open
+     * script tab of that editor via `script/updateVariables`, so completion goes
+     * live without reopening. Scoped to the originating editor's scripts only.
+     */
+    updateVariables(editorId: string, variables: VariableDef[]): void {
+        this.variablesByEditor.set(editorId, variables);
+        for (const [scriptId, entry] of this.scripts) {
+            if (entry.editorId === editorId) {
+                this.rpc.notify("script/updateVariables", { scriptId, variables });
+            }
+        }
     }
 
     /** Host reported an edit in the script editor → push it into the owning webview. */
@@ -159,6 +185,7 @@ export class BridgeScriptEditor {
                 this.scripts.delete(scriptId);
             }
         }
+        this.variablesByEditor.delete(editorId);
     }
 
     /**

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -30,6 +30,7 @@ import {
     setTextClipboardHandler,
     syncDocumentHandler,
     openScriptEditorHandler,
+    updateScriptVariablesHandler,
     navigateToReferencedModelHandler,
 } from "../modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers";
 import {
@@ -38,17 +39,19 @@ import {
 } from "../modeler/dmn/controller/webview-handlers/dmnMessageHandlers";
 import { BpmnDiffController } from "../diff/controller/BpmnDiffController";
 import { ScriptTaskService } from "../scriptTask/controller/ScriptTaskService";
-import { BPMN_VIEW_TYPE, DMN_VIEW_TYPE } from "@miragon/bpmn-modeler-core";
+import { BPMN_VIEW_TYPE, DMN_VIEW_TYPE, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { SharedDeps } from "./sharedDeps";
 
 /**
  * Lifecycle-bearing collaborators owned by sibling features that the editor
  * routes into: the diff controller decides whether a resolved pane is a diff
- * view, and the script-task service handles inline-editor messages and teardown.
+ * view, the script-task service handles inline-editor messages and teardown,
+ * and the variable store feeds script completion.
  */
 interface EditorHandles {
     diffController: BpmnDiffController;
     scriptTaskSvc: ScriptTaskService;
+    scriptVariableStore: ScriptVariableStore;
 }
 
 /**
@@ -63,7 +66,7 @@ export function register(
     deps: SharedDeps,
     handles: EditorHandles,
 ): { bpmnService: BpmnModelerService } {
-    const { diffController, scriptTaskSvc } = handles;
+    const { diffController, scriptTaskSvc, scriptVariableStore } = handles;
 
     const panelStateRepo = new PropertiesPanelStateRepository(context);
     const bpmnService = new BpmnModelerService(
@@ -119,7 +122,8 @@ export function register(
         .on("GetTextClipboardCommand", getTextClipboardHandler(clipboardMediator))
         .on("SetTextClipboardCommand", setTextClipboardHandler(clipboardMediator))
         .on("SyncDocumentCommand", syncDocumentHandler(bpmnService))
-        .on("OpenScriptEditorCommand", openScriptEditorHandler(scriptTaskSvc))
+        .on("OpenScriptEditorCommand", openScriptEditorHandler(scriptTaskSvc, scriptVariableStore))
+        .on("UpdateScriptVariablesCommand", updateScriptVariablesHandler(scriptVariableStore))
         .on(
             "NavigateToReferencedModelCommand",
             navigateToReferencedModelHandler(
@@ -140,7 +144,7 @@ export function register(
             new ElementTemplatesParticipant(templatesSvc, deps.artifactSvc, deps.notifier),
             new SettingsParticipant(settingsBroadcaster),
             new EngineVersionStatusBarParticipant(deps.statusBar, deps.vsDocument),
-            new ScriptTaskTeardownParticipant(scriptTaskSvc),
+            new ScriptTaskTeardownParticipant(scriptTaskSvc, scriptVariableStore),
         ],
         // Diff routing: when the URI resolves as a diff pane the diff controller
         // owns it, so signal "handled" and skip editor-session creation.

--- a/apps/vscode-plugin/src/composition/scriptFeature.ts
+++ b/apps/vscode-plugin/src/composition/scriptFeature.ts
@@ -1,5 +1,6 @@
 import { ExtensionContext, workspace } from "vscode";
 
+import { ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { BpmnScriptFileSystem } from "../scriptTask/infrastructure/BpmnScriptFileSystem";
 import { ScriptCompletionProvider } from "../scriptTask/controller/ScriptCompletionProvider";
 import { ScriptTaskService } from "../scriptTask/controller/ScriptTaskService";
@@ -7,15 +8,16 @@ import { SharedDeps } from "./sharedDeps";
 
 /**
  * The inline-script-editor feature owns the virtual `bpmn-script:` filesystem,
- * the task service, and the completion provider. Registering the FS provider
- * here (rather than in `activate`) is safe because no `bpmn-script:` URI is
- * resolved during activation. `scriptTaskSvc` is returned because the editor
- * feature wires it into the BPMN router and a teardown participant.
+ * the task service, the completion provider, and the process-variable store.
+ * Registering the FS provider here (rather than in `activate`) is safe because
+ * no `bpmn-script:` URI is resolved during activation. `scriptTaskSvc` and
+ * `scriptVariableStore` are returned because the editor feature wires them into
+ * the BPMN router and the teardown participant.
  */
 export function register(
     context: ExtensionContext,
     deps: SharedDeps,
-): { scriptTaskSvc: ScriptTaskService } {
+): { scriptTaskSvc: ScriptTaskService; scriptVariableStore: ScriptVariableStore } {
     const bpmnScriptFs = new BpmnScriptFileSystem();
     context.subscriptions.push(
         workspace.registerFileSystemProvider("bpmn-script", bpmnScriptFs, {
@@ -31,7 +33,8 @@ export function register(
     );
     scriptTaskSvc.register(context);
 
-    new ScriptCompletionProvider().register(context);
+    const scriptVariableStore = new ScriptVariableStore();
+    new ScriptCompletionProvider(scriptVariableStore).register(context);
 
-    return { scriptTaskSvc };
+    return { scriptTaskSvc, scriptVariableStore };
 }

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -27,10 +27,11 @@ export function activate(context: ExtensionContext): void {
 
     const deps = buildSharedDeps(context);
     const { diffController } = diffFeature.register(context, deps);
-    const { scriptTaskSvc } = scriptFeature.register(context, deps);
+    const { scriptTaskSvc, scriptVariableStore } = scriptFeature.register(context, deps);
     const { bpmnService } = editorFeature.register(context, deps, {
         diffController,
         scriptTaskSvc,
+        scriptVariableStore,
     });
     compareFeature.register(context, deps, { diffController });
     commandsFeature.register(context, deps, { bpmnService });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptTaskTeardownParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptTaskTeardownParticipant.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { ScriptTaskService } from "../../../../scriptTask/index";
 import { EditorSessionContext } from "../../../editor-session/EditorSessionParticipant";
 import { ScriptTaskTeardownParticipant } from "./ScriptTaskTeardownParticipant";
@@ -20,15 +21,18 @@ function createContext() {
 }
 
 describe("ScriptTaskTeardownParticipant", () => {
-    it("disposes the editor's script tasks only on teardown", () => {
+    it("disposes the editor's script tasks and clears its variables only on teardown", () => {
         const scriptTaskSvc = { disposeForEditor: vi.fn() } as unknown as ScriptTaskService;
+        const variableStore = { clear: vi.fn() } as unknown as ScriptVariableStore;
         const { context, captured } = createContext();
 
-        new ScriptTaskTeardownParticipant(scriptTaskSvc).onResolve(context);
+        new ScriptTaskTeardownParticipant(scriptTaskSvc, variableStore).onResolve(context);
         // Nothing happens until the session closes — this is purely a teardown concern.
         expect(scriptTaskSvc.disposeForEditor).not.toHaveBeenCalled();
+        expect(variableStore.clear).not.toHaveBeenCalled();
 
         captured.dispose?.();
         expect(scriptTaskSvc.disposeForEditor).toHaveBeenCalledWith(EDITOR_ID);
+        expect(variableStore.clear).toHaveBeenCalledWith(EDITOR_ID);
     });
 });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptTaskTeardownParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptTaskTeardownParticipant.ts
@@ -1,3 +1,4 @@
+import { ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { ScriptTaskService } from "../../../../scriptTask/index";
 import {
     EditorSessionContext,
@@ -5,14 +6,21 @@ import {
 } from "../../../editor-session/EditorSessionParticipant";
 
 /**
- * Disposes a session's inline script-task editors and buffered replays on close.
- * Script-task resync/open are router handlers (message-driven); only teardown is
- * a lifecycle concern, so this participant carries nothing else.
+ * Disposes a session's inline script-task editors and buffered replays on close,
+ * and drops its process-variable model so a reopened editor never sees stale
+ * completions. Script-task resync/open are router handlers (message-driven);
+ * only teardown is a lifecycle concern, so this participant carries nothing else.
  */
 export class ScriptTaskTeardownParticipant implements EditorSessionParticipant {
-    constructor(private readonly scriptTaskSvc: ScriptTaskService) {}
+    constructor(
+        private readonly scriptTaskSvc: ScriptTaskService,
+        private readonly variableStore: ScriptVariableStore,
+    ) {}
 
     onResolve(session: EditorSessionContext): void {
-        session.onDispose(() => this.scriptTaskSvc.disposeForEditor(session.editorId));
+        session.onDispose(() => {
+            this.scriptTaskSvc.disposeForEditor(session.editorId);
+            this.variableStore.clear(session.editorId);
+        });
     }
 }

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -14,6 +14,7 @@ import {
     SetPropertiesPanelStateCommand,
     SetTextClipboardCommand,
     SyncDocumentCommand,
+    UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
 
 import {
@@ -29,6 +30,7 @@ import {
     setPropertiesPanelStateHandler,
     setTextClipboardHandler,
     syncDocumentHandler,
+    updateScriptVariablesHandler,
 } from "./bpmnMessageHandlers";
 
 const EDITOR = "file:///work/diagram.bpmn";
@@ -137,8 +139,9 @@ describe("set-style handlers forward the command payload", () => {
 describe("openScriptEditorHandler", () => {
     it("maps every command field to the script-task service, in order", async () => {
         const scriptTaskSvc = { openScriptEditor: vi.fn().mockResolvedValue(undefined) };
+        const variableStore = { set: vi.fn() };
 
-        await openScriptEditorHandler(scriptTaskSvc as never)(
+        await openScriptEditorHandler(scriptTaskSvc as never, variableStore as never)(
             new OpenScriptEditorCommand(
                 "Element_1",
                 "execution-listener",
@@ -159,5 +162,40 @@ describe("openScriptEditorHandler", () => {
             "javascript",
             "x=1",
         );
+    });
+
+    it("seeds the variable store from the command before opening", async () => {
+        const scriptTaskSvc = { openScriptEditor: vi.fn().mockResolvedValue(undefined) };
+        const variableStore = { set: vi.fn() };
+        const variables = [{ name: "amount", origin: "form field", confidence: "declared" }];
+
+        await openScriptEditorHandler(scriptTaskSvc as never, variableStore as never)(
+            new OpenScriptEditorCommand(
+                "Element_1",
+                "script-task",
+                undefined,
+                undefined,
+                "groovy",
+                "",
+                variables as never,
+            ),
+            EDITOR,
+        );
+
+        expect(variableStore.set).toHaveBeenCalledWith(EDITOR, variables);
+    });
+});
+
+describe("updateScriptVariablesHandler", () => {
+    it("replaces the editor's variable model in the store", () => {
+        const variableStore = { set: vi.fn() };
+        const variables = [{ name: "total", origin: "output mapping", confidence: "declared" }];
+
+        updateScriptVariablesHandler(variableStore as never)(
+            new UpdateScriptVariablesCommand(variables as never),
+            EDITOR,
+        );
+
+        expect(variableStore.set).toHaveBeenCalledWith(EDITOR, variables);
     });
 });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -6,9 +6,10 @@ import {
     SetPropertiesPanelStateCommand,
     SetTextClipboardCommand,
     SyncDocumentCommand,
+    UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
 
-import { EditorSessionStore } from "@miragon/bpmn-modeler-core";
+import { EditorSessionStore, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { VsCodeNotifier } from "../../../../shared/infrastructure/VsCodeNotifier";
 import { MessageHandler } from "@miragon/bpmn-modeler-core";
 import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
@@ -125,10 +126,20 @@ export function syncDocumentHandler(bpmnService: BpmnModelerService): MessageHan
     };
 }
 
-/** `OpenScriptEditorCommand` → open the inline script in a virtual editor. */
-export function openScriptEditorHandler(scriptTaskSvc: ScriptTaskService): MessageHandler {
+/**
+ * `OpenScriptEditorCommand` → open the inline script in a virtual editor.
+ *
+ * Seeds the variable store from the command's `variables` first so completion
+ * is accurate before the very first keystroke, even if no live
+ * `UpdateScriptVariablesCommand` has arrived yet.
+ */
+export function openScriptEditorHandler(
+    scriptTaskSvc: ScriptTaskService,
+    variableStore: ScriptVariableStore,
+): MessageHandler {
     return async (message: Command, editorId: string) => {
         const cmd = message as OpenScriptEditorCommand;
+        variableStore.set(editorId, cmd.variables ?? []);
         await scriptTaskSvc.openScriptEditor(
             editorId,
             cmd.elementId,
@@ -138,6 +149,13 @@ export function openScriptEditorHandler(scriptTaskSvc: ScriptTaskService): Messa
             cmd.scriptFormat,
             cmd.content,
         );
+    };
+}
+
+/** `UpdateScriptVariablesCommand` → replace the editor's variable model for live completion. */
+export function updateScriptVariablesHandler(variableStore: ScriptVariableStore): MessageHandler {
+    return (message: Command, editorId: string) => {
+        variableStore.set(editorId, (message as UpdateScriptVariablesCommand).variables);
     };
 }
 

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The provider class touches the `vscode` value namespace (`CompletionItem`,
+// `MarkdownString`, `SnippetString`, `languages`), so the factory supplies
+// runtime stand-ins. The pure helper tests live in the sibling
+// `ScriptCompletionProvider.spec.ts`, which needs no vscode mock.
+vi.mock("vscode", () => {
+    class CompletionItem {
+        detail?: string;
+        documentation?: unknown;
+        insertText?: unknown;
+        constructor(
+            public label: string,
+            public kind: number,
+        ) {}
+    }
+    class MarkdownString {
+        constructor(public value: string) {}
+    }
+    class SnippetString {
+        constructor(public value: string) {}
+    }
+    return {
+        CompletionItem,
+        CompletionItemKind: { Variable: 5, Method: 1 },
+        MarkdownString,
+        SnippetString,
+        languages: { registerCompletionItemProvider: vi.fn() },
+    };
+});
+
+import { ScriptUri, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
+import { VariableDef } from "@miragon/bpmn-modeler-shared";
+
+import { ScriptCompletionProvider } from "./ScriptCompletionProvider";
+
+const EDITOR = "file:///work/diagram.bpmn";
+const HASH = ScriptUri.hashEditorId(EDITOR);
+// A script-task URI path keyed to EDITOR's hash; the provider derives both the
+// kind (`script-task`) and the editor hash from this path.
+const SCRIPT_PATH = `/${HASH}/Task_1/script-task/Task_1.groovy`;
+
+function storeWith(...variables: VariableDef[]): ScriptVariableStore {
+    const store = new ScriptVariableStore();
+    store.set(EDITOR, variables);
+    return store;
+}
+
+function complete(
+    provider: ScriptCompletionProvider,
+    linePrefix: string,
+    options: { path?: string; triggerCharacter?: string } = {},
+): string[] {
+    const path = options.path ?? SCRIPT_PATH;
+    const document = { uri: { path }, lineAt: () => ({ text: linePrefix }) } as never;
+    const position = { character: linePrefix.length } as never;
+    const context = { triggerCharacter: options.triggerCharacter } as never;
+    const items = provider.provideCompletionItems(document, position, undefined, context);
+    return items.map((item) => item.label as string);
+}
+
+const variable = (name: string, typeHint?: string): VariableDef => ({
+    name,
+    origin: `origin of ${name}`,
+    typeHint,
+    confidence: "declared",
+});
+
+describe("ScriptCompletionProvider modes", () => {
+    it("root mode offers beans and process variables", () => {
+        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const labels = complete(provider, "am");
+        expect(labels).toContain("execution");
+        expect(labels).toContain("amount");
+    });
+
+    it("variable-string-arg mode offers only process variables", () => {
+        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const labels = complete(provider, `execution.getVariable("am`);
+        expect(labels).toEqual(["amount"]);
+    });
+
+    it("a quote trigger outside a variable argument returns nothing", () => {
+        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        expect(complete(provider, `def label = "am`, { triggerCharacter: '"' })).toEqual([]);
+    });
+
+    it("an unknown editor hash yields beans only, no variables", () => {
+        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const labels = complete(provider, "am", {
+            path: "/unknownhash/Task_1/script-task/Task_1.groovy",
+        });
+        expect(labels).toContain("execution");
+        expect(labels).not.toContain("amount");
+    });
+
+    it("member access on a known bean returns its methods, not variables", () => {
+        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const labels = complete(provider, "execution.");
+        expect(labels).toContain("getVariable");
+        expect(labels).not.toContain("amount");
+    });
+
+    it("carries the typeHint as the completion detail", () => {
+        const provider = new ScriptCompletionProvider(storeWith(variable("amount", "long")));
+        const document = {
+            uri: { path: SCRIPT_PATH },
+            lineAt: () => ({ text: `execution.getVariable("` }),
+        } as never;
+        const items = provider.provideCompletionItems(
+            document,
+            { character: 23 } as never,
+            undefined,
+            {} as never,
+        );
+        expect(items[0].detail).toBe("long");
+    });
+});

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -1,4 +1,5 @@
 import {
+    CompletionContext,
     CompletionItem,
     CompletionItemKind,
     CompletionItemProvider,
@@ -12,7 +13,14 @@ import {
 } from "vscode";
 
 import { BeanDef, beansFor, MethodDef, methodsForBean } from "@miragon/bpmn-modeler-core";
-import { matchMemberAccess, parseKindFromUri } from "@miragon/bpmn-modeler-core";
+import {
+    matchMemberAccess,
+    matchVariableStringArg,
+    parseEditorHashFromUri,
+    parseKindFromUri,
+    ScriptVariableStore,
+} from "@miragon/bpmn-modeler-core";
+import { VariableDef } from "@miragon/bpmn-modeler-shared";
 
 /**
  * VS Code language-feature provider that powers IntelliSense for inline
@@ -33,21 +41,31 @@ import { matchMemberAccess, parseKindFromUri } from "@miragon/bpmn-modeler-core"
  * suggestions accurate per surface (e.g. `task` only appears in task
  * listeners; `eventName` only in listener kinds).
  *
- * Two modes:
+ * Three modes, in order:
  *
- * 1. **Member completion**: triggered after a `.` following a known bean.
+ * 1. **Variable-name completion**: triggered inside the string argument of a
+ *    `getVariable`/`setVariable`/… call. Returns the editor's process
+ *    variables (from {@link ScriptVariableStore}).
+ * 2. **Member completion**: triggered after a `.` following a known bean.
  *    Returns the bean's methods rendered as snippets so the cursor lands
  *    inside the parentheses with parameter placeholders.
- * 2. **Root completion**: returns the bean names themselves whenever a
- *    word is being typed at root scope.
+ * 3. **Root completion**: returns the bean names plus the process variables
+ *    whenever a word is being typed at root scope.
+ *
+ * The provider depends on a {@link ScriptVariableStore} (populated by the
+ * webview's live variable extraction) so suggestions reflect the current model
+ * without reopening the script.
  */
 export class ScriptCompletionProvider implements CompletionItemProvider {
     // Languages this provider participates in.
     private static readonly LANGUAGES = ["javascript", "groovy", "python", "ruby"] as const;
 
+    constructor(private readonly store: ScriptVariableStore) {}
+
     /**
      * Registers the completion provider for every supported language scoped
-     * to the `bpmn-script` scheme.
+     * to the `bpmn-script` scheme. Quote characters trigger variable-name
+     * completion inside `getVariable("…`; `.` triggers member completion.
      */
     register(context: ExtensionContext): void {
         for (const language of ScriptCompletionProvider.LANGUAGES) {
@@ -55,30 +73,66 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
                 scheme: "bpmn-script",
                 language,
             };
-            context.subscriptions.push(languages.registerCompletionItemProvider(filter, this, "."));
+            context.subscriptions.push(
+                languages.registerCompletionItemProvider(filter, this, ".", '"', "'"),
+            );
         }
     }
 
-    provideCompletionItems(document: TextDocument, position: Position): CompletionItem[] {
+    provideCompletionItems(
+        document: TextDocument,
+        position: Position,
+        _token: unknown,
+        context: CompletionContext,
+    ): CompletionItem[] {
         const kind = parseKindFromUri(document.uri.path);
         if (!kind) {
             return [];
         }
         const beans = beansFor(kind);
-
         const linePrefix = document.lineAt(position).text.slice(0, position.character);
 
+        // Mode 1: cursor inside a `getVariable("…` style string argument.
+        if (matchVariableStringArg(linePrefix)) {
+            return this.variableItems(document);
+        }
+
+        // A quote trigger that is *not* inside a variable-string argument must
+        // not dump bean/root completions into an arbitrary string literal.
+        if (context.triggerCharacter === '"' || context.triggerCharacter === "'") {
+            return [];
+        }
+
+        // Mode 2: member access on a known bean. An unknown qualifier (e.g. a
+        // user's own variable `myVar.`) stays empty — no type info until later
+        // phases; never fall back to root items here.
         const memberAccess = matchMemberAccess(linePrefix);
         if (memberAccess) {
             const bean = beans.find((b) => b.name === memberAccess);
-            if (!bean) {
-                return [];
-            }
-            return methodsForBean(bean).map(methodToCompletion);
+            return bean ? methodsForBean(bean).map(methodToCompletion) : [];
         }
 
-        return beans.map(beanToCompletion);
+        // Mode 3: root — beans first, then process variables, beans winning any
+        // name clash (a variable named `execution` would be shadowed anyway).
+        const beanNames = new Set(beans.map((b) => b.name));
+        const variableItems = this.variableItems(document).filter(
+            (item) => !beanNames.has(item.label as string),
+        );
+        return [...beans.map(beanToCompletion), ...variableItems];
     }
+
+    /** Process-variable completions for the editor the script URI belongs to. */
+    private variableItems(document: TextDocument): CompletionItem[] {
+        const editorHash = parseEditorHashFromUri(document.uri.path) ?? "";
+        return this.store.getByEditorHash(editorHash).map(variableToCompletion);
+    }
+}
+
+function variableToCompletion(variable: VariableDef): CompletionItem {
+    const item = new CompletionItem(variable.name, CompletionItemKind.Variable);
+    item.detail = variable.typeHint ?? "process variable";
+    item.documentation = new MarkdownString(variable.origin);
+    return item;
 }
 
 function beanToCompletion(bean: BeanDef): CompletionItem {

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -60,6 +60,7 @@ export * from "./deployment/infrastructure/camunda/MultipartBuilder";
 
 // ── scriptTask: domain ───────────────────────────────────────────────────────
 export * from "./scriptTask/domain/ScriptUri";
+export * from "./scriptTask/domain/ScriptVariableStore";
 export * from "./scriptTask/domain/scriptApi";
 export * from "./scriptTask/domain/scriptCompletion";
 export * from "./scriptTask/domain/scriptLanguage";

--- a/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { VariableDef } from "@miragon/bpmn-modeler-shared";
+
+import { ScriptUri } from "./ScriptUri";
+import { ScriptVariableStore } from "./ScriptVariableStore";
+
+const EDITOR = "file:///work/diagram.bpmn";
+const HASH = ScriptUri.hashEditorId(EDITOR);
+
+function variable(name: string): VariableDef {
+    return { name, origin: "test", confidence: "declared" };
+}
+
+describe("ScriptVariableStore", () => {
+    it("stores variables keyed by the editor hash", () => {
+        const store = new ScriptVariableStore();
+        store.set(EDITOR, [variable("a")]);
+        expect(store.getByEditorHash(HASH).map((v) => v.name)).toEqual(["a"]);
+    });
+
+    it("returns an empty array for an unknown editor hash", () => {
+        expect(new ScriptVariableStore().getByEditorHash("unknown")).toEqual([]);
+    });
+
+    it("replaces the previous model on set", () => {
+        const store = new ScriptVariableStore();
+        store.set(EDITOR, [variable("a")]);
+        store.set(EDITOR, [variable("b")]);
+        expect(store.getByEditorHash(HASH).map((v) => v.name)).toEqual(["b"]);
+    });
+
+    it("clears an editor's variables", () => {
+        const store = new ScriptVariableStore();
+        store.set(EDITOR, [variable("a")]);
+        store.clear(EDITOR);
+        expect(store.getByEditorHash(HASH)).toEqual([]);
+    });
+});

--- a/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.ts
+++ b/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.ts
@@ -1,0 +1,33 @@
+import { VariableDef } from "@miragon/bpmn-modeler-shared";
+
+import { ScriptUri } from "./ScriptUri";
+
+/**
+ * Holds the latest process-variable model per BPMN editor so the script
+ * completion provider can serve variable-name suggestions for any inline script
+ * opened from that editor.
+ *
+ * Keyed by the one-way {@link ScriptUri.hashEditorId} hash rather than the raw
+ * editor id because that hash is the only addressing a `bpmn-script://` URI
+ * carries — the provider recovers it from the document path, never the original
+ * editor URI. Keeping the store pure (no `vscode` import) lets both the VS Code
+ * plugin and the bridge tests drive it directly.
+ */
+export class ScriptVariableStore {
+    private readonly byEditorHash = new Map<string, VariableDef[]>();
+
+    /** Replaces the variable model for an editor (full re-extraction, never merge). */
+    set(editorId: string, variables: VariableDef[]): void {
+        this.byEditorHash.set(ScriptUri.hashEditorId(editorId), variables);
+    }
+
+    /** Variables for a script URI's editor hash; empty when the editor is unknown. */
+    getByEditorHash(editorHash: string): VariableDef[] {
+        return this.byEditorHash.get(editorHash) ?? [];
+    }
+
+    /** Drops an editor's variables on teardown so closed editors leave no stale completions. */
+    clear(editorId: string): void {
+        this.byEditorHash.delete(ScriptUri.hashEditorId(editorId));
+    }
+}

--- a/libs/modeler-core/src/scriptTask/domain/scriptCompletion.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptCompletion.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { matchVariableStringArg, parseEditorHashFromUri } from "./scriptCompletion";
+
+/**
+ * Pure-function tests for the variable-completion helpers behind the script
+ * completion provider — exercised without the `vscode`-bound provider class.
+ */
+describe("matchVariableStringArg", () => {
+    it("matches getVariable with a double quote and a partial name", () => {
+        expect(matchVariableStringArg(`execution.getVariable("am`)).toEqual({
+            methodName: "getVariable",
+            partial: "am",
+        });
+    });
+
+    it("matches a single quote and an empty partial right after the quote", () => {
+        expect(matchVariableStringArg(`execution.setVariable('`)).toEqual({
+            methodName: "setVariable",
+            partial: "",
+        });
+    });
+
+    it("recognises the Local suffix", () => {
+        expect(matchVariableStringArg(`execution.setVariableLocal("x`)?.methodName).toBe(
+            "setVariableLocal",
+        );
+    });
+
+    it("recognises has/remove variants", () => {
+        expect(matchVariableStringArg(`execution.hasVariable("`)?.methodName).toBe("hasVariable");
+        expect(matchVariableStringArg(`execution.removeVariable("`)?.methodName).toBe(
+            "removeVariable",
+        );
+    });
+
+    it("returns undefined once the string argument is closed", () => {
+        expect(matchVariableStringArg(`execution.getVariable("amount")`)).toBeUndefined();
+    });
+
+    it("returns undefined for an ordinary string literal", () => {
+        expect(matchVariableStringArg(`def label = "hello`)).toBeUndefined();
+    });
+});
+
+describe("parseEditorHashFromUri", () => {
+    it("returns the first path segment", () => {
+        expect(parseEditorHashFromUri("/abc123/Task_1/script-task/Task_1.groovy")).toBe("abc123");
+    });
+
+    it("returns undefined for an empty path", () => {
+        expect(parseEditorHashFromUri("/")).toBeUndefined();
+    });
+});

--- a/libs/modeler-core/src/scriptTask/domain/scriptCompletion.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptCompletion.ts
@@ -24,6 +24,38 @@ export function matchMemberAccess(linePrefix: string): string | undefined {
     return match ? match[1] : undefined;
 }
 
+// `getVariable("…` / `setVariableLocal('…` etc. with an *unterminated* string
+// argument at the end of the line. Group 1 is the method name (Local suffix
+// included), group 2 the partial variable name typed so far (possibly empty,
+// right after the opening quote). The absence of a closing quote is what scopes
+// this to "the cursor is inside the variable-name argument".
+const VARIABLE_STRING_ARG = /((?:get|set|has|remove)Variable(?:Local)?)\s*\(\s*["']([^"'\\]*)$/;
+
+/**
+ * When the cursor sits inside the string argument of a
+ * `getVariable`/`setVariable`/`hasVariable`/`removeVariable` (`Local`) call,
+ * returns the method name and the partial variable name typed so far. Drives
+ * variable-name completion; `undefined` for any other position so the provider
+ * falls through to its bean/root modes.
+ */
+export function matchVariableStringArg(
+    linePrefix: string,
+): { methodName: string; partial: string } | undefined {
+    const match = VARIABLE_STRING_ARG.exec(linePrefix);
+    return match ? { methodName: match[1], partial: match[2] } : undefined;
+}
+
+/**
+ * Extracts the editor hash (first path segment) from a `bpmn-script://` URI
+ * path. The hash keys the host-side variable store, which the completion
+ * provider reads to scope suggestions to the BPMN editor the script belongs to.
+ *
+ * Path shape: `/<editorHash>/<elementId>/<slug>/<filename>`.
+ */
+export function parseEditorHashFromUri(path: string): string | undefined {
+    return path.split("/").filter(Boolean)[0];
+}
+
 /**
  * Extracts the script kind from a `bpmn-script://` URI path written by
  * `ScriptUri.slug`.

--- a/libs/shared/package.json
+++ b/libs/shared/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc -p tsconfig.lib.json",
-    "dev": "tsc -p tsconfig.lib.json --watch"
+    "dev": "tsc -p tsconfig.lib.json --watch",
+    "test": "vitest run --coverage"
   },
   "dependencies": {
     "lodash": "4.18.1",
@@ -14,6 +15,8 @@
     "@types/lodash": "4.17.24",
     "@types/node": "25.9.1",
     "@types/vscode-webview": "1.57.5",
-    "typescript": "6.0.3"
+    "@vitest/coverage-v8": "4.1.8",
+    "typescript": "6.0.3",
+    "vitest": "4.1.8"
   }
 }

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -4,4 +4,5 @@ export * from "./lib/asyncDebounce";
 export * from "./lib/utils";
 export * from "./lib/messages";
 export * from "./lib/modeler";
+export * from "./lib/processVariables";
 export * from "./lib/bpmnFlowOrder";

--- a/libs/shared/src/lib/modeler.ts
+++ b/libs/shared/src/lib/modeler.ts
@@ -25,10 +25,12 @@
  * - {@link SetClipboardCommand}               — ask the host to write text to the clipboard
  * - {@link GetDiagramAsSVGCommand}            — request an SVG export of the current diagram
  * - {@link OpenScriptEditorCommand}           — request the host to open a script task in a VS Code editor
+ * - {@link UpdateScriptVariablesCommand}      — push the re-extracted process-variable model to the host
  *
  * @see messages.ts for the base {@link Query} and {@link Command} classes.
  */
 import { Command, Query } from "./messages";
+import { VariableDef } from "./processVariables";
 
 // =================================== Queries ==================================>
 /**
@@ -347,6 +349,10 @@ export class SetTextClipboardCommand extends Command {
  *
  * For listener kinds, {@link eventName} (e.g. `"start"`, `"create"`) is the
  * listener's `event` attribute and is surfaced in the editor tab title.
+ *
+ * {@link variables} seeds the host's process-variable model so completion is
+ * accurate from the first keystroke; it is an optional trailing parameter so
+ * older webview/host pairs that don't send it stay compatible.
  */
 export class OpenScriptEditorCommand extends Command {
     public readonly elementId: string;
@@ -361,6 +367,8 @@ export class OpenScriptEditorCommand extends Command {
 
     public readonly content: string;
 
+    public readonly variables: VariableDef[];
+
     constructor(
         elementId: string,
         kind: ScriptKind,
@@ -368,6 +376,7 @@ export class OpenScriptEditorCommand extends Command {
         eventName: string | undefined,
         scriptFormat: string,
         content: string,
+        variables: VariableDef[] = [],
     ) {
         super("OpenScriptEditorCommand");
         this.elementId = elementId;
@@ -376,6 +385,22 @@ export class OpenScriptEditorCommand extends Command {
         this.eventName = eventName;
         this.scriptFormat = scriptFormat;
         this.content = content;
+        this.variables = variables;
+    }
+}
+
+/**
+ * Sent by the BPMN webview whenever the process-variable model changes (debounced
+ * + change-gated on the webview side) so open script editors get live variable
+ * completion without reopening. Carries the full re-extracted model — the host
+ * replaces, never merges.
+ */
+export class UpdateScriptVariablesCommand extends Command {
+    public readonly variables: VariableDef[];
+
+    constructor(variables: VariableDef[]) {
+        super("UpdateScriptVariablesCommand");
+        this.variables = variables;
     }
 }
 

--- a/libs/shared/src/lib/processVariables.spec.ts
+++ b/libs/shared/src/lib/processVariables.spec.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    collectExpressionRefs,
+    collectSetVariableNames,
+    dedupeVariables,
+    extractProcessVariables,
+    VariableDef,
+} from "./processVariables";
+
+/**
+ * The extractor walks `$type`-discriminated plain objects, so the fixtures here
+ * are hand-built moddle shapes — no bpmn-js dependency. Each test isolates one
+ * evidence source (or the cross-source dedupe / recursion behaviour) so a
+ * regression points straight at the rule that broke.
+ */
+
+/** Wraps flow elements in a single-process definitions object. */
+function definitionsOf(...flowElements: any[]): any {
+    return {
+        rootElements: [{ $type: "bpmn:Process", id: "Process_1", flowElements }],
+    };
+}
+
+function names(vars: VariableDef[]): string[] {
+    return vars.map((v) => v.name).sort();
+}
+
+function byName(vars: VariableDef[], name: string): VariableDef | undefined {
+    return vars.find((v) => v.name === name);
+}
+
+describe("collectSetVariableNames", () => {
+    it("captures setVariable and setVariableLocal with either quote style", () => {
+        const script = `execution.setVariable("a", 1); execution.setVariableLocal('b', 2);`;
+        expect(collectSetVariableNames(script)).toEqual(["a", "b"]);
+    });
+
+    it("ignores method calls that are not setVariable", () => {
+        expect(collectSetVariableNames(`execution.getVariable("a")`)).toEqual([]);
+    });
+});
+
+describe("collectExpressionRefs", () => {
+    it("captures the leading identifier of ${...} and #{...}", () => {
+        expect(collectExpressionRefs("${approved} and #{amount}")).toEqual(["approved", "amount"]);
+    });
+
+    it("returns only the root identifier of a property path", () => {
+        expect(collectExpressionRefs("${order.total}")).toEqual(["order"]);
+    });
+
+    it("filters reserved names", () => {
+        expect(collectExpressionRefs("${execution} ${true} ${myVar}")).toEqual(["myVar"]);
+    });
+});
+
+describe("extractProcessVariables", () => {
+    it("returns nothing for an empty model", () => {
+        expect(extractProcessVariables({ rootElements: [] })).toEqual([]);
+        expect(extractProcessVariables(undefined)).toEqual([]);
+    });
+
+    it("reads input/output mapping parameter names as declared", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ServiceTask",
+                id: "Task_1",
+                extensionElements: {
+                    values: [
+                        {
+                            $type: "camunda:InputOutput",
+                            inputParameters: [{ name: "in1", value: "${src}" }],
+                            outputParameters: [{ name: "out1" }],
+                        },
+                    ],
+                },
+            }),
+        );
+        expect(names(vars)).toEqual(["in1", "out1", "src"]);
+        expect(byName(vars, "out1")?.confidence).toBe("declared");
+        // The input parameter's value reads `src` → referenced.
+        expect(byName(vars, "src")?.confidence).toBe("referenced");
+    });
+
+    it("reads form field ids with their declared type as a typeHint", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:UserTask",
+                id: "UserTask_1",
+                extensionElements: {
+                    values: [
+                        {
+                            $type: "camunda:FormData",
+                            fields: [{ id: "amount", type: "long" }],
+                        },
+                    ],
+                },
+            }),
+        );
+        expect(byName(vars, "amount")?.typeHint).toBe("long");
+        expect(byName(vars, "amount")?.confidence).toBe("declared");
+    });
+
+    it("reads camunda:resultVariable as declared", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({ $type: "bpmn:ScriptTask", id: "Task_1", resultVariable: "result" }),
+        );
+        expect(byName(vars, "result")?.confidence).toBe("declared");
+    });
+
+    it("reads CallActivity in.source as referenced and out.target as declared", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:CallActivity",
+                id: "Call_1",
+                extensionElements: {
+                    values: [
+                        { $type: "camunda:In", source: "inVar", target: "x" },
+                        { $type: "camunda:Out", target: "outVar", source: "y" },
+                    ],
+                },
+            }),
+        );
+        expect(byName(vars, "inVar")?.confidence).toBe("referenced");
+        expect(byName(vars, "outVar")?.confidence).toBe("declared");
+    });
+
+    it("reads setVariable literals from script-task bodies and listener scripts", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ScriptTask",
+                id: "Task_1",
+                script: `execution.setVariable("scripted", 1)`,
+                extensionElements: {
+                    values: [
+                        {
+                            $type: "camunda:ExecutionListener",
+                            script: { value: `execution.setVariable("listened", 2)` },
+                        },
+                    ],
+                },
+            }),
+        );
+        expect(names(vars)).toEqual(["listened", "scripted"]);
+        expect(byName(vars, "scripted")?.confidence).toBe("declared");
+    });
+
+    it("reads ${var} from sequence-flow condition expressions as referenced", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:SequenceFlow",
+                id: "Flow_1",
+                conditionExpression: { $type: "bpmn:FormalExpression", body: "${approved}" },
+            }),
+        );
+        expect(byName(vars, "approved")?.confidence).toBe("referenced");
+    });
+
+    it("recurses into sub-process flow elements", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:SubProcess",
+                id: "Sub_1",
+                flowElements: [
+                    { $type: "bpmn:ScriptTask", id: "Inner_1", resultVariable: "nested" },
+                ],
+            }),
+        );
+        expect(byName(vars, "nested")?.confidence).toBe("declared");
+    });
+
+    it("lets declared evidence win over a referenced occurrence of the same name", () => {
+        const vars = extractProcessVariables(
+            definitionsOf(
+                {
+                    $type: "bpmn:SequenceFlow",
+                    id: "Flow_1",
+                    conditionExpression: { body: "${shared}" },
+                },
+                {
+                    $type: "bpmn:ScriptTask",
+                    id: "Task_1",
+                    extensionElements: {
+                        values: [
+                            {
+                                $type: "camunda:InputOutput",
+                                outputParameters: [{ name: "shared" }],
+                            },
+                        ],
+                    },
+                },
+            ),
+        );
+        const shared = vars.filter((v) => v.name === "shared");
+        expect(shared).toHaveLength(1);
+        expect(shared[0].confidence).toBe("declared");
+    });
+});
+
+describe("dedupeVariables", () => {
+    it("prefers a typed entry over an untyped one of equal confidence", () => {
+        const deduped = dedupeVariables([
+            { name: "x", origin: "a", confidence: "declared" },
+            { name: "x", origin: "b", typeHint: "String", confidence: "declared" },
+        ]);
+        expect(deduped).toHaveLength(1);
+        expect(deduped[0].typeHint).toBe("String");
+    });
+});

--- a/libs/shared/src/lib/processVariables.ts
+++ b/libs/shared/src/lib/processVariables.ts
@@ -1,0 +1,270 @@
+/**
+ * Pure, bpmn-js-free extraction of process-variable evidence from a moddle
+ * definitions tree.
+ *
+ * Process variables are a *runtime* concept with no design-time declaration in
+ * BPMN, so design-time IntelliSense has to assemble a best-effort model from
+ * static evidence: parameter mappings, form fields, result variables,
+ * call-activity mappings, and `setVariable(...)` / `${...}` occurrences inside
+ * script and expression strings. We deliberately never touch XML text — only
+ * the `$type`-discriminated plain objects bpmn-js hands us via
+ * `getDefinitions()` — so the same code runs in the webview and against
+ * object-literal fixtures in tests.
+ *
+ * Two confidence tiers drive how aggressively a name is surfaced: a `declared`
+ * variable has a concrete producer (an output mapping, a result variable, a
+ * form field, a `setVariable` call) and outranks a merely `referenced` one
+ * (seen only inside a `${...}` read), which might be a typo or a variable
+ * injected from outside the model.
+ */
+
+export type VariableConfidence = "declared" | "referenced";
+
+/**
+ * A single process variable discovered from static model evidence.
+ *
+ * {@link origin} is human-facing (shown in completion docs) and names the
+ * element + evidence kind so the author can trace where a suggestion came from.
+ */
+export interface VariableDef {
+    readonly name: string;
+    readonly origin: string;
+    readonly typeHint?: string;
+    readonly confidence: VariableConfidence;
+}
+
+/**
+ * Names that look like variable references inside `${...}` but are reserved
+ * Camunda/expression-language identifiers, never process variables. Filtering
+ * them keeps `referenced` evidence from polluting completion with `execution`,
+ * `true`, etc.
+ */
+const RESERVED_EXPRESSION_NAMES: ReadonlySet<string> = new Set([
+    "execution",
+    "task",
+    "eventName",
+    "true",
+    "false",
+    "null",
+    "empty",
+]);
+
+// `setVariable("x")` / `setVariableLocal('x')` literals. Group 2 is the name;
+// the back-reference \1 forces matching quote styles. A `\\`-free char class
+// keeps the match to a single, un-escaped string literal.
+const SET_VARIABLE_RE = /setVariable(?:Local)?\s*\(\s*(["'])([^"'\\]+)\1/g;
+
+// `${var}` / `#{var}` — the leading identifier of a JUEL/EL expression. Only
+// the first identifier is captured: `${a.b}` yields `a`, the variable in scope.
+const EXPRESSION_REF_RE = /[$#]\{\s*([A-Za-z_$][A-Za-z0-9_$]*)/g;
+
+/**
+ * Returns the variable names written by `setVariable`/`setVariableLocal` string
+ * literals in a script body. Exported for unit testing the regex in isolation.
+ */
+export function collectSetVariableNames(script: string): string[] {
+    const names: string[] = [];
+    for (const match of script.matchAll(SET_VARIABLE_RE)) {
+        names.push(match[2]);
+    }
+    return names;
+}
+
+/**
+ * Returns the leading identifiers referenced by `${...}` / `#{...}` expressions,
+ * minus reserved names. Exported for unit testing the regex in isolation.
+ */
+export function collectExpressionRefs(expression: string): string[] {
+    const names: string[] = [];
+    for (const match of expression.matchAll(EXPRESSION_REF_RE)) {
+        const name = match[1];
+        if (!RESERVED_EXPRESSION_NAMES.has(name)) {
+            names.push(name);
+        }
+    }
+    return names;
+}
+
+/**
+ * Collapses duplicate names to one entry each, with `declared` evidence winning
+ * over `referenced` (a concrete producer beats a bare read), and — among equal
+ * confidence — a typed entry winning over an untyped one. Order of first
+ * appearance is otherwise preserved so the completion list stays stable.
+ */
+export function dedupeVariables(vars: VariableDef[]): VariableDef[] {
+    const byName = new Map<string, VariableDef>();
+    for (const candidate of vars) {
+        const existing = byName.get(candidate.name);
+        byName.set(candidate.name, existing ? preferred(existing, candidate) : candidate);
+    }
+    return [...byName.values()];
+}
+
+/** Picks the stronger of two same-named variable definitions. */
+function preferred(a: VariableDef, b: VariableDef): VariableDef {
+    if (a.confidence !== b.confidence) {
+        return a.confidence === "declared" ? a : b;
+    }
+    if (a.typeHint && !b.typeHint) {
+        return a;
+    }
+    if (b.typeHint && !a.typeHint) {
+        return b;
+    }
+    return a;
+}
+
+/**
+ * Walks every `bpmn:Process` root (recursing into sub-process `flowElements`)
+ * and assembles the deduplicated process-variable model.
+ *
+ * Scope is process-wide for Phase 1: input-parameter names are technically
+ * element-local, but per-element scoping is cheap to add later because the
+ * script URI already carries the `elementId`.
+ */
+export function extractProcessVariables(definitions: any): VariableDef[] {
+    const out: VariableDef[] = [];
+    const rootElements: any[] = definitions?.rootElements ?? [];
+    for (const root of rootElements) {
+        if (root?.$type === "bpmn:Process") {
+            collectFromFlowElements(root.flowElements ?? [], out);
+        }
+    }
+    return dedupeVariables(out);
+}
+
+/** Recurses the flow-element tree, collecting evidence from each element. */
+function collectFromFlowElements(flowElements: any[], out: VariableDef[]): void {
+    for (const element of flowElements) {
+        collectFromElement(element, out);
+        // Sub-processes (`bpmn:SubProcess`, `bpmn:Transaction`, …) nest their
+        // own flow elements; variables they produce are visible process-wide.
+        if (Array.isArray(element?.flowElements)) {
+            collectFromFlowElements(element.flowElements, out);
+        }
+    }
+}
+
+/** Collects every evidence kind carried directly on a single flow element. */
+function collectFromElement(element: any, out: VariableDef[]): void {
+    const label = elementLabel(element);
+
+    // `camunda:resultVariable` on Script/Service/BusinessRule tasks.
+    if (typeof element?.resultVariable === "string" && element.resultVariable) {
+        out.push({
+            name: element.resultVariable,
+            origin: `result variable of ${label}`,
+            confidence: "declared",
+        });
+    }
+
+    // Inline script-task body: `setVariable(...)` literals.
+    if (element?.$type === "bpmn:ScriptTask" && typeof element.script === "string") {
+        for (const name of collectSetVariableNames(element.script)) {
+            out.push({ name, origin: `script of ${label}`, confidence: "declared" });
+        }
+    }
+
+    // Sequence-flow condition expression: `${var}` reads.
+    const condition = element?.conditionExpression;
+    if (condition && typeof condition.body === "string") {
+        for (const name of collectExpressionRefs(condition.body)) {
+            out.push({ name, origin: `condition on ${label}`, confidence: "referenced" });
+        }
+    }
+
+    for (const extension of element?.extensionElements?.values ?? []) {
+        collectFromExtension(extension, label, out);
+    }
+}
+
+/** Collects evidence from one `extensionElements` child. */
+function collectFromExtension(extension: any, label: string, out: VariableDef[]): void {
+    switch (extension?.$type) {
+        case "camunda:InputOutput": {
+            for (const param of extension.inputParameters ?? []) {
+                pushParameterName(param, `input mapping of ${label}`, out);
+                pushParameterValueRefs(param, `input mapping of ${label}`, out);
+            }
+            for (const param of extension.outputParameters ?? []) {
+                pushParameterName(param, `output mapping of ${label}`, out);
+                pushParameterValueRefs(param, `output mapping of ${label}`, out);
+            }
+            break;
+        }
+        case "camunda:FormData": {
+            for (const field of extension.fields ?? []) {
+                if (typeof field?.id === "string" && field.id) {
+                    out.push({
+                        name: field.id,
+                        origin: `form field of ${label}`,
+                        typeHint: typeof field.type === "string" ? field.type : undefined,
+                        confidence: "declared",
+                    });
+                }
+            }
+            break;
+        }
+        // `camunda:In.source` reads a variable from the *calling* process.
+        case "camunda:In": {
+            if (typeof extension.source === "string" && extension.source) {
+                out.push({
+                    name: extension.source,
+                    origin: `in mapping of ${label}`,
+                    confidence: "referenced",
+                });
+            }
+            if (typeof extension.sourceExpression === "string") {
+                for (const name of collectExpressionRefs(extension.sourceExpression)) {
+                    out.push({ name, origin: `in mapping of ${label}`, confidence: "referenced" });
+                }
+            }
+            break;
+        }
+        // `camunda:Out.target` writes a variable back into the calling process.
+        case "camunda:Out": {
+            if (typeof extension.target === "string" && extension.target) {
+                out.push({
+                    name: extension.target,
+                    origin: `out mapping of ${label}`,
+                    confidence: "declared",
+                });
+            }
+            break;
+        }
+        case "camunda:ExecutionListener":
+        case "camunda:TaskListener": {
+            if (extension.script && typeof extension.script.value === "string") {
+                for (const name of collectSetVariableNames(extension.script.value)) {
+                    out.push({
+                        name,
+                        origin: `listener script of ${label}`,
+                        confidence: "declared",
+                    });
+                }
+            }
+            break;
+        }
+    }
+}
+
+/** A mapped parameter's `name` is a declared variable (output) or local (input). */
+function pushParameterName(param: any, origin: string, out: VariableDef[]): void {
+    if (typeof param?.name === "string" && param.name) {
+        out.push({ name: param.name, origin, confidence: "declared" });
+    }
+}
+
+/** A mapped parameter's `value` may read other variables via `${...}`. */
+function pushParameterValueRefs(param: any, origin: string, out: VariableDef[]): void {
+    if (typeof param?.value === "string") {
+        for (const name of collectExpressionRefs(param.value)) {
+            out.push({ name, origin, confidence: "referenced" });
+        }
+    }
+}
+
+/** Quoted element id for an origin string, falling back when no id is present. */
+function elementLabel(element: any): string {
+    return typeof element?.id === "string" && element.id ? `"${element.id}"` : "an element";
+}

--- a/libs/shared/vitest.config.ts
+++ b/libs/shared/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        name: "shared",
+        environment: "node",
+        include: ["src/**/*.{spec,test}.ts"],
+        coverage: {
+            provider: "v8",
+            reportsDirectory: "../../coverage/libs/shared",
+            reporter: ["text", "html", "lcov", "clover", "json", "json-summary"],
+        },
+    },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
             "apps/bpmn-webview",
             "libs/bpmn-i18n",
             "libs/modeler-core",
+            "libs/shared",
         ],
         coverage: {
             provider: "v8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3578,9 +3578,11 @@ __metadata:
     "@types/lodash": "npm:4.17.24"
     "@types/node": "npm:25.9.1"
     "@types/vscode-webview": "npm:1.57.5"
+    "@vitest/coverage-v8": "npm:4.1.8"
     lodash: "npm:4.18.1"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.3"
+    vitest: "npm:4.1.8"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Issue**

Closes: #1113
Closes: #1114
Closes: #1115

**Description**

Adds process-variable IntelliSense to inline BPMN scripts by extracting a variable model from the live bpmn-js moddle tree in the webview — input/output mappings, form fields, `resultVariable`, call-activity in/out, `setVariable` literals, and `${…}` references, each tagged `declared` or `referenced`. The model is published debounced + change-gated on `commandStack.changed` and seeded on open via `OpenScriptEditorCommand`, then surfaced as variable-name completion in both IDE hosts: VS Code reads a `ScriptVariableStore` keyed by editor hash, while IntelliJ receives it over the bridge through the `script/open` payload and a new `script/updateVariables` notification. The extractor + `VariableDef` live in `libs/shared` (the webview must not depend on the host engine), and the host-only store/helpers live in `libs/modeler-core`. New unit tests cover the extraction, store, completion helpers, provider modes, message handlers, and the bridge RPC flow.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created