### PR TITLE
docs(libs): add readmes for previously undocumented libraries

### DIFF
--- a/libs/append-menu/README.md
+++ b/libs/append-menu/README.md
@@ -1,0 +1,58 @@
+# `@miragon/bpmn-modeler-append-menu`
+
+Replaces the flat dropdown that `bpmn-js-create-append-anything` shows when the
+user clicks **Append element** on the context pad (or presses **A** in the
+palette) with a custom **two-panel Preact overlay**. The left panel is a
+searchable, category-filterable list of **element templates** with
+hover-to-expand detail cards (implementation binding, property preview); the
+right panel is a category-grouped palette of standard **BPMN elements** with
+optional pinned favourites.
+
+## How it works
+
+`AppendMenuModule` registers a single bpmn-js DI service,
+`appendMenuOverride` (`AppendMenuOverride`). The service **decorates**
+`popupMenu.open()`: it intercepts only the `bpmn-append` and `bpmn-create`
+providers and lets every other popup (e.g. `bpmn-replace`) fall through
+untouched. Intercepted entries are pulled via `popupMenu._getContext(...)`,
+split with `classifyEntries()` into template vs. standard-element groups, and
+rendered into a `document.body` overlay. Selecting an entry unmounts the
+overlay and runs the entry's **original** action (`executeEntryAction()`) — the
+override changes only the presentation, never the command dispatch. It closes
+itself on `contextPad.close`, `canvas.viewbox.changing`, and
+`commandStack.changed`.
+
+## Why this lives in its own library
+
+- **It is a pure bpmn-js decorator with zero VS Code knowledge.** The overlay
+  works in any bpmn-js host (Camunda 7 and 8 alike — it sits in the
+  `commonModules` of `apps/bpmn-webview`). Keeping it out of the webview makes
+  that "no host APIs" contract explicit and the module reusable.
+- **It is a heavy, optional UI.** A multi-file Preact component tree plus CSS
+  only matters once the append menu opens. Isolating it keeps that weight off
+  the webview's core path and out of unrelated build graphs.
+- **It depends on the element-templates infrastructure.** Enriching template
+  entries pulls in `@miragon/bpmn-modeler-element-template-chooser`. As a
+  separate package you only take that dependency when you register the module —
+  the `elementTemplates` service is treated as optional, so plain BPMN elements
+  still work without it.
+
+## Usage
+
+```ts
+import { AppendMenuModule } from "@miragon/bpmn-modeler-append-menu";
+import { ElementTemplateChooserModule } from "@miragon/bpmn-modeler-element-template-chooser";
+import { CreateAppendElementTemplatesModule } from "bpmn-js-create-append-anything";
+
+const modeler = new BpmnModeler({
+    additionalModules: [
+        ElementTemplateChooserModule,        // optional: enriches template entries
+        CreateAppendElementTemplatesModule,  // must register before the override, so entries exist
+        AppendMenuModule,
+    ],
+});
+
+// Pin up to 6 element types to the top of the right panel.
+modeler.get("appendMenuOverride", false)
+    ?.setFavourites(["bpmn:ServiceTask", "bpmn:UserTask"]);
+```

--- a/libs/bpmn-clipboard/README.md
+++ b/libs/bpmn-clipboard/README.md
@@ -1,0 +1,68 @@
+# `@miragon/bpmn-modeler-clipboard`
+
+Makes copy/paste work inside the BPMN editor when it runs in a VS Code webview
+iframe — both **diagram elements** (copy a shape/connection in one editor tab,
+paste it into another) and **label text** while direct-editing an element name.
+Inside a sandboxed webview `navigator.clipboard` is unusable (the iframe lacks
+`clipboard-read`/`clipboard-write` permissions), so neither bpmn-js's native
+copy-paste nor contenteditable's default clipboard handling can reach the
+system clipboard on their own.
+
+## How it works
+
+The library routes every clipboard access through a `ClipboardBridge`
+(`requestClipboard` / `writeClipboard`) that the host wires to `postMessage`,
+so the real clipboard call (`vscode.env.clipboard`) happens on the extension
+host, outside the iframe. It ships two DI modules:
+
+- **`VsCodeClipboardModule`** disables bpmn-js's `NativeCopyPaste`
+  (`nativeCopyPaste.toggle(false)`) and takes over at EventBus priority **2051**
+  (just above the disabled layer's 2050): on `copyPaste.elementsCopied` it
+  serialises the element tree to prefixed JSON and writes it through the bridge;
+  on `copyPaste.pasteElements` it reads back and revives it. It also intercepts
+  the DOM `copy` event in the **capture phase** so VS Code's own webview handler
+  can't overwrite the serialised BPMN with stale DOM text.
+- **`LabelClipboardModule`** attaches a capture-phase `keydown` listener to the
+  contenteditable label on `directEditing.activate`, so Cmd/Ctrl+C/V/A are
+  routed through the bridge *before* diagram-js's `DirectEditing._handleKey`
+  calls `stopPropagation()`.
+
+It binds two independent bridges, `elementClipboardBridge` and
+`textClipboardBridge`, so element and label clipboards stay separate.
+
+## Why this lives in its own library
+
+- **The bridge indirection is the whole point.** The webview half (these
+  modules) and the host half (`vscode.env.clipboard`) live on opposite sides of
+  the iframe boundary; isolating the webview half behind a small `ClipboardBridge`
+  interface keeps the diagram code free of webview message types and makes the
+  modules trivially mockable.
+- **It is opt-in per host.** In plain-browser dev mode the modules simply aren't
+  loaded and bpmn-js's `NativeCopyPaste` handles the clipboard natively. That
+  conditional wiring is cleaner as a separate package than as dead branches in
+  the webview.
+
+## Usage
+
+```ts
+import {
+    VsCodeClipboardModule,
+    LabelClipboardModule,
+    type ClipboardBridge,
+} from "@miragon/bpmn-modeler-clipboard";
+
+const elementClipboardBridge: ClipboardBridge = {
+    requestClipboard: async () => { /* postMessage → host, await reply */ },
+    writeClipboard: (text) => { /* postMessage → host */ },
+};
+// ...a second bridge for label text...
+
+new BpmnModeler({
+    additionalModules: [
+        VsCodeClipboardModule,
+        LabelClipboardModule,
+        { elementClipboardBridge: ["value", elementClipboardBridge] },
+        { textClipboardBridge: ["value", textClipboardBridge] },
+    ],
+});
+```

--- a/libs/bpmn-i18n/README.md
+++ b/libs/bpmn-i18n/README.md
@@ -1,0 +1,55 @@
+# `@miragon/bpmn-modeler-i18n`
+
+Runtime language switching for the modeler UI. Translates bpmn-js and dmn-js
+labels, `@bpmn-io/properties-panel` field captions/descriptions, and the app's
+own strings (diff legend, resizer toggle, …). Ships German, English (default),
+Spanish, French, Dutch, Brazilian Portuguese, Russian, and Simplified /
+Traditional Chinese — each locale assembled from four flat dictionaries
+(`bpmn-js`, `dmn-js`, `properties-panel`, `other`). Keys are the English source
+strings; `{param}` placeholders are substituted at lookup time, and a missing
+key falls back to the English source.
+
+## How it works
+
+A single `CustomTranslator` instance is exported as the shared singleton
+`i18n`. `TranslateModule` is a didi module that binds that same instance as the
+`customTranslator` service and as the `translate(template, replacements)`
+factory bpmn-js calls during rendering. `i18n.setLanguage(locale)` atomically
+swaps the active dictionary and fires `onChange` listeners so UI that lives
+*outside* the bpmn-js DI container can re-render.
+
+## Why this lives in its own library
+
+- **One translator, two scopes.** bpmn-js internals reach the translator only
+  through their private DI container (via the `translate` factory), while
+  webview UI that sits outside that container — the diff legend, the resizer
+  toggle — can't inject DI services and must import `i18n` directly. Exporting
+  the *same* instance both as a didi module and as a singleton is what keeps the
+  two scopes in sync on a language change; that dual shape is the reason it is
+  its own package rather than folded into the webview or `shared`.
+- **The extension host needs the catalogue too.** `supportedLanguages` (label +
+  locale per language) feeds the host's language QuickPick, so the metadata has
+  to be importable from both the webview and the Node-side plugin.
+
+## Usage
+
+```ts
+import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
+
+// In bpmn-js: register the didi module.
+new BpmnModeler({ additionalModules: [TranslateModule] });
+
+// Anywhere (DI or not): switch language; bpmn-js picks it up, onChange listeners re-render.
+i18n.setLanguage("de");
+
+// Outside the DI container: translate directly and react to changes.
+const label = i18n.translate("Added");
+const off = i18n.onChange(() => updateLabels());
+```
+
+```ts
+// Extension host: drive a QuickPick from the catalogue.
+import { supportedLanguages } from "@miragon/bpmn-modeler-i18n";
+
+const items = supportedLanguages.map((l) => ({ label: l.label, description: l.locale }));
+```

--- a/libs/element-template-chooser/README.md
+++ b/libs/element-template-chooser/README.md
@@ -1,0 +1,45 @@
+# `@miragon/bpmn-modeler-element-template-chooser`
+
+Replaces `@bpmn-io/element-template-chooser` with a richer overlay for picking
+an element template. When the user clicks **Select** in the properties panel's
+template section, a modal opens with a searchable, category-filterable template
+list on the left and a live detail preview on the right (description,
+documentation link, and a breakdown of inputs / outputs / properties), with
+keyboard navigation and apply-on-Enter/double-click.
+
+## How it works
+
+`ElementTemplateChooserModule` registers the `elementTemplateChooser` bpmn-js
+DI service. It listens for the properties panel's `elementTemplates.select`
+event, asks `elementTemplates.getLatest(element)` for the applicable (not
+already applied) templates, renders the Preact overlay into a `position: fixed`
+container mounted on the canvas parent, and on confirm calls
+`elementTemplates.applyTemplate(element, template)`. Property bindings are
+classified (`classifyBinding`) and the implementation summary is derived
+(`extractImplementationDetail`) for both Camunda 7 (`camunda:topic`,
+`camunda:class`, …) and Camunda 8 (`zeebe:taskDefinition:type`, …) shapes.
+
+## Why this lives in its own library
+
+- **It is Preact JSX in a non-React webview.** The overlay is written in TSX
+  with a `/** @jsx h */` pragma; the surrounding `apps/bpmn-webview` code does
+  not bundle React/Preact globally. Isolating the UI as a source-only package
+  gives it its own JSX compilation boundary so the pragma doesn't leak into —
+  or break — the rest of the webview build. (Several other libs here, e.g.
+  `append-menu`, reuse this chooser's `ElementTemplate` types.)
+- **It is a self-contained properties-panel integration.** All it needs from the
+  host is the bpmn-js `elementTemplates` service; keeping it separate keeps the
+  overlay reusable in any bpmn-js application and lets its UX evolve
+  independently.
+
+## Usage
+
+```ts
+import { ElementTemplateChooserModule } from "@miragon/bpmn-modeler-element-template-chooser";
+
+new BpmnModeler({ additionalModules: [ElementTemplateChooserModule] });
+```
+
+The DI container wires the service automatically; it subscribes to
+`elementTemplates.select` and shows the overlay when the properties panel's
+template **Select** button is pressed.


### PR DESCRIPTION
## Why

Four `libs/` modules shipped without a README. This adds a compact one to each, matching the house style of the existing lib READMEs (`code-link`, `model-navigation`): a short *what*, a *How it works*, a *Why this lives in its own library*, and a *Usage* snippet.

## What

| Module | Summary |
|---|---|
| `libs/append-menu` | Two-panel append overlay; pure bpmn-js popup-menu decorator with no VS Code knowledge. |
| `libs/bpmn-clipboard` | Copy/paste in sandboxed webview iframes via a `ClipboardBridge` to `vscode.env.clipboard`. |
| `libs/bpmn-i18n` | Runtime language switching; one translator shared across the bpmn-js DI scope and webview UI. |
| `libs/element-template-chooser` | Preact element-template chooser overlay with its own JSX compilation boundary. |

Docs only — no code changes. Facts taken verbatim from each module's source.