### PR TITLE
refactor(bridge): decompose createBridge() into per-feature composition modules

### DIFF
--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -12,6 +12,12 @@
  * is the thin set of port adapters. The host implements the ports as RPC
  * handlers; the core never knows it isn't talking to VS Code.
  *
+ * `createBridge` is a pure composition root: it builds the shared collaborators
+ * once ({@link buildSharedDeps}) and lets each `composition/*Feature.ts` module
+ * wire its own services and register its own slice of the protocol. Each
+ * Host→Core method group below is implemented by the matching feature module;
+ * this table is the index (a seed for a later protocol-typing effort).
+ *
  * Protocol (see {@link Rpc} for framing):
  *   Host → Core (notifications): session/register, webview/message,
  *                                document/didChange, settings/didChange,
@@ -33,86 +39,22 @@
  * instead of VS Code's `vscode.diff` + custom-editor resolution.
  */
 
-import {
-    Command,
-    DiffOrigin,
-    ImplementationKind,
-    NavigateToImplementationCommand,
-    NavigateToReferencedModelCommand,
-    OpenScriptEditorCommand,
-    Query,
-    SetClipboardCommand,
-    SetTextClipboardCommand,
-    SyncActivitiesCommand,
-    SyncDocumentCommand,
-    UpdateScriptVariablesCommand,
-} from "@miragon/bpmn-modeler-shared";
-import {
-    ArtifactService,
-    AuthHeaderResolver,
-    BpmnClipboardMediator,
-    BpmnDiffService,
-    BpmnElementTemplatesService,
-    BpmnModelerService,
-    BpmnSettingsBroadcaster,
-    Camunda7RestClient,
-    Camunda8RestClient,
-    CamundaEngineRouter,
-    CodeLinkMapService,
-    DeploymentMessageDispatcher,
-    DeploymentService,
-    DiffPaneStore,
-    DiffSession,
-    EditorSessionStore,
-    FetchHttpClient,
-    ImplementationLocator,
-    ImplementationNavigationService,
-    ModelNavigationService,
-    ReferencedModelLocator,
-    StartInstanceService,
-    WebviewMessageRouter,
-} from "@miragon/bpmn-modeler-core";
-
-import {
-    DeploymentStateSnapshot,
-    DocumentMirror,
-    RpcClipboard,
-    RpcDeploymentState,
-    RpcDocumentPort,
-    RpcEditorHandle,
-    RpcNotifier,
-    RpcPicker,
-    RpcSecretStore,
-    RpcStatusBar,
-    SessionMeta,
-} from "./adapters";
-import { RpcDiffPaneHandle, dispatchDiffMessage } from "./diffAdapters";
-import { BridgeSettings, NodeWorkspace, SettingsSnapshot } from "./nodeAdapters";
 import { Rpc } from "./rpc";
-import { BridgeScriptEditor } from "./scriptAdapters";
-
-/** Builds a typed-but-stub host reply. The webview only reads `.type`, so a plain object is enough. */
-function query(type: string, fields: Record<string, unknown>): Query {
-    return { type, ...fields } as unknown as Query;
-}
-
-/** Implementation kinds the locator can resolve; a guard against a malformed webview message. */
-const KNOWN_IMPLEMENTATION_KINDS: ReadonlySet<ImplementationKind> = new Set<ImplementationKind>([
-    "javaClass",
-    "delegateExpression",
-    "expression",
-    "externalTopic",
-    "jobType",
-]);
-
-interface RegisterParams extends SessionMeta {
-    content: string;
-    /** Full `miragon.bpmnModeler.*` snapshot; seeds settings before template discovery. */
-    settings?: Partial<SettingsSnapshot>;
-}
+import { buildSharedDeps } from "./composition/sharedDeps";
+import * as diffFeature from "./composition/diffFeature";
+import * as templatesSettingsFeature from "./composition/templatesSettingsFeature";
+import * as clipboardFeature from "./composition/clipboardFeature";
+import * as navigationFeature from "./composition/navigationFeature";
+import * as codeLinkFeature from "./composition/codeLinkFeature";
+import * as scriptFeature from "./composition/scriptFeature";
+import * as editorSessionFeature from "./composition/editorSessionFeature";
+import * as deploymentFeature from "./composition/deploymentFeature";
 
 /**
- * Constructs the bridge: the core, the RPC peer, and every host→core handler.
+ * Constructs the bridge: the shared collaborators, then every per-feature wiring
+ * module. Handles flow forward (diff's `rebroadcastLanguage` into the
+ * templates/settings feature); session hooks flow backward into the editor-
+ * session feature's register/dispose loop.
  *
  * @param write Emits one framed JSON line (caller appends the newline + flushes).
  * @param log   Diagnostic sink (stderr in production; a spy in tests). Kept off
@@ -123,438 +65,24 @@ export function createBridge(
     write: (line: string) => void,
     log: (message: string) => void = () => {},
 ): { rpc: Rpc } {
-    const rpc = new Rpc(write);
+    const deps = buildSharedDeps(write, log);
 
-    const mirror = new DocumentMirror();
-    const notifier = new RpcNotifier(rpc);
-    const statusBar = new RpcStatusBar(rpc);
-    const documentPort = new RpcDocumentPort(rpc, mirror);
-
-    // The element-templates pipeline is the *real* production stack: the only new
-    // code is the two pure-fs/host-fed port adapters (NodeWorkspace/BridgeSettings).
-    // This is what makes the status-bar template count genuine rather than a placeholder.
-    const nodeWorkspace = new NodeWorkspace();
-    const settings = new BridgeSettings();
-
-    // The picker reuses NodeWorkspace for its one filesystem-backed prompt
-    // (pickWorkspaceFiles); every other prompt receives its candidates inline.
-    const picker = new RpcPicker(rpc, nodeWorkspace);
-
-    // onOpenCountChanged is the VS Code setContext hook; irrelevant out-of-process.
-    const store = new EditorSessionStore(() => {});
-    const bpmnService = new BpmnModelerService(store, documentPort, picker, statusBar, notifier);
-    const artifactSvc = new ArtifactService(nodeWorkspace, settings);
-    const templatesSvc = new BpmnElementTemplatesService(
-        store,
-        documentPort,
-        artifactSvc,
-        statusBar,
-        notifier,
-    );
-
-    // The same broadcaster the VS Code host uses: on a settings change it re-pushes
-    // modeler settings + language to the webview. It is `vscode`-free, so it runs
-    // here unmodified — the only difference is the change events come from the
-    // host's RPC snapshots rather than `workspace.onDidChangeConfiguration`.
-    const settingsBroadcaster = new BpmnSettingsBroadcaster(store, settings, notifier);
-
-    // Real clipboard mediator (sandboxed-iframe pattern): the host reads/writes
-    // the system clipboard on the webview's behalf over RPC.
-    const clipboard = new RpcClipboard(rpc);
-    const clipboardMediator = new BpmnClipboardMediator(store, clipboard, notifier);
-
-    // The diff feature reuses the production diff brain verbatim: the same store
-    // and service VS Code wires up. `settings` supplies the locale; diff panes are
-    // not editor sessions, so they don't ride the per-session settings hub — the
-    // locale is pushed on open via the service's `markReady` and re-pushed on
-    // `settings/didChange` via `rebroadcastLanguage` (see the handler below).
-    const diffStore = new DiffPaneStore();
-    const diffService = new BpmnDiffService(notifier, settings, diffStore);
-
-    // The model-navigation brain is `vscode`-free, so it runs unmodified here:
-    // the locator searches via NodeWorkspace's findFiles/readFile/readDirectory,
-    // and the service surfaces results through the same notifier/picker the host
-    // already implements over RPC (notifier/openDocument + picker/show).
-    const referencedModelLocator = new ReferencedModelLocator(nodeWorkspace, notifier);
-    const modelNavigationService = new ModelNavigationService(
-        referencedModelLocator,
-        notifier,
-        picker,
-    );
-
-    // The code-link brain is `vscode`-free too: the locator/navigation service
-    // mirror the model-navigation pair (search via NodeWorkspace, surface via the
-    // RPC notifier/picker), while the always-on map service maintains context-pad
-    // visibility and live linking off the source-file watcher. Mirrors
-    // `composition/codeLinkFeature.ts` — the locator is shared by both consumers.
-    const implementationLocator = new ImplementationLocator(nodeWorkspace, notifier);
-    const implementationNavigationService = new ImplementationNavigationService(
-        implementationLocator,
-        notifier,
-        picker,
-    );
-    const codeLinkMapService = new CodeLinkMapService(
-        store,
-        implementationLocator,
-        artifactSvc,
-        nodeWorkspace,
-        settings,
-        notifier,
-    );
-
-    // "Edit Script" orchestrator. Unlike the other features this one has no
-    // in-core service — the VS Code original was never extracted (its guts are
-    // VS Code-specific accidental complexity) — so the portable slice lives here
-    // and the Kotlin host is a dumb editor surface keyed by an opaque scriptId.
-    const scriptEditor = new BridgeScriptEditor(store, picker, rpc, notifier);
-
-    // Deployment reuses the production deployment brain verbatim: the same
-    // services + dispatcher the VS Code host wires, now fed by the host-fed
-    // deployment-state mirror and the PasswordSafe-backed secret store over RPC.
-    // The Camunda REST stack is pure Node (Buffer/fetch/multipart), so it runs
-    // unmodified under Bun. `post` notifies the host, which pushes the Query into
-    // the deployment tool-window's JCEF browser.
-    const httpClient = new FetchHttpClient();
-    const authResolver = new AuthHeaderResolver(httpClient);
-    const camundaRouter = new CamundaEngineRouter(
-        new Camunda7RestClient(httpClient, authResolver),
-        new Camunda8RestClient(httpClient, authResolver, settings.getC8ApiVersion()),
-    );
-    const deploymentState = new RpcDeploymentState(rpc);
-    const secretStore = new RpcSecretStore(rpc);
-    const deploymentService = new DeploymentService(
-        documentPort,
-        nodeWorkspace,
-        deploymentState,
-        camundaRouter,
-        notifier,
-        picker,
-        secretStore,
-    );
-    const startInstanceService = new StartInstanceService(
-        documentPort,
-        nodeWorkspace,
-        camundaRouter,
-        notifier,
-        picker,
-        artifactSvc,
-    );
-    const deploymentDispatcher = new DeploymentMessageDispatcher(
-        store,
-        documentPort,
-        deploymentService,
-        startInstanceService,
-        notifier,
-        (message) => rpc.notify("deployment/postMessage", { message }),
-    );
-
-    // The form's defaults track the active editor, but only while the panel is
-    // open — refreshing a hidden panel would be wasted RPC. The host reports
-    // open/close via `deployment/open`.
-    let deploymentPanelOpen = false;
-    store.onDidChangeActiveEditor(() => {
-        if (deploymentPanelOpen) {
-            deploymentDispatcher.sendFormDefaults();
-        }
+    const diff = diffFeature.register(deps);
+    const templates = templatesSettingsFeature.register(deps, {
+        onSettingsApplied: diff.rebroadcastLanguage,
     });
+    clipboardFeature.register(deps);
+    navigationFeature.register(deps);
+    const codeLink = codeLinkFeature.register(deps);
+    const script = scriptFeature.register(deps);
+    // Hook order is the per-session teardown order: script → code-link →
+    // templates, reproducing the original inline dispose sequence.
+    editorSessionFeature.register(deps, [
+        script.sessionHooks,
+        codeLink.sessionHooks,
+        templates.sessionHooks,
+    ]);
+    deploymentFeature.register(deps);
 
-    const handles = new Map<string, RpcEditorHandle>();
-    const watchers = new Map<string, { dispose(): void }[]>();
-
-    // Diff panes route by `paneUri` (a diff has two browsers, indexed
-    // independently of editor sessions); `diffSessions` maps each `diffId` to
-    // its session so `diff/dispose` can detach and drop both panes at once.
-    const diffPanes = new Map<string, RpcDiffPaneHandle>();
-    const diffSessions = new Map<string, DiffSession>();
-
-    // The real webview-message dispatch table. The file/sync/settings/templates/
-    // clipboard/navigation handlers call the genuine services; the remaining
-    // handshake reply is a bridge-level stub because its real service (properties
-    // panel) is not wired on this host path. It must still answer, or the
-    // webview's `Promise.all` over templates+settings+panel-state never resolves
-    // and bootstrap stalls.
-    const router = new WebviewMessageRouter();
-    router
-        .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
-            if (await bpmnService.display(editorId)) {
-                notifier.logInfo("BPMN modeler is ready");
-            }
-        })
-        .on("SyncDocumentCommand", async (message: Command, editorId: string) => {
-            await bpmnService.sync(editorId, (message as SyncDocumentCommand).content);
-        })
-        // Inlined rather than importing the VS Code element-templates handler,
-        // whose module pulls in `VsCodeNotifier` → `vscode`, which we must avoid.
-        .on("GetElementTemplatesCommand", (_m: Command, editorId: string) => {
-            void templatesSvc.setElementTemplates(editorId);
-        })
-        // The webview re-requests settings on every (re)load; push the live snapshot
-        // and language, mirroring the VS Code `getBpmnModelerSettingHandler`.
-        .on("GetBpmnModelerSettingCommand", (_m: Command, editorId: string) => {
-            void settingsBroadcaster.setSettings(editorId);
-            settingsBroadcaster.setLanguage(editorId);
-        })
-        .on("GetPropertiesPanelStateCommand", (_m: Command, editorId: string) => {
-            store.postMessage(editorId, query("PropertiesPanelStateQuery", { visible: true }));
-        })
-        .on("GetClipboardCommand", (_m: Command, editorId: string) => {
-            void clipboardMediator.readClipboard(editorId);
-        })
-        .on("SetClipboardCommand", (message: Command) => {
-            void clipboardMediator.writeClipboard((message as SetClipboardCommand).text);
-        })
-        .on("GetTextClipboardCommand", (_m: Command, editorId: string) => {
-            void clipboardMediator.readTextClipboard(editorId);
-        })
-        .on("SetTextClipboardCommand", (message: Command) => {
-            void clipboardMediator.writeClipboard((message as SetTextClipboardCommand).text);
-        })
-        // Mirrors `navigateToReferencedModelHandler` on the VS Code host: an
-        // unknown discriminant is rejected with a warning rather than falling
-        // through to "decision" by default — defence in depth against a
-        // malformed webview message ever opening the wrong kind of file.
-        .on("NavigateToReferencedModelCommand", async (message: Command, editorId: string) => {
-            const cmd = message as NavigateToReferencedModelCommand;
-            if (cmd.referenceKind !== "process" && cmd.referenceKind !== "decision") {
-                notifier.logWarning(
-                    `Ignoring NavigateToReferencedModelCommand with unknown kind: ${String(
-                        cmd.referenceKind,
-                    )}`,
-                );
-                return;
-            }
-            const sourceFsPath = store.requireHandle(editorId).documentFsPath();
-            await modelNavigationService.navigate(cmd.referenceId, cmd.referenceKind, sourceFsPath);
-        })
-        // Mirrors `navigateToImplementationHandler` on the VS Code host: the same
-        // defence-in-depth guard rejects an unknown/empty `kind` so a malformed
-        // message can't be resolved as an arbitrary kind.
-        .on("NavigateToImplementationCommand", async (message: Command, editorId: string) => {
-            const cmd = message as NavigateToImplementationCommand;
-            if (!KNOWN_IMPLEMENTATION_KINDS.has(cmd.kind)) {
-                notifier.logWarning(
-                    `Ignoring NavigateToImplementationCommand with unknown kind: ${String(
-                        cmd.kind,
-                    )}`,
-                );
-                return;
-            }
-            const sourceFsPath = store.requireHandle(editorId).documentFsPath();
-            await implementationNavigationService.navigate(cmd.reference, cmd.kind, sourceFsPath);
-        })
-        // Always-on activity→code reconciliation; the map service filters invalid
-        // entries internally, so this stays a thin pass-through.
-        .on("SyncActivitiesCommand", async (message: Command, editorId: string) => {
-            await codeLinkMapService.syncActivities(
-                editorId,
-                (message as SyncActivitiesCommand).entries,
-            );
-        })
-        .on("OpenScriptEditorCommand", (message: Command, editorId: string) => {
-            void scriptEditor.open(message as OpenScriptEditorCommand, editorId);
-        })
-        // Live process-variable model update → push to every open script tab of
-        // this editor so completion stays current without reopening.
-        .on("UpdateScriptVariablesCommand", (message: Command, editorId: string) => {
-            scriptEditor.updateVariables(
-                editorId,
-                (message as UpdateScriptVariablesCommand).variables,
-            );
-        });
-
-    rpc.on("session/register", async (params: RegisterParams) => {
-        // Seed settings before any discovery so `getConfigFolder()` is correct on
-        // the first template scan/watcher. Snapshots are host-global; applying the
-        // same one on each register is idempotent.
-        if (params.settings) {
-            settings.apply(params.settings);
-        }
-
-        mirror.register(params, params.content);
-        const handle = new RpcEditorHandle(params, mirror, rpc, settings);
-        handles.set(params.editorId, handle);
-
-        // Same wiring the VS Code controller does: route incoming webview
-        // messages through the store into the router, and arm the echo-prevention
-        // session.
-        store.register(handle);
-        store.subscribeToMessageEvent(params.editorId, (message, editorId) =>
-            router.dispatch(message, editorId),
-        );
-        bpmnService.registerSession(params.editorId);
-
-        // Mirrors SettingsParticipant + ElementTemplatesParticipant: re-push
-        // modeler/language settings on change, and reload templates when the
-        // config folder moves. Both ride the BridgeSettings change hub via the
-        // handle's onDidChangeSetting; disposed with the session by the store.
-        settingsBroadcaster.subscribe(params.editorId);
-        store.subscribeToSettingChangeEvent(params.editorId, (event, editorId) => {
-            if (event.affectsConfiguration("miragon.bpmnModeler.configFolder")) {
-                void templatesSvc.setElementTemplates(editorId);
-            }
-        });
-
-        // Seed discovery with the host's authoritative root, then arm the live-
-        // reload watcher (the production `ArtifactService` wiring, reused verbatim).
-        if (params.workspaceRoot) {
-            nodeWorkspace.registerRoot(params.workspaceRoot);
-        }
-        const { disposables } = await artifactSvc.createWatcher(params.editorId, templatesSvc);
-        watchers.set(params.editorId, disposables);
-
-        log(`session registered: ${params.editorId}`);
-    });
-
-    // One host frame updates every open editor: `apply` fires a SettingChange that
-    // each session's broadcaster + configFolder listener turn into webview pushes.
-    // Diff panes aren't editor sessions, so they need an explicit locale re-push.
-    rpc.on("settings/didChange", (params: { settings: Partial<SettingsSnapshot> }) => {
-        settings.apply(params.settings);
-        diffService.rebroadcastLanguage();
-    });
-
-    rpc.on("webview/message", (params: { editorId: string; message: Command }) => {
-        handles.get(params.editorId)?.receive(params.message);
-    });
-
-    // External edits (git revert/checkout, the IDE's plain-text tab, another
-    // tool) must re-render the open diagram. The host stays dumb and forwards
-    // *every* document change — including the echo of our own `document/write` —
-    // so the bridge classifies them here: `RpcDocumentPort.write` updates the
-    // mirror to the core-originated content before the RPC round-trip, so an
-    // unchanged compare means this is that echo and re-rendering would loop.
-    // Only a genuinely different text is an external edit worth displaying.
-    rpc.on("document/didChange", async (params: { editorId: string; content: string }) => {
-        if (mirror.content(params.editorId) === params.content) {
-            return;
-        }
-        mirror.setContent(params.editorId, params.content);
-        await bpmnService.display(params.editorId);
-    });
-
-    // The host reports which editor tab is focused so the store's active-editor
-    // pointer stays correct with several `.bpmn` files open (commands/diff that
-    // target "the active editor" depend on it).
-    rpc.on("session/setActive", (params: { editorId: string }) => {
-        store.setActiveEditor(params.editorId);
-    });
-
-    rpc.on("session/dispose", (params: { editorId: string }) => {
-        bpmnService.disposeSession(params.editorId);
-        // Close any script tabs this editor opened before its handle is dropped.
-        scriptEditor.disposeEditor(params.editorId);
-        // Release this editor's code-link map state + its share of the source
-        // watcher; mirrors `CodeLinkParticipant` (the bridge has no participants).
-        codeLinkMapService.disposeEditor(params.editorId);
-        watchers.get(params.editorId)?.forEach((d) => d.dispose());
-        watchers.delete(params.editorId);
-        // Read the root before removing the mirror entry that holds it.
-        const workspaceRoot = mirror.peek(params.editorId)?.workspaceRoot;
-        if (workspaceRoot) {
-            nodeWorkspace.unregisterRoot(workspaceRoot);
-        }
-        handles.get(params.editorId)?.dispose();
-        handles.delete(params.editorId);
-        mirror.remove(params.editorId);
-        log(`session disposed: ${params.editorId}`);
-    });
-
-    /**
-     * Host-originated diff start. Unlike VS Code — where the two panes resolve
-     * independently and the controller has to pair them — IntelliJ hands us both
-     * sides up front (it knows HEAD vs working tree), so we build the fully-armed
-     * session in one shot: two handles seeded with cached XML, both attached,
-     * indexed. Each pane's webview then boots, asks for its file, reports ready,
-     * and `markReady` runs the differ once both sides are in. Sides are already
-     * assigned by the host, so the `forScm`/`forCompareFiles` choice is made by
-     * origin alone — only so the legend's origin-specific chrome stays correct.
-     */
-    rpc.on("diff/open", (params: DiffOpenParams) => {
-        const beforeHandle = new RpcDiffPaneHandle(params.before.uri, params.before.content, rpc);
-        const afterHandle = new RpcDiffPaneHandle(params.after.uri, params.after.content, rpc);
-
-        const session =
-            params.origin === "scm"
-                ? DiffSession.forScm(beforeHandle, afterHandle)
-                : DiffSession.forCompareFiles(params.before.uri, params.after.uri);
-        session.attachPane(beforeHandle);
-        session.attachPane(afterHandle);
-        diffStore.index(session);
-
-        diffPanes.set(beforeHandle.uri, beforeHandle);
-        diffPanes.set(afterHandle.uri, afterHandle);
-        diffSessions.set(params.diffId, session);
-
-        log(`diff opened: ${params.diffId} (${params.origin})`);
-    });
-
-    rpc.on("diff/webviewMessage", (params: { paneUri: string; message: Command }) => {
-        const handle = diffPanes.get(params.paneUri);
-        if (handle) {
-            void dispatchDiffMessage(diffService, handle, params.message);
-        }
-    });
-
-    rpc.on("diff/dispose", (params: { diffId: string }) => {
-        const session = diffSessions.get(params.diffId);
-        if (!session) {
-            return;
-        }
-        for (const pane of session.attachedPanes()) {
-            diffPanes.delete(pane.uri);
-            session.detachPane(pane);
-            pane.dispose();
-        }
-        diffStore.remove(session);
-        diffSessions.delete(params.diffId);
-        log(`diff disposed: ${params.diffId}`);
-    });
-
-    // The host edited an open script tab → push the new content into the owning
-    // BPMN webview, which writes it to the moddle property via bpmn-js.
-    rpc.on("script/didChange", (params: { scriptId: string; content: string }) => {
-        void scriptEditor.didChange(params.scriptId, params.content);
-    });
-
-    // The user closed a script tab on the host → drop tracking so a re-open
-    // re-reads the current BPMN content rather than revealing a stale tab.
-    rpc.on("script/didClose", (params: { scriptId: string }) => {
-        scriptEditor.didClose(params.scriptId);
-    });
-
-    // Seed the deployment-state mirror once at startup (and after a persisted
-    // save, if the host chooses to re-seed); getters then read it synchronously.
-    rpc.on("deploymentState/seed", (params: { state: Partial<DeploymentStateSnapshot> }) => {
-        deploymentState.seed(params.state);
-    });
-
-    // Inbound deployment-webview message → the shared dispatch core. Errors are
-    // caught inside each handler, so this never rejects.
-    rpc.on("deployment/webviewMessage", (params: { message: Command }) => {
-        void deploymentDispatcher.handle(params.message);
-    });
-
-    // The host reports the tool window's visibility; on open, push the current
-    // form defaults so the panel reflects the active diagram immediately.
-    rpc.on("deployment/open", (params: { open: boolean }) => {
-        deploymentPanelOpen = params.open;
-        if (params.open) {
-            deploymentDispatcher.sendFormDefaults();
-        }
-    });
-
-    return { rpc };
-}
-
-interface DiffPaneInput {
-    /** Stable, diff-scoped pane identity (host appends `#<diffId>-<role>`). */
-    uri: string;
-    content: string;
-}
-
-interface DiffOpenParams {
-    diffId: string;
-    origin: DiffOrigin;
-    before: DiffPaneInput;
-    after: DiffPaneInput;
+    return { rpc: deps.rpc };
 }

--- a/apps/modeler-bridge/src/composition/clipboardFeature.ts
+++ b/apps/modeler-bridge/src/composition/clipboardFeature.ts
@@ -1,0 +1,37 @@
+import {
+    Command,
+    SetClipboardCommand,
+    SetTextClipboardCommand,
+} from "@miragon/bpmn-modeler-shared";
+import { BpmnClipboardMediator } from "@miragon/bpmn-modeler-core";
+
+import { RpcClipboard } from "../adapters";
+import { BridgeSharedDeps } from "./sharedDeps";
+
+/**
+ * The clipboard feature owns the {@link RpcClipboard} adapter and the
+ * {@link BpmnClipboardMediator}, plus its four webview-message handlers.
+ *
+ * Webview messages: GetClipboardCommand, SetClipboardCommand,
+ * GetTextClipboardCommand, SetTextClipboardCommand.
+ */
+export function register(deps: BridgeSharedDeps): void {
+    // Real clipboard mediator (sandboxed-iframe pattern): the host reads/writes
+    // the system clipboard on the webview's behalf over RPC.
+    const clipboard = new RpcClipboard(deps.rpc);
+    const clipboardMediator = new BpmnClipboardMediator(deps.store, clipboard, deps.notifier);
+
+    deps.router
+        .on("GetClipboardCommand", (_m: Command, editorId: string) => {
+            void clipboardMediator.readClipboard(editorId);
+        })
+        .on("SetClipboardCommand", (message: Command) => {
+            void clipboardMediator.writeClipboard((message as SetClipboardCommand).text);
+        })
+        .on("GetTextClipboardCommand", (_m: Command, editorId: string) => {
+            void clipboardMediator.readTextClipboard(editorId);
+        })
+        .on("SetTextClipboardCommand", (message: Command) => {
+            void clipboardMediator.writeClipboard((message as SetTextClipboardCommand).text);
+        });
+}

--- a/apps/modeler-bridge/src/composition/codeLinkFeature.ts
+++ b/apps/modeler-bridge/src/composition/codeLinkFeature.ts
@@ -1,0 +1,90 @@
+import {
+    Command,
+    ImplementationKind,
+    NavigateToImplementationCommand,
+    SyncActivitiesCommand,
+} from "@miragon/bpmn-modeler-shared";
+import {
+    CodeLinkMapService,
+    ImplementationLocator,
+    ImplementationNavigationService,
+} from "@miragon/bpmn-modeler-core";
+
+import { BridgeSharedDeps } from "./sharedDeps";
+import { SessionHooks } from "./sessionHooks";
+
+/** Implementation kinds the locator can resolve; a guard against a malformed webview message. */
+const KNOWN_IMPLEMENTATION_KINDS: ReadonlySet<ImplementationKind> = new Set<ImplementationKind>([
+    "javaClass",
+    "delegateExpression",
+    "expression",
+    "externalTopic",
+    "jobType",
+]);
+
+/**
+ * The code-link feature owns the shared {@link ImplementationLocator} and both
+ * consumers built on it: the on-click {@link ImplementationNavigationService}
+ * and the always-on {@link CodeLinkMapService} (which maintains context-pad
+ * visibility + live linking off the source-file watcher). It returns a session
+ * hook so the editor-session feature releases per-editor map/watcher state on
+ * dispose. This *is* the bridge's code-link feature, mirroring the VS Code
+ * `composition/codeLinkFeature.ts`.
+ *
+ * Webview messages: NavigateToImplementationCommand, SyncActivitiesCommand.
+ */
+export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks } {
+    // The code-link brain is `vscode`-free too: the locator/navigation service
+    // mirror the model-navigation pair (search via NodeWorkspace, surface via the
+    // RPC notifier/picker), while the always-on map service maintains context-pad
+    // visibility and live linking off the source-file watcher. The locator is
+    // shared by both consumers.
+    const implementationLocator = new ImplementationLocator(deps.nodeWorkspace, deps.notifier);
+    const implementationNavigationService = new ImplementationNavigationService(
+        implementationLocator,
+        deps.notifier,
+        deps.picker,
+    );
+    const codeLinkMapService = new CodeLinkMapService(
+        deps.store,
+        implementationLocator,
+        deps.artifactSvc,
+        deps.nodeWorkspace,
+        deps.settings,
+        deps.notifier,
+    );
+
+    deps.router
+        // Mirrors `navigateToImplementationHandler` on the VS Code host: the same
+        // defence-in-depth guard rejects an unknown/empty `kind` so a malformed
+        // message can't be resolved as an arbitrary kind.
+        .on("NavigateToImplementationCommand", async (message: Command, editorId: string) => {
+            const cmd = message as NavigateToImplementationCommand;
+            if (!KNOWN_IMPLEMENTATION_KINDS.has(cmd.kind)) {
+                deps.notifier.logWarning(
+                    `Ignoring NavigateToImplementationCommand with unknown kind: ${String(
+                        cmd.kind,
+                    )}`,
+                );
+                return;
+            }
+            const sourceFsPath = deps.store.requireHandle(editorId).documentFsPath();
+            await implementationNavigationService.navigate(cmd.reference, cmd.kind, sourceFsPath);
+        })
+        // Always-on activity→code reconciliation; the map service filters invalid
+        // entries internally, so this stays a thin pass-through.
+        .on("SyncActivitiesCommand", async (message: Command, editorId: string) => {
+            await codeLinkMapService.syncActivities(
+                editorId,
+                (message as SyncActivitiesCommand).entries,
+            );
+        });
+
+    return {
+        sessionHooks: {
+            // Release this editor's code-link map state + its share of the source
+            // watcher; mirrors `CodeLinkParticipant` (the bridge has no participants).
+            onSessionDisposed: (editorId) => codeLinkMapService.disposeEditor(editorId),
+        },
+    };
+}

--- a/apps/modeler-bridge/src/composition/deploymentFeature.ts
+++ b/apps/modeler-bridge/src/composition/deploymentFeature.ts
@@ -1,0 +1,97 @@
+import { Command } from "@miragon/bpmn-modeler-shared";
+import {
+    AuthHeaderResolver,
+    Camunda7RestClient,
+    Camunda8RestClient,
+    CamundaEngineRouter,
+    DeploymentMessageDispatcher,
+    DeploymentService,
+    FetchHttpClient,
+    StartInstanceService,
+} from "@miragon/bpmn-modeler-core";
+
+import { DeploymentStateSnapshot, RpcDeploymentState, RpcSecretStore } from "../adapters";
+import { BridgeSharedDeps } from "./sharedDeps";
+
+/**
+ * The deployment feature owns its entire stack: the Camunda 7/8 REST client
+ * chain, the deployment-state mirror, the PasswordSafe-backed secret store, the
+ * two services, and the message dispatcher. None of it is shared, so the engine
+ * router is assembled here. `artifactSvc` (shared with templates/code-link) is
+ * the only collaborator pulled from `deps`.
+ *
+ * RPC (Host → Core): deploymentState/seed, deployment/webviewMessage,
+ * deployment/open.
+ */
+export function register(deps: BridgeSharedDeps): void {
+    // Deployment reuses the production deployment brain verbatim: the same
+    // services + dispatcher the VS Code host wires, now fed by the host-fed
+    // deployment-state mirror and the PasswordSafe-backed secret store over RPC.
+    // The Camunda REST stack is pure Node (Buffer/fetch/multipart), so it runs
+    // unmodified under Bun. `post` notifies the host, which pushes the Query into
+    // the deployment tool-window's JCEF browser.
+    const httpClient = new FetchHttpClient();
+    const authResolver = new AuthHeaderResolver(httpClient);
+    const camundaRouter = new CamundaEngineRouter(
+        new Camunda7RestClient(httpClient, authResolver),
+        new Camunda8RestClient(httpClient, authResolver, deps.settings.getC8ApiVersion()),
+    );
+    const deploymentState = new RpcDeploymentState(deps.rpc);
+    const secretStore = new RpcSecretStore(deps.rpc);
+    const deploymentService = new DeploymentService(
+        deps.documentPort,
+        deps.nodeWorkspace,
+        deploymentState,
+        camundaRouter,
+        deps.notifier,
+        deps.picker,
+        secretStore,
+    );
+    const startInstanceService = new StartInstanceService(
+        deps.documentPort,
+        deps.nodeWorkspace,
+        camundaRouter,
+        deps.notifier,
+        deps.picker,
+        deps.artifactSvc,
+    );
+    const deploymentDispatcher = new DeploymentMessageDispatcher(
+        deps.store,
+        deps.documentPort,
+        deploymentService,
+        startInstanceService,
+        deps.notifier,
+        (message) => deps.rpc.notify("deployment/postMessage", { message }),
+    );
+
+    // The form's defaults track the active editor, but only while the panel is
+    // open — refreshing a hidden panel would be wasted RPC. The host reports
+    // open/close via `deployment/open`.
+    let deploymentPanelOpen = false;
+    deps.store.onDidChangeActiveEditor(() => {
+        if (deploymentPanelOpen) {
+            deploymentDispatcher.sendFormDefaults();
+        }
+    });
+
+    // Seed the deployment-state mirror once at startup (and after a persisted
+    // save, if the host chooses to re-seed); getters then read it synchronously.
+    deps.rpc.on("deploymentState/seed", (params: { state: Partial<DeploymentStateSnapshot> }) => {
+        deploymentState.seed(params.state);
+    });
+
+    // Inbound deployment-webview message → the shared dispatch core. Errors are
+    // caught inside each handler, so this never rejects.
+    deps.rpc.on("deployment/webviewMessage", (params: { message: Command }) => {
+        void deploymentDispatcher.handle(params.message);
+    });
+
+    // The host reports the tool window's visibility; on open, push the current
+    // form defaults so the panel reflects the active diagram immediately.
+    deps.rpc.on("deployment/open", (params: { open: boolean }) => {
+        deploymentPanelOpen = params.open;
+        if (params.open) {
+            deploymentDispatcher.sendFormDefaults();
+        }
+    });
+}

--- a/apps/modeler-bridge/src/composition/diffFeature.ts
+++ b/apps/modeler-bridge/src/composition/diffFeature.ts
@@ -1,0 +1,96 @@
+import { Command, DiffOrigin } from "@miragon/bpmn-modeler-shared";
+import { BpmnDiffService, DiffPaneStore, DiffSession } from "@miragon/bpmn-modeler-core";
+
+import { RpcDiffPaneHandle, dispatchDiffMessage } from "../diffAdapters";
+import { BridgeSharedDeps } from "./sharedDeps";
+
+interface DiffPaneInput {
+    /** Stable, diff-scoped pane identity (host appends `#<diffId>-<role>`). */
+    uri: string;
+    content: string;
+}
+
+interface DiffOpenParams {
+    diffId: string;
+    origin: DiffOrigin;
+    before: DiffPaneInput;
+    after: DiffPaneInput;
+}
+
+/**
+ * The diff feature owns the production diff brain (`DiffPaneStore` +
+ * `BpmnDiffService`) and the pane/session bookkeeping behind host-originated
+ * `diff/*` RPC. Diff panes are not editor sessions, so they don't ride the
+ * per-session settings hub; the locale is pushed on open and re-pushed on
+ * `settings/didChange` via the returned `rebroadcastLanguage` handle (the
+ * settings feature owns that route and calls back).
+ *
+ * RPC (Host → Core): diff/open, diff/webviewMessage, diff/dispose.
+ */
+export function register(deps: BridgeSharedDeps): { rebroadcastLanguage: () => void } {
+    const diffStore = new DiffPaneStore();
+    const diffService = new BpmnDiffService(deps.notifier, deps.settings, diffStore);
+
+    // Diff panes route by `paneUri` (a diff has two browsers, indexed
+    // independently of editor sessions); `diffSessions` maps each `diffId` to
+    // its session so `diff/dispose` can detach and drop both panes at once.
+    const diffPanes = new Map<string, RpcDiffPaneHandle>();
+    const diffSessions = new Map<string, DiffSession>();
+
+    /**
+     * Host-originated diff start. Unlike VS Code — where the two panes resolve
+     * independently and the controller has to pair them — IntelliJ hands us both
+     * sides up front (it knows HEAD vs working tree), so we build the fully-armed
+     * session in one shot: two handles seeded with cached XML, both attached,
+     * indexed. Each pane's webview then boots, asks for its file, reports ready,
+     * and `markReady` runs the differ once both sides are in. Sides are already
+     * assigned by the host, so the `forScm`/`forCompareFiles` choice is made by
+     * origin alone — only so the legend's origin-specific chrome stays correct.
+     */
+    deps.rpc.on("diff/open", (params: DiffOpenParams) => {
+        const beforeHandle = new RpcDiffPaneHandle(
+            params.before.uri,
+            params.before.content,
+            deps.rpc,
+        );
+        const afterHandle = new RpcDiffPaneHandle(params.after.uri, params.after.content, deps.rpc);
+
+        const session =
+            params.origin === "scm"
+                ? DiffSession.forScm(beforeHandle, afterHandle)
+                : DiffSession.forCompareFiles(params.before.uri, params.after.uri);
+        session.attachPane(beforeHandle);
+        session.attachPane(afterHandle);
+        diffStore.index(session);
+
+        diffPanes.set(beforeHandle.uri, beforeHandle);
+        diffPanes.set(afterHandle.uri, afterHandle);
+        diffSessions.set(params.diffId, session);
+
+        deps.log(`diff opened: ${params.diffId} (${params.origin})`);
+    });
+
+    deps.rpc.on("diff/webviewMessage", (params: { paneUri: string; message: Command }) => {
+        const handle = diffPanes.get(params.paneUri);
+        if (handle) {
+            void dispatchDiffMessage(diffService, handle, params.message);
+        }
+    });
+
+    deps.rpc.on("diff/dispose", (params: { diffId: string }) => {
+        const session = diffSessions.get(params.diffId);
+        if (!session) {
+            return;
+        }
+        for (const pane of session.attachedPanes()) {
+            diffPanes.delete(pane.uri);
+            session.detachPane(pane);
+            pane.dispose();
+        }
+        diffStore.remove(session);
+        diffSessions.delete(params.diffId);
+        deps.log(`diff disposed: ${params.diffId}`);
+    });
+
+    return { rebroadcastLanguage: () => diffService.rebroadcastLanguage() };
+}

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -1,0 +1,138 @@
+import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
+import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
+
+import { RpcEditorHandle } from "../adapters";
+import { BridgeSharedDeps } from "./sharedDeps";
+import { RegisterParams, SessionHooks } from "./sessionHooks";
+
+/** Builds a typed-but-stub host reply. The webview only reads `.type`, so a plain object is enough. */
+function query(type: string, fields: Record<string, unknown>): Query {
+    return { type, ...fields } as unknown as Query;
+}
+
+/**
+ * The editor-session feature is the bridge's lifecycle hub: it owns
+ * {@link BpmnModelerService}, the per-editor handle registry, document sync, and
+ * the register/dispose RPC. Sibling features contribute their per-session state
+ * through {@link SessionHooks} (template watchers, script tabs, code-link maps),
+ * so this module drives the lifecycle without importing any of them — hooks flow
+ * backward, handles flow forward.
+ *
+ * Webview messages: GetBpmnFileCommand, SyncDocumentCommand,
+ * GetPropertiesPanelStateCommand.
+ * RPC (Host → Core): session/register, session/setActive, session/dispose,
+ * webview/message, document/didChange.
+ */
+export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): void {
+    const bpmnService = new BpmnModelerService(
+        deps.store,
+        deps.documentPort,
+        deps.picker,
+        deps.statusBar,
+        deps.notifier,
+    );
+
+    const handles = new Map<string, RpcEditorHandle>();
+
+    deps.router
+        .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
+            if (await bpmnService.display(editorId)) {
+                deps.notifier.logInfo("BPMN modeler is ready");
+            }
+        })
+        .on("SyncDocumentCommand", async (message: Command, editorId: string) => {
+            await bpmnService.sync(editorId, (message as SyncDocumentCommand).content);
+        })
+        // The remaining handshake reply is a bridge-level stub because its real
+        // service (properties panel) is not wired on this host path. It must still
+        // answer, or the webview's `Promise.all` over templates+settings+panel-state
+        // never resolves and bootstrap stalls.
+        .on("GetPropertiesPanelStateCommand", (_m: Command, editorId: string) => {
+            deps.store.postMessage(editorId, query("PropertiesPanelStateQuery", { visible: true }));
+        });
+
+    deps.rpc.on("session/register", async (params: RegisterParams) => {
+        // Seed settings before any discovery so `getConfigFolder()` is correct on
+        // the first template scan/watcher. Snapshots are host-global; applying the
+        // same one on each register is idempotent. Kept inline (settings is a
+        // shared seam) so it precedes every hook.
+        if (params.settings) {
+            deps.settings.apply(params.settings);
+        }
+
+        deps.mirror.register(params, params.content);
+        const handle = new RpcEditorHandle(params, deps.mirror, deps.rpc, deps.settings);
+        handles.set(params.editorId, handle);
+
+        // Same wiring the VS Code controller does: route incoming webview
+        // messages through the store into the router, and arm the echo-prevention
+        // session.
+        deps.store.register(handle);
+        deps.store.subscribeToMessageEvent(params.editorId, (message, editorId) =>
+            deps.router.dispatch(message, editorId),
+        );
+        bpmnService.registerSession(params.editorId);
+
+        // Seed discovery with the host's authoritative root before the hooks run.
+        // Hoisted above the hook loop is safe: the hooks it now precedes only
+        // register callbacks (broadcaster subscribe + configFolder listener) or
+        // arm the watcher, none of which read the root synchronously.
+        if (params.workspaceRoot) {
+            deps.nodeWorkspace.registerRoot(params.workspaceRoot);
+        }
+
+        // Hooks run last and are awaited to preserve the promise chain
+        // `rpc.handleLine` sees (e.g. the template watcher's async creation).
+        for (const hooks of sessionHooks) {
+            await hooks.onSessionRegistered?.(params);
+        }
+
+        deps.log(`session registered: ${params.editorId}`);
+    });
+
+    deps.rpc.on("webview/message", (params: { editorId: string; message: Command }) => {
+        handles.get(params.editorId)?.receive(params.message);
+    });
+
+    // External edits (git revert/checkout, the IDE's plain-text tab, another
+    // tool) must re-render the open diagram. The host stays dumb and forwards
+    // *every* document change — including the echo of our own `document/write` —
+    // so the bridge classifies them here: `RpcDocumentPort.write` updates the
+    // mirror to the core-originated content before the RPC round-trip, so an
+    // unchanged compare means this is that echo and re-rendering would loop.
+    // Only a genuinely different text is an external edit worth displaying.
+    deps.rpc.on("document/didChange", async (params: { editorId: string; content: string }) => {
+        if (deps.mirror.content(params.editorId) === params.content) {
+            return;
+        }
+        deps.mirror.setContent(params.editorId, params.content);
+        await bpmnService.display(params.editorId);
+    });
+
+    // The host reports which editor tab is focused so the store's active-editor
+    // pointer stays correct with several `.bpmn` files open (commands/diff that
+    // target "the active editor" depend on it).
+    deps.rpc.on("session/setActive", (params: { editorId: string }) => {
+        deps.store.setActiveEditor(params.editorId);
+    });
+
+    deps.rpc.on("session/dispose", (params: { editorId: string }) => {
+        bpmnService.disposeSession(params.editorId);
+
+        // Per-session teardown owned by sibling features (script tabs, code-link
+        // map, template watcher), in the array order `createBridge` fixes.
+        for (const hooks of sessionHooks) {
+            hooks.onSessionDisposed?.(params.editorId);
+        }
+
+        // Read the root before removing the mirror entry that holds it.
+        const workspaceRoot = deps.mirror.peek(params.editorId)?.workspaceRoot;
+        if (workspaceRoot) {
+            deps.nodeWorkspace.unregisterRoot(workspaceRoot);
+        }
+        handles.get(params.editorId)?.dispose();
+        handles.delete(params.editorId);
+        deps.mirror.remove(params.editorId);
+        deps.log(`session disposed: ${params.editorId}`);
+    });
+}

--- a/apps/modeler-bridge/src/composition/navigationFeature.ts
+++ b/apps/modeler-bridge/src/composition/navigationFeature.ts
@@ -1,0 +1,45 @@
+import { Command, NavigateToReferencedModelCommand } from "@miragon/bpmn-modeler-shared";
+import { ModelNavigationService, ReferencedModelLocator } from "@miragon/bpmn-modeler-core";
+
+import { BridgeSharedDeps } from "./sharedDeps";
+
+/**
+ * The navigation feature owns referenced-model resolution: the
+ * {@link ReferencedModelLocator} and {@link ModelNavigationService}, plus the
+ * webview-message handler that opens a called process/decision.
+ *
+ * Webview messages: NavigateToReferencedModelCommand.
+ */
+export function register(deps: BridgeSharedDeps): void {
+    // The model-navigation brain is `vscode`-free, so it runs unmodified here:
+    // the locator searches via NodeWorkspace's findFiles/readFile/readDirectory,
+    // and the service surfaces results through the same notifier/picker the host
+    // already implements over RPC (notifier/openDocument + picker/show).
+    const referencedModelLocator = new ReferencedModelLocator(deps.nodeWorkspace, deps.notifier);
+    const modelNavigationService = new ModelNavigationService(
+        referencedModelLocator,
+        deps.notifier,
+        deps.picker,
+    );
+
+    // Mirrors `navigateToReferencedModelHandler` on the VS Code host: an
+    // unknown discriminant is rejected with a warning rather than falling
+    // through to "decision" by default — defence in depth against a
+    // malformed webview message ever opening the wrong kind of file.
+    deps.router.on(
+        "NavigateToReferencedModelCommand",
+        async (message: Command, editorId: string) => {
+            const cmd = message as NavigateToReferencedModelCommand;
+            if (cmd.referenceKind !== "process" && cmd.referenceKind !== "decision") {
+                deps.notifier.logWarning(
+                    `Ignoring NavigateToReferencedModelCommand with unknown kind: ${String(
+                        cmd.referenceKind,
+                    )}`,
+                );
+                return;
+            }
+            const sourceFsPath = deps.store.requireHandle(editorId).documentFsPath();
+            await modelNavigationService.navigate(cmd.referenceId, cmd.referenceKind, sourceFsPath);
+        },
+    );
+}

--- a/apps/modeler-bridge/src/composition/scriptFeature.ts
+++ b/apps/modeler-bridge/src/composition/scriptFeature.ts
@@ -1,0 +1,57 @@
+import {
+    Command,
+    OpenScriptEditorCommand,
+    UpdateScriptVariablesCommand,
+} from "@miragon/bpmn-modeler-shared";
+
+import { BridgeScriptEditor } from "../scriptAdapters";
+import { BridgeSharedDeps } from "./sharedDeps";
+import { SessionHooks } from "./sessionHooks";
+
+/**
+ * The inline-script-editor feature owns the {@link BridgeScriptEditor}
+ * orchestrator. It returns a session hook so the editor-session feature closes
+ * this editor's open script tabs on dispose — without importing script types.
+ *
+ * Webview messages: OpenScriptEditorCommand, UpdateScriptVariablesCommand.
+ * RPC (Host → Core): script/didChange, script/didClose.
+ */
+export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks } {
+    // "Edit Script" orchestrator. Unlike the other features this one has no
+    // in-core service — the VS Code original was never extracted (its guts are
+    // VS Code-specific accidental complexity) — so the portable slice lives here
+    // and the Kotlin host is a dumb editor surface keyed by an opaque scriptId.
+    const scriptEditor = new BridgeScriptEditor(deps.store, deps.picker, deps.rpc, deps.notifier);
+
+    deps.router
+        .on("OpenScriptEditorCommand", (message: Command, editorId: string) => {
+            void scriptEditor.open(message as OpenScriptEditorCommand, editorId);
+        })
+        // Live process-variable model update → push to every open script tab of
+        // this editor so completion stays current without reopening.
+        .on("UpdateScriptVariablesCommand", (message: Command, editorId: string) => {
+            scriptEditor.updateVariables(
+                editorId,
+                (message as UpdateScriptVariablesCommand).variables,
+            );
+        });
+
+    // The host edited an open script tab → push the new content into the owning
+    // BPMN webview, which writes it to the moddle property via bpmn-js.
+    deps.rpc.on("script/didChange", (params: { scriptId: string; content: string }) => {
+        void scriptEditor.didChange(params.scriptId, params.content);
+    });
+
+    // The user closed a script tab on the host → drop tracking so a re-open
+    // re-reads the current BPMN content rather than revealing a stale tab.
+    deps.rpc.on("script/didClose", (params: { scriptId: string }) => {
+        scriptEditor.didClose(params.scriptId);
+    });
+
+    return {
+        sessionHooks: {
+            // Close any script tabs this editor opened before its handle is dropped.
+            onSessionDisposed: (editorId) => scriptEditor.disposeEditor(editorId),
+        },
+    };
+}

--- a/apps/modeler-bridge/src/composition/sessionHooks.ts
+++ b/apps/modeler-bridge/src/composition/sessionHooks.ts
@@ -1,0 +1,25 @@
+import { SessionMeta } from "../adapters";
+import { SettingsSnapshot } from "../nodeAdapters";
+
+/**
+ * The payload the host sends on `session/register`: the editor identity/meta plus
+ * the initial document content and an optional settings snapshot that must seed
+ * the host-global config before any template discovery runs.
+ */
+export interface RegisterParams extends SessionMeta {
+    content: string;
+    /** Full `miragon.bpmnModeler.*` snapshot; seeds settings before template discovery. */
+    settings?: Partial<SettingsSnapshot>;
+}
+
+/**
+ * The bridge counterpart of the VS Code host's `EditorSessionParticipant`: the
+ * seam that lets a feature keep its own per-session state (template watchers,
+ * script tabs, code-link maps) without the editor-session feature importing it.
+ * Hooks flow backward into {@link editorSessionFeature}'s register/dispose loop
+ * while handles flow forward, so no feature has to know its siblings.
+ */
+export interface SessionHooks {
+    onSessionRegistered?(params: RegisterParams): void | Promise<void>;
+    onSessionDisposed?(editorId: string): void;
+}

--- a/apps/modeler-bridge/src/composition/sharedDeps.ts
+++ b/apps/modeler-bridge/src/composition/sharedDeps.ts
@@ -1,0 +1,87 @@
+import {
+    ArtifactService,
+    EditorSessionStore,
+    WebviewMessageRouter,
+} from "@miragon/bpmn-modeler-core";
+
+import { DocumentMirror, RpcDocumentPort, RpcNotifier, RpcPicker, RpcStatusBar } from "../adapters";
+import { BridgeSettings, NodeWorkspace } from "../nodeAdapters";
+import { Rpc } from "../rpc";
+
+/**
+ * The cross-cutting collaborators every bridge feature draws from: the RPC peer,
+ * the host-capability port adapters, the shared editor-session registry, the one
+ * webview-message router each feature registers its own surface on, and the
+ * stateless `artifactSvc` consumed by templates, code-link, and deployment.
+ * Bundling them lets each feature's `register()` take a single `deps` argument
+ * instead of the long, order-sensitive parameter list `createBridge` would
+ * otherwise thread by hand — the bridge analogue of the VS Code `SharedDeps`.
+ */
+export interface BridgeSharedDeps {
+    rpc: Rpc;
+    log: (message: string) => void;
+    mirror: DocumentMirror;
+    notifier: RpcNotifier;
+    statusBar: RpcStatusBar;
+    documentPort: RpcDocumentPort;
+    nodeWorkspace: NodeWorkspace;
+    settings: BridgeSettings;
+    picker: RpcPicker;
+    store: EditorSessionStore;
+    router: WebviewMessageRouter;
+    artifactSvc: ArtifactService;
+}
+
+/**
+ * Constructs the collaborators shared across features exactly once, so every
+ * feature observes the same RPC peer, session registry, router, and adapter
+ * instances. Only genuinely cross-feature objects live here; feature-specific
+ * infrastructure (services, maps, flags) is built inside the owning feature's
+ * `register()`.
+ */
+export function buildSharedDeps(
+    write: (line: string) => void,
+    log: (message: string) => void,
+): BridgeSharedDeps {
+    const rpc = new Rpc(write);
+
+    const mirror = new DocumentMirror();
+    const notifier = new RpcNotifier(rpc);
+    const statusBar = new RpcStatusBar(rpc);
+    const documentPort = new RpcDocumentPort(rpc, mirror);
+
+    // The element-templates pipeline is the *real* production stack: the only new
+    // code is the two pure-fs/host-fed port adapters (NodeWorkspace/BridgeSettings).
+    // This is what makes the status-bar template count genuine rather than a placeholder.
+    const nodeWorkspace = new NodeWorkspace();
+    const settings = new BridgeSettings();
+
+    // The picker reuses NodeWorkspace for its one filesystem-backed prompt
+    // (pickWorkspaceFiles); every other prompt receives its candidates inline.
+    const picker = new RpcPicker(rpc, nodeWorkspace);
+
+    // onOpenCountChanged is the VS Code setContext hook; irrelevant out-of-process.
+    const store = new EditorSessionStore(() => {});
+
+    const artifactSvc = new ArtifactService(nodeWorkspace, settings);
+
+    // One router shared across features: each feature registers its own
+    // webview-message surface on it. The core enforces one handler per type, so
+    // the registrations are order-independent (see the protocol table in bridge.ts).
+    const router = new WebviewMessageRouter();
+
+    return {
+        rpc,
+        log,
+        mirror,
+        notifier,
+        statusBar,
+        documentPort,
+        nodeWorkspace,
+        settings,
+        picker,
+        store,
+        router,
+        artifactSvc,
+    };
+}

--- a/apps/modeler-bridge/src/composition/templatesSettingsFeature.ts
+++ b/apps/modeler-bridge/src/composition/templatesSettingsFeature.ts
@@ -1,0 +1,94 @@
+import { Command } from "@miragon/bpmn-modeler-shared";
+import { BpmnElementTemplatesService, BpmnSettingsBroadcaster } from "@miragon/bpmn-modeler-core";
+
+import { SettingsSnapshot } from "../nodeAdapters";
+import { BridgeSharedDeps } from "./sharedDeps";
+import { RegisterParams, SessionHooks } from "./sessionHooks";
+
+/**
+ * The templates/settings feature owns element-template discovery
+ * ({@link BpmnElementTemplatesService}), the settings broadcaster, and the
+ * per-session template watchers. The diff dependency arrives as a plain
+ * `onSettingsApplied` callback so this module never imports diff types — the
+ * route is named in `createBridge`. Its session hook arms the per-session
+ * settings/template wiring on register and disposes the watcher on dispose.
+ *
+ * Webview messages: GetElementTemplatesCommand, GetBpmnModelerSettingCommand.
+ * RPC (Host → Core): settings/didChange.
+ */
+export function register(
+    deps: BridgeSharedDeps,
+    handles: { onSettingsApplied: () => void },
+): { sessionHooks: SessionHooks } {
+    const templatesSvc = new BpmnElementTemplatesService(
+        deps.store,
+        deps.documentPort,
+        deps.artifactSvc,
+        deps.statusBar,
+        deps.notifier,
+    );
+
+    // The same broadcaster the VS Code host uses: on a settings change it re-pushes
+    // modeler settings + language to the webview. It is `vscode`-free, so it runs
+    // here unmodified — the only difference is the change events come from the
+    // host's RPC snapshots rather than `workspace.onDidChangeConfiguration`.
+    const settingsBroadcaster = new BpmnSettingsBroadcaster(
+        deps.store,
+        deps.settings,
+        deps.notifier,
+    );
+
+    const watchers = new Map<string, { dispose(): void }[]>();
+
+    deps.router
+        // Inlined rather than importing the VS Code element-templates handler,
+        // whose module pulls in `VsCodeNotifier` → `vscode`, which we must avoid.
+        .on("GetElementTemplatesCommand", (_m: Command, editorId: string) => {
+            void templatesSvc.setElementTemplates(editorId);
+        })
+        // The webview re-requests settings on every (re)load; push the live snapshot
+        // and language, mirroring the VS Code `getBpmnModelerSettingHandler`.
+        .on("GetBpmnModelerSettingCommand", (_m: Command, editorId: string) => {
+            void settingsBroadcaster.setSettings(editorId);
+            settingsBroadcaster.setLanguage(editorId);
+        });
+
+    // One host frame updates every open editor: `apply` fires a SettingChange that
+    // each session's broadcaster + configFolder listener turn into webview pushes.
+    // Diff panes aren't editor sessions, so they need an explicit locale re-push,
+    // delivered via the diff feature's `rebroadcastLanguage` callback.
+    deps.rpc.on("settings/didChange", (params: { settings: Partial<SettingsSnapshot> }) => {
+        deps.settings.apply(params.settings);
+        handles.onSettingsApplied();
+    });
+
+    return {
+        sessionHooks: {
+            onSessionRegistered: async (params: RegisterParams) => {
+                // Mirrors SettingsParticipant + ElementTemplatesParticipant: re-push
+                // modeler/language settings on change, and reload templates when the
+                // config folder moves. Both ride the BridgeSettings change hub via the
+                // handle's onDidChangeSetting; disposed with the session by the store.
+                settingsBroadcaster.subscribe(params.editorId);
+                deps.store.subscribeToSettingChangeEvent(params.editorId, (event, editorId) => {
+                    if (event.affectsConfiguration("miragon.bpmnModeler.configFolder")) {
+                        void templatesSvc.setElementTemplates(editorId);
+                    }
+                });
+
+                // Arm the live-reload watcher (the production `ArtifactService`
+                // wiring, reused verbatim). The authoritative root is registered by
+                // the editor-session feature before this hook runs.
+                const { disposables } = await deps.artifactSvc.createWatcher(
+                    params.editorId,
+                    templatesSvc,
+                );
+                watchers.set(params.editorId, disposables);
+            },
+            onSessionDisposed: (editorId) => {
+                watchers.get(editorId)?.forEach((d) => d.dispose());
+                watchers.delete(editorId);
+            },
+        },
+    };
+}


### PR DESCRIPTION
**Issue**

Closes #1102

**Description**

Splits the ~561-line `createBridge()` monolith in `apps/modeler-bridge/src/bridge.ts` into a 37-line composition root plus per-feature wiring modules under `composition/`, following the precedent in `apps/vscode-plugin/src/composition/`: a `BridgeSharedDeps` bag, per-feature `register()` modules, handles flowing forward (diff's `rebroadcastLanguage` reaches templates/settings via a plain callback) and session lifecycle flowing backward through a `SessionHooks` contract — the bridge's analogue of the VS Code host's `EditorSessionParticipant` — so each feature keeps its own per-session state without the editor-session feature importing it. This is a pure code move: every RPC/webview method is still registered exactly once and all 8 spec files (98 tests) pass unmodified. Verified with typecheck, lint (0 errors), the full test suite, and `build:bridge` (bun compile).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created