### PR TITLE
fix(bpmn-webview): apply element colour changes in dark mode (#1122)

### DIFF
--- a/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
@@ -117,12 +117,23 @@ defs marker > [style*="stroke: rgb(34, 36, 42)"] {
     stroke: var(--bpmn-shape-fill-color) !important;
 }
 
-/* Text inside shapes (e.g. task labels rendered inline) */
-.djs-shape > .djs-visual > text {
+/*
+ * Embedded labels (task names rendered inside the shape). Recolour ONLY the
+ * default label colour. With no `defaultLabelColor` configured, bpmn-js paints
+ * a label with the element's stroke colour (BpmnRenderUtil#getLabelColor), so a
+ * user-coloured shape already gets a dark label that reads against its light
+ * palette fill — forcing it light here would make it illegible.
+ */
+.djs-shape > .djs-visual > text[style*="fill: rgb(34, 36, 42)"] {
     fill: var(--bpmn-label-color) !important;
 }
 
-/* Labels (text elements) */
+/*
+ * External labels (event/flow names) sit on the dark canvas, not on a shape, so
+ * they always need the light colour — including the stroke-coloured labels of
+ * user-coloured elements, which would otherwise be unreadable against the
+ * canvas.
+ */
 .djs-label .djs-visual text {
     fill: var(--bpmn-label-color) !important;
 }

--- a/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
@@ -77,30 +77,43 @@
 }
 
 /**
- * BPMN shapes — override fill and stroke set by bpmn-js.
- * Some renderers use inline styles, so !important is required.
+ * BPMN shapes — recolour bpmn-js's DEFAULT paint for dark mode, and ONLY the
+ * default paint. bpmn-js emits two paint constants as inline SVG styles:
+ * `fill: white` and `stroke: rgb(34, 36, 42)` (hsl(225, 10%, 15%), its
+ * `defaultStrokeColor`). A blanket `*` override would also clobber palette
+ * colours the user picks via the context pad's "Set color", because a
+ * stylesheet `!important` beats a non-important inline style. Scoping every
+ * rule to the known default value lets any user-chosen colour pass through
+ * untouched.
+ *
+ * Two special cases fall out of value-scoping for free:
+ *   - `fill: none` (bpmn:Group, text annotations) matches no rule and stays
+ *     transparent, so groups never hide the elements they enclose (#1056).
+ *   - filled throw markers paint their body with the stroke constant
+ *     (`fill: rgb(34, 36, 42)`) and their fold lines `stroke: white`; both are
+ *     covered by the value rules below, keeping them legible (#1017).
  */
-.djs-shape > .djs-visual > *:not(text) {
+
+/* defaultFillColor (white) → dark surface */
+.djs-shape > .djs-visual > [style*="fill: white"] {
     fill: var(--bpmn-shape-fill-color) !important;
+}
+
+/* defaultStrokeColor used as a fill (filled throw markers, arrowheads) → light */
+.djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"],
+defs marker > [style*="fill: rgb(34, 36, 42)"] {
+    fill: var(--bpmn-shape-stroke-color) !important;
+}
+
+/* defaultStrokeColor (rgb(34, 36, 42)) → light stroke */
+.djs-shape > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
+.djs-connection > .djs-visual > [style*="stroke: rgb(34, 36, 42)"],
+defs marker > [style*="stroke: rgb(34, 36, 42)"] {
     stroke: var(--bpmn-shape-stroke-color) !important;
 }
 
-/*
- * bpmn-js marks deliberately transparent shapes (bpmn:Group, text
- * annotations) with an inline `fill: none`. The blanket fill override above
- * would paint them opaque, hiding any elements the group encloses (#1056).
- * Honor bpmn-js's transparency instead.
- */
-.djs-shape > .djs-visual > [style*="fill: none"] {
-    fill: none !important;
-}
-
-/* Distinguish bpmn-js throw vs. catch (and other filled) markers in dark mode. */
-.djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"]:not([style*="stroke: white"]) {
-    fill: var(--bpmn-shape-stroke-color) !important;
-}
+/* Throw markers pair a filled body with a white outline → dark-surface outline. */
 .djs-shape > .djs-visual > [style*="fill: rgb(34, 36, 42)"][style*="stroke: white"] {
-    fill: var(--bpmn-shape-stroke-color) !important;
     stroke: var(--bpmn-shape-fill-color) !important;
 }
 
@@ -109,21 +122,9 @@
     fill: var(--bpmn-label-color) !important;
 }
 
-.djs-connection > .djs-visual > path {
-    stroke: var(--bpmn-shape-stroke-color) !important;
-    fill: none !important;
-}
-
 /* Labels (text elements) */
 .djs-label .djs-visual text {
     fill: var(--bpmn-label-color) !important;
-}
-
-/* SVG markers (arrows on connections) in <defs> */
-defs marker > path,
-defs marker > circle {
-    fill: var(--bpmn-shape-stroke-color) !important;
-    stroke: var(--bpmn-shape-stroke-color) !important;
 }
 
 /* Grid — the element has class="layer djs-grid" (two classes) */

--- a/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/diagram-js.css
@@ -77,21 +77,12 @@
 }
 
 /**
- * BPMN shapes — recolour bpmn-js's DEFAULT paint for dark mode, and ONLY the
- * default paint. bpmn-js emits two paint constants as inline SVG styles:
- * `fill: white` and `stroke: rgb(34, 36, 42)` (hsl(225, 10%, 15%), its
- * `defaultStrokeColor`). A blanket `*` override would also clobber palette
- * colours the user picks via the context pad's "Set color", because a
- * stylesheet `!important` beats a non-important inline style. Scoping every
- * rule to the known default value lets any user-chosen colour pass through
- * untouched.
- *
- * Two special cases fall out of value-scoping for free:
- *   - `fill: none` (bpmn:Group, text annotations) matches no rule and stays
- *     transparent, so groups never hide the elements they enclose (#1056).
- *   - filled throw markers paint their body with the stroke constant
- *     (`fill: rgb(34, 36, 42)`) and their fold lines `stroke: white`; both are
- *     covered by the value rules below, keeping them legible (#1017).
+ * Recolour ONLY bpmn-js's default paint (`fill: white`, `stroke: rgb(34, 36, 42)`),
+ * scoping each rule to the known value. A blanket `*` override would beat — via
+ * `!important` — the inline style bpmn-js writes for a user's "Set color" choice.
+ * Value-scoping also handles two cases for free: `fill: none` (bpmn:Group, text
+ * annotations) matches nothing and stays transparent (#1056), and filled throw
+ * markers are covered by the rules below (#1017).
  */
 
 /* defaultFillColor (white) → dark surface */
@@ -118,22 +109,15 @@ defs marker > [style*="stroke: rgb(34, 36, 42)"] {
 }
 
 /*
- * Embedded labels (task names rendered inside the shape). Recolour ONLY the
- * default label colour. With no `defaultLabelColor` configured, bpmn-js paints
- * a label with the element's stroke colour (BpmnRenderUtil#getLabelColor), so a
- * user-coloured shape already gets a dark label that reads against its light
- * palette fill — forcing it light here would make it illegible.
+ * Embedded labels — recolour only the default. bpmn-js paints a label with the
+ * element's stroke colour (no `defaultLabelColor` configured), so a coloured
+ * shape's dark label already reads against its light fill; don't force it light.
  */
 .djs-shape > .djs-visual > text[style*="fill: rgb(34, 36, 42)"] {
     fill: var(--bpmn-label-color) !important;
 }
 
-/*
- * External labels (event/flow names) sit on the dark canvas, not on a shape, so
- * they always need the light colour — including the stroke-coloured labels of
- * user-coloured elements, which would otherwise be unreadable against the
- * canvas.
- */
+/* External labels sit on the dark canvas, so always light — even when coloured. */
 .djs-label .djs-visual text {
     fill: var(--bpmn-label-color) !important;
 }


### PR DESCRIPTION
**Issue**

Closes #1122 — element colour changes (context pad → *Set color*) were not applied in dark mode; the element kept the dark default fill/stroke while light mode worked.

**Description**

The dark theme repainted every shape with blanket `!important` fill/stroke overrides, which always beat the user's chosen colour (bpmn-js emits it as a non-important inline style). The recolouring is now value-scoped to bpmn-js's known default paint constants (`fill: white`, `stroke: rgb(34, 36, 42)`), so any palette colour passes through untouched, and the former special cases collapse into the value rules — `fill: none` stays transparent (#1056) and throw/catch markers stay legible (#1017). The embedded-label override is value-scoped the same way: with no `defaultLabelColor` configured, bpmn-js paints labels with the element's stroke colour, so a coloured shape's dark label now passes through and stays readable on its light palette fill (external labels remain light since they sit on the dark canvas). Verified end-to-end in the real modeler in dark mode: coloured shapes/connections/labels keep their colour and contrast, defaults stay dark, throw markers and group transparency are unaffected, and the change stays pure CSS so the live theme swap keeps working.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* ~Tests were implemented~ (CSS-only change, verified manually in the modeler)
* Documentation was created