### PR TITLE
chore(ci): tier dependabot cooldown, split major from minor+patch, cover gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,23 @@ updates:
       prefix: chore
       prefix-development: chore
       include: scope
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
     groups:
-      npm-all:
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - "*"
+      npm-major:
+        applies-to: version-updates
+        update-types:
+          - major
         patterns:
           - "*"
   # Fetch and update latest `github-actions` packages
@@ -32,5 +47,37 @@ updates:
       include: scope
     groups:
       github-actions-all:
+        patterns:
+          - "*"
+  # Fetch and update latest `gradle` packages (IntelliJ plugin module).
+  - package-ecosystem: gradle
+    directory: "/apps/intellij-plugin"
+    target-branch: "main"
+    labels:
+      - "Technical Dept"
+    schedule:
+      interval: weekly
+      time: "05:00"
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      gradle-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - "*"
+      gradle-major:
+        applies-to: version-updates
+        update-types:
+          - major
         patterns:
           - "*"

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 
 plugins {
-    kotlin("jvm") version "2.0.20"
-    id("org.jetbrains.intellij.platform") version "2.5.0"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.intellij.platform)
 }
 
 group = "io.miragon"
@@ -28,7 +28,7 @@ dependencies {
     // Gson does the JSON encode/decode for the host ↔ bridge ↔ webview messages.
     // Hand-built strings are unsafe here: SyncDocumentCommand carries the full
     // BPMN XML, which must round-trip through proper escaping.
-    implementation("com.google.code.gson:gson:2.11.0")
+    implementation(libs.gson)
 }
 
 kotlin {

--- a/apps/intellij-plugin/gradle/libs.versions.toml
+++ b/apps/intellij-plugin/gradle/libs.versions.toml
@@ -1,0 +1,11 @@
+[versions]
+kotlin = "2.0.20"
+intellijPlatform = "2.5.0"
+gson = "2.11.0"
+
+[libraries]
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+intellij-platform = { id = "org.jetbrains.intellij.platform", version.ref = "intellijPlatform" }


### PR DESCRIPTION
## Summary

Improves the Dependabot configuration on two fronts and closes a coverage gap:

- **Tiered cooldown** for `npm` and the new `gradle` ecosystem: major `14d` / minor `5d` / patch `3d` (default `5d`). Gives freshly-published releases a soak window before they're proposed. Cooldown only delays **version** updates — security PRs bypass it and still open immediately.
- **Major vs minor+patch split**: each ecosystem now opens a `*-minor-patch` PR (safe, quick-merge) separate from a `*-major` PR (isolated for deliberate review), instead of one mixed bucket.
- **New `gradle` ecosystem** for `apps/intellij-plugin`, which was previously uncovered. To make it useful, the Kotlin & IntelliJ-platform **plugin** versions and Gson are migrated into a `gradle/libs.versions.toml` version catalog — Dependabot cannot bump versions declared inline in the `plugins {}` block, only via a catalog.

`github-actions` is intentionally left as a single group (small, low-risk surface).

## Changes

- `.github/dependabot.yml` — cooldown + split for `npm`; add `gradle` ecosystem.
- `apps/intellij-plugin/gradle/libs.versions.toml` — new version catalog (kotlin, intellijPlatform, gson).
- `apps/intellij-plugin/build.gradle.kts` — use `alias(libs.plugins.…)` and `libs.gson`.

## Verification

- `./gradlew help` configures cleanly — the catalog resolves and plugin aliases apply.
- `dependabot.yml` parses as valid YAML; three ecosystems (`npm`, `github-actions`, `gradle`) with the expected groups.

## Notes / follow-ups (not in this PR)

- PR CI (`build.yml`) does not build the Gradle module, so `gradle` Dependabot PRs won't be auto-validated on the PR. A lightweight `./gradlew assemble` job for `apps/intellij-plugin` would close that gap if desired.
- `ideaVersion` in `gradle.properties` stays a manual bump (free-form property, not a Dependabot-managed coordinate).
- Dependabot + version catalogs has had upstream rough edges (dependabot-core #6863, #14084); worth eyeballing that the first gradle PRs land cleanly.