### PR TITLE
refactor(intellij): split CoreProcess into supervisor, RPC channel, and feature routers (#1103)

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
@@ -46,7 +46,7 @@ import javax.swing.SwingConstants
  *
  * **Crash recovery note:** diff panes are host-originated and their XML is held
  * here (not in the core's document mirror), so a mid-diff bridge respawn does
- * **not** auto-recover the diff — `CoreProcess.reregisterLiveSessions` covers
+ * **not** auto-recover the diff — `EditorSessionRouter.reregisterLiveSessions` covers
  * editor sessions only. A diff tab is transient and re-openable, so this is an
  * accepted limitation rather than a silent gap.
  */

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -1,39 +1,21 @@
 package io.miragon.intellij.bpmn
 
-import com.google.gson.Gson
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.PathManager
-import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
-import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
-import com.intellij.openapi.ide.CopyPasteManager
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.util.concurrency.AppExecutorUtil
-import java.awt.datatransfer.DataFlavor
-import java.awt.datatransfer.StringSelection
-import java.io.BufferedReader
-import java.io.BufferedWriter
-import java.io.InputStream
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
-import java.nio.charset.StandardCharsets
-import java.nio.file.FileAlreadyExistsException
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardCopyOption
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
+import io.miragon.intellij.bpmn.bridge.BridgeBinaryResolver
+import io.miragon.intellij.bpmn.bridge.BridgeDeps
+import io.miragon.intellij.bpmn.bridge.DeploymentRouter
+import io.miragon.intellij.bpmn.bridge.DiffRouter
+import io.miragon.intellij.bpmn.bridge.EditorSessionRouter
+import io.miragon.intellij.bpmn.bridge.HostUiRouter
+import io.miragon.intellij.bpmn.bridge.ProcessSupervisor
+import io.miragon.intellij.bpmn.bridge.RpcChannel
+import io.miragon.intellij.bpmn.bridge.RpcHandlerRegistry
+import io.miragon.intellij.bpmn.bridge.ScriptRouter
+import io.miragon.intellij.bpmn.bridge.SecretStoreRouter
 
 /**
  * Supervises the out-of-process modeler core and bridges it to the IntelliJ host
@@ -48,6 +30,12 @@ import java.util.concurrent.atomic.AtomicInteger
  *    real IntelliJ `Document`;
  *  - render the core's `NotifierPort` / `StatusBarPort` as IntelliJ UI, and its
  *    `PickerPort` (`picker/show`) as a native `JBPopup` chooser.
+ *
+ * **Role.** This service is the composition root + façade. It wires the bridge
+ * collaborators in `io.miragon.intellij.bpmn.bridge` — the [RpcChannel]
+ * transport, the [ProcessSupervisor], and the per-feature routers populating one
+ * [RpcHandlerRegistry] — and exposes the host-facing API as one-line delegations.
+ * The decomposition mirrors the TS-side `bridge.ts` split into `composition/`.
  *
  * **Topology.** A project-level service: one supervised bridge per project
  * window, lazily spawned on the first editor and torn down with the project.
@@ -64,69 +52,48 @@ import java.util.concurrent.atomic.AtomicInteger
  */
 @Service(Service.Level.PROJECT)
 class CoreProcess(private val project: Project) : Disposable {
-    private val log = Logger.getInstance(CoreProcess::class.java)
-    private val gson = Gson()
-    private val notifications by lazy { HostNotifications(project) }
-    private val secretStore by lazy { IntellijSecretStore() }
-    private val deploymentState by lazy { IntellijDeploymentState.getInstance(project) }
+    // Lazy so the happy path never constructs the UI surface; shared between the
+    // supervisor (spawn-failure errors) and the host-UI router.
+    private val notifications = lazy { HostNotifications(project) }
 
-    // Owns the inline-script editor tabs. Edits stream back as `script/didChange`;
-    // a user closing a tab reports `script/didClose`. Parented to this service so
-    // its listeners die with the project. The core addresses scripts by opaque id.
-    private val scriptEditors by lazy {
-        ScriptEditorManager(
-            project,
-            this,
-            onChange = { scriptId, content ->
-                notify("script/didChange", linkedMapOf("scriptId" to scriptId, "content" to content))
-            },
-            onUserClose = { scriptId ->
-                notify("script/didClose", linkedMapOf("scriptId" to scriptId))
-            },
+    private val handlers = RpcHandlerRegistry()
+    private val channel = RpcChannel { method, params, id -> handlers.dispatch(method, params, id) }
+    private val supervisor: ProcessSupervisor =
+        ProcessSupervisor(
+            channel = channel,
+            binaryResolver = BridgeBinaryResolver(),
+            notifications = { notifications.value },
+            // Declared after the supervisor; safe because both lambdas only fire
+            // post-construction, on the first (re)spawn.
+            onSpawned = { deploymentRouter.sendSeed() },
+            onRespawned = { editorRouter.reregisterLiveSessions() },
         )
-    }
-
-    private val sessions = ConcurrentHashMap<String, CoreSession>()
-
-    // The deployment tool window's core→webview sink. One tool window per project,
-    // so a later register replaces the previous sink (null when closed).
-    @Volatile
-    private var deploymentSink: ((String) -> Unit)? = null
-
-    // Diff panes route by `paneUri`, not editor id: a diff has two browsers and
-    // is host-originated. `diffPanes` maps each pane's URI to its core→webview
-    // sink; `diffPaneUris` lets `disposeDiff` drop both panes of a diff at once.
-    private val diffPanes = ConcurrentHashMap<String, (String) -> Unit>()
-    private val diffPaneUris = ConcurrentHashMap<String, List<String>>()
-
-    private val writeLock = Any()
-
-    // Read unsynchronized from pushSettings/reregisterLiveSessions/dispose and the
-    // shutdown hook, so its writes must publish safely across threads.
-    @Volatile
-    private var process: Process? = null
-    private var writer: BufferedWriter? = null
-
-    private val disposed = AtomicBoolean(false)
-    private val restartAttempts = AtomicInteger(0)
-
-    @Volatile
-    private var lastSpawnAt = 0L
-
-    @Volatile
-    private var cachedBinary: Path? = null
-    private var shutdownHook: Thread? = null
-
-    // Outbound (host→core) frames are drained by a single writer thread so the
-    // EDT / JCEF threads never block on the bridge's stdin. The deque also enables
-    // coalescing: a flood of document syncs collapses to its latest frame.
-    private data class OutFrame(val line: String, val coalesceKey: String?)
-
-    private val outbound = ArrayDeque<OutFrame>()
-    private val outboundMonitor = Object()
-    private var writerThread: Thread? = null
+    private val deps =
+        BridgeDeps(
+            project = project,
+            channel = channel,
+            handlers = handlers,
+            gson = channel.gson,
+            isProcessAlive = { supervisor.isAlive },
+            ensureStartedAsync = { supervisor.ensureStartedAsync() },
+            parentDisposable = this,
+            notifications = notifications,
+        )
+    private val editorRouter = EditorSessionRouter(deps)
+    private val deploymentRouter = DeploymentRouter(deps)
+    private val diffRouter = DiffRouter(deps)
+    private val scriptRouter = ScriptRouter(deps)
+    private val secretStoreRouter = SecretStoreRouter(deps)
+    private val hostUiRouter = HostUiRouter(deps)
 
     init {
+        editorRouter.register()
+        deploymentRouter.register()
+        diffRouter.register()
+        scriptRouter.register()
+        secretStoreRouter.register()
+        hostUiRouter.register()
+
         // Keep the core's active-editor pointer in sync with the focused tab so
         // operations that target "the active editor" address the right session
         // when several `.bpmn` files are open. Parented to this service, so the
@@ -135,273 +102,42 @@ class CoreProcess(private val project: Project) : Disposable {
             FileEditorManagerListener.FILE_EDITOR_MANAGER,
             object : FileEditorManagerListener {
                 override fun selectionChanged(event: FileEditorManagerEvent) {
-                    event.newFile?.url?.let { setActiveEditor(it) }
+                    event.newFile?.url?.let { editorRouter.setActiveEditor(it) }
                 }
             },
         )
     }
 
-    // ── lifecycle ────────────────────────────────────────────────────────────
+    // ── lifecycle ──────────────────────────────────────────────────────────────
 
-    @Synchronized
-    private fun ensureStarted() {
-        if (process?.isAlive == true) return
-        spawn()
-    }
+    /** Pre-warms the bridge at project open so the first surface renders against a live process. */
+    fun prewarm() = supervisor.prewarm()
 
-    /**
-     * Brings the bridge up **off the EDT** when it isn't already running.
-     *
-     * `spawn()` does blocking process I/O — `ProcessBuilder.start()` can stall for
-     * seconds on Windows while Defender scans the freshly materialised binary — so
-     * it must never run on the caller's thread when that caller is the EDT (editor,
-     * diff, or tool-window construction). Callers enqueue their first frame
-     * synchronously instead; the writer thread drains it once the process is up, so
-     * nothing is lost by deferring the spawn.
-     */
-    private fun ensureStartedAsync() {
-        if (process?.isAlive == true) return
-        AppExecutorUtil.getAppScheduledExecutorService().execute {
-            if (disposed.get()) return@execute
-            ensureStarted()
-        }
-    }
+    // ── editor sessions ──────────────────────────────────────────────────────────
 
-    /**
-     * Pre-warms the bridge at project open so the first `.bpmn` tab, diff, or
-     * deployment panel renders against an already-running process instead of
-     * waiting on a cold spawn. Safe to call repeatedly — no-ops once alive.
-     */
-    fun prewarm() = ensureStartedAsync()
+    fun registerSession(session: CoreSession) = editorRouter.registerSession(session)
 
-    private fun spawn() {
-        val binary =
-            try {
-                resolveBridgeBinary()
-            } catch (e: Exception) {
-                log.error("Failed to resolve the bundled modeler bridge binary", e)
-                notifications.showError("Could not start the BPMN modeler engine: ${e.message}")
-                return
-            }
-        try {
-            val started = ProcessBuilder(binary.toString()).redirectErrorStream(false).start()
-            synchronized(writeLock) {
-                process = started
-                writer = BufferedWriter(OutputStreamWriter(started.outputStream, StandardCharsets.UTF_8))
-            }
-            lastSpawnAt = System.currentTimeMillis()
-            pump(started.inputStream) { onLine(it) }
-            // stderr is the core's diagnostic channel (stdout is reserved for RPC).
-            pump(started.errorStream) { log.info("[bridge stderr] $it") }
-            started.onExit().thenAccept { handleExit(started) }
-            ensureWriterThread()
-            ensureShutdownHook()
-            // Seed the deployment-state mirror up front so the bridge's synchronous
-            // getters are correct; re-runs on every (re)spawn, rebuilding the mirror.
-            sendDeploymentSeed()
-            log.info("Miragon modeler bridge started: $binary")
-        } catch (e: Exception) {
-            log.error("Failed to start the modeler bridge", e)
-            notifications.showError("Could not start the BPMN modeler engine. See idea.log.")
-        }
-    }
+    fun notifyDocumentChanged(editorId: String, content: String) = editorRouter.notifyDocumentChanged(editorId, content)
 
-    /**
-     * Reacts to the bridge process dying. Distinguishes a stable run that
-     * crashed (reset the attempt counter) from a rapid restart loop (give up
-     * after [MAX_RESTARTS]); on a survivable crash, respawns with linear backoff
-     * and recovers every open editor.
-     */
-    private fun handleExit(dead: Process) {
-        if (disposed.get()) return
-        synchronized(writeLock) {
-            if (process !== dead) return // already replaced by a newer spawn
-            writer = null
-        }
+    fun forwardWebviewMessage(editorId: String, rawMessage: String) = editorRouter.forwardWebviewMessage(editorId, rawMessage)
 
-        if (System.currentTimeMillis() - lastSpawnAt > STABLE_RUN_MS) {
-            restartAttempts.set(0)
-        }
-        val attempt = restartAttempts.incrementAndGet()
-        if (attempt > MAX_RESTARTS) {
-            log.error("Modeler bridge exited $attempt times in quick succession; giving up.")
-            notifications.showError(
-                "The BPMN modeler engine crashed repeatedly and will not be restarted. " +
-                    "Reopen the file or restart the IDE. See idea.log.",
-            )
-            return
-        }
-        log.warn(
-            "Modeler bridge exited (code ${runCatching { dead.exitValue() }.getOrNull()}); " +
-                "restart attempt $attempt/$MAX_RESTARTS",
-        )
+    fun disposeSession(editorId: String) = editorRouter.disposeSession(editorId)
 
-        // Respawn off this thread, not via Thread.sleep: handleExit runs on the
-        // Process.onExit() CompletableFuture callback (ForkJoinPool.commonPool),
-        // and blocking it for the backoff would hold a shared platform pool
-        // thread for up to seconds. Re-check disposed/liveness at fire time.
-        AppExecutorUtil.getAppScheduledExecutorService().schedule(
-            {
-                if (disposed.get()) return@schedule
-                synchronized(this) { if (process?.isAlive != true) spawn() }
-                reregisterLiveSessions()
-            },
-            RESTART_BACKOFF_MS * attempt,
-            TimeUnit.MILLISECONDS,
-        )
-    }
-
-    /**
-     * Re-seeds every open session into a freshly spawned bridge (the document
-     * mirror is rebuilt from the live IntelliJ `Document`, the authoritative
-     * source) and replays `GetBpmnFileCommand` so the still-alive JCEF page
-     * re-renders without a reload.
-     */
-    private fun reregisterLiveSessions() {
-        if (process?.isAlive != true) return
-        sessions.values.forEach { session ->
-            sendRegister(session)
-            forwardWebviewMessage(session.editorId, GET_BPMN_FILE_COMMAND)
-        }
-    }
-
-    // ── host → core ──────────────────────────────────────────────────────────
-
-    /** Registers an editor and tells the core to open it (seeding the document mirror). */
-    fun registerSession(session: CoreSession) {
-        sessions[session.editorId] = session
-        // Enqueue the register frame now and spawn off the EDT: the outbound queue
-        // buffers it until the writer exists, so editor construction never blocks on
-        // the (occasionally seconds-long) process start.
-        sendRegister(session)
-        ensureStartedAsync()
-    }
-
-    private fun sendRegister(session: CoreSession) {
-        val content =
-            ReadAction.compute<String, RuntimeException> {
-                FileDocumentManager.getInstance().getDocument(session.file)?.text.orEmpty()
-            }
-        notify(
-            "session/register",
-            linkedMapOf(
-                "editorId" to session.editorId,
-                "uriString" to session.editorId,
-                "path" to session.file.path,
-                "fsPath" to session.file.path,
-                "scheme" to "file",
-                // Authoritative IntelliJ project root for element-template
-                // discovery; falls back to the file's dir for light-edit
-                // projects where basePath is null.
-                "workspaceRoot" to (project.basePath ?: session.file.parent?.path),
-                // Seed the core's SettingsPort before it scans templates, so the
-                // very first discovery uses the configured folder, not the default.
-                "settings" to ModelerSettingsStore.getInstance().snapshotMap(),
-                "content" to content,
-            ),
-        )
-    }
-
-    /**
-     * Pushes the current settings snapshot to the running core so an open editor
-     * reacts live (language re-render, configFolder template reload). No-ops when
-     * no bridge is alive: the snapshot is re-seeded on the next [sendRegister].
-     */
-    fun pushSettings() {
-        if (process?.isAlive != true) return
-        notify("settings/didChange", linkedMapOf("settings" to ModelerSettingsStore.getInstance().snapshotMap()))
-    }
-
-    /** Forwards one raw webview message (already JSON) to the core untouched. */
-    fun forwardWebviewMessage(editorId: String, rawMessage: String) {
-        val parsed =
-            try {
-                JsonParser.parseString(rawMessage)
-            } catch (e: Exception) {
-                log.warn("Discarding malformed webview message: $rawMessage", e)
-                return
-            }
-        val type = (parsed as? JsonObject)?.get("type")?.takeIf { !it.isJsonNull }?.asString
-        // Document syncs fire once per diagram edit and supersede each other —
-        // only the latest XML matters for write-back — so collapse queued ones.
-        val coalesceKey = if (type == "SyncDocumentCommand") "sync:$editorId" else null
-        notify("webview/message", linkedMapOf("editorId" to editorId, "message" to parsed), coalesceKey)
-    }
-
-    /**
-     * Forwards a document change to the core so external edits (git revert/
-     * checkout, the plain-text tab, another tool) re-render the diagram. The host
-     * stays dumb: it reports *every* change, including the echo of its own
-     * `document/write`. The bridge tells the two apart — re-rendering our own
-     * write would loop, so it is filtered there, not here.
-     */
-    fun notifyDocumentChanged(editorId: String, content: String) {
-        if (!sessions.containsKey(editorId)) return
-        notify("document/didChange", linkedMapOf("editorId" to editorId, "content" to content))
-    }
-
-    /** Tells the core which open editor is focused (drives its active-editor pointer). */
-    private fun setActiveEditor(editorId: String) {
-        if (!sessions.containsKey(editorId)) return
-        notify("session/setActive", linkedMapOf("editorId" to editorId))
-    }
-
-    fun disposeSession(editorId: String) {
-        sessions.remove(editorId)
-        notify("session/dispose", linkedMapOf("editorId" to editorId))
-    }
+    /** Pushes the current settings snapshot to the running core so an open editor reacts live. */
+    fun pushSettings() = editorRouter.pushSettings()
 
     // ── deployment tool window ─────────────────────────────────────────────────
 
-    /**
-     * Registers the deployment tool window's core→webview sink and (re-)seeds the
-     * deployment-state mirror. One tool window per project, so a later register
-     * replaces the previous sink.
-     */
-    fun registerDeploymentWindow(sink: (String) -> Unit) {
-        deploymentSink = sink
-        // Seed now if the bridge is already up; otherwise spawn() re-seeds on start.
-        // Spawning runs off the EDT so the tool window opens without blocking.
-        sendDeploymentSeed()
-        ensureStartedAsync()
-    }
+    fun registerDeploymentWindow(sink: (String) -> Unit) = deploymentRouter.registerDeploymentWindow(sink)
 
-    /** Drops the deployment sink and marks the panel closed (stops default refreshes). */
-    fun unregisterDeploymentWindow() {
-        deploymentSink = null
-        notify("deployment/open", linkedMapOf("open" to false))
-    }
+    fun unregisterDeploymentWindow() = deploymentRouter.unregisterDeploymentWindow()
 
-    /** Forwards one raw deployment-webview message (already JSON) to the core untouched. */
-    fun forwardDeploymentMessage(rawMessage: String) {
-        val parsed =
-            try {
-                JsonParser.parseString(rawMessage)
-            } catch (e: Exception) {
-                log.warn("Discarding malformed deployment message: $rawMessage", e)
-                return
-            }
-        notify("deployment/webviewMessage", linkedMapOf("message" to parsed))
-    }
+    fun forwardDeploymentMessage(rawMessage: String) = deploymentRouter.forwardDeploymentMessage(rawMessage)
 
-    /** Tells the core whether the deployment panel is visible (drives form-default refresh). */
-    fun setDeploymentOpen(open: Boolean) {
-        notify("deployment/open", linkedMapOf("open" to open))
-    }
+    fun setDeploymentOpen(open: Boolean) = deploymentRouter.setDeploymentOpen(open)
 
-    private fun sendDeploymentSeed() {
-        if (process?.isAlive != true) return
-        notify("deploymentState/seed", linkedMapOf("state" to deploymentState.snapshotMap()))
-    }
+    // ── diff ─────────────────────────────────────────────────────────────────────
 
-    /**
-     * Starts a host-originated diff session in the core. Both sides are known up
-     * front (IntelliJ resolves the diff with HEAD and working-tree contents in
-     * hand), so the core arms a fully-paired diff session immediately — no
-     * VS Code-style out-of-order pane resolution. `postToBefore`/`postToAfter`
-     * sink core→webview messages into each side's JCEF browser; `beforeUri`/
-     * `afterUri` are the diff-scoped pane identities the core routes replies by.
-     */
     fun openDiff(
         diffId: String,
         origin: String,
@@ -411,546 +147,16 @@ class CoreProcess(private val project: Project) : Disposable {
         afterUri: String,
         afterContent: String,
         postToAfter: (String) -> Unit,
-    ) {
-        diffPanes[beforeUri] = postToBefore
-        diffPanes[afterUri] = postToAfter
-        diffPaneUris[diffId] = listOf(beforeUri, afterUri)
-        // Route the panes, enqueue diff/open, then spawn off the EDT (the queue
-        // holds the frame until the writer exists), so opening a diff never blocks.
-        notify(
-            "diff/open",
-            linkedMapOf(
-                "diffId" to diffId,
-                "origin" to origin,
-                "before" to linkedMapOf("uri" to beforeUri, "content" to beforeContent),
-                "after" to linkedMapOf("uri" to afterUri, "content" to afterContent),
-            ),
-        )
-        ensureStartedAsync()
-    }
+    ) = diffRouter.openDiff(diffId, origin, beforeUri, beforeContent, postToBefore, afterUri, afterContent, postToAfter)
 
-    /** Forwards one raw diff-pane webview message (already JSON) to the core. */
-    fun forwardDiffMessage(paneUri: String, rawMessage: String) {
-        val message =
-            try {
-                JsonParser.parseString(rawMessage)
-            } catch (e: Exception) {
-                log.warn("Discarding malformed diff message: $rawMessage", e)
-                return
-            }
-        notify("diff/webviewMessage", linkedMapOf("paneUri" to paneUri, "message" to message))
-    }
+    fun forwardDiffMessage(paneUri: String, rawMessage: String) = diffRouter.forwardDiffMessage(paneUri, rawMessage)
 
-    /**
-     * Tears a diff down: drops both panes' sinks (so a stray late reply can't
-     * resurrect a closed pane) and tells the core to retire the session. Called
-     * on tab close and, with an immediate re-`openDiff`, on swap.
-     */
-    fun disposeDiff(diffId: String) {
-        diffPaneUris.remove(diffId)?.forEach { diffPanes.remove(it) }
-        notify("diff/dispose", linkedMapOf("diffId" to diffId))
-    }
-
-    // ── core → host ──────────────────────────────────────────────────────────
-
-    /** Dispatches one line received from the core's stdout. */
-    private fun onLine(line: String) {
-        val message =
-            try {
-                gson.fromJson(line, JsonObject::class.java)
-            } catch (e: Exception) {
-                log.warn("Discarding malformed core message: $line", e)
-                return
-            }
-        // The host issues no requests to the core, so a frame without `method`
-        // (i.e. a response) is never expected and is ignored.
-        val method = message.get("method")?.takeIf { !it.isJsonNull }?.asString ?: return
-        val params = message.getAsJsonObject("params")
-        val id = message.get("id")?.takeIf { !it.isJsonNull }?.asInt
-
-        // A malformed/unexpected frame (missing member, wrong type, a throwing
-        // handler such as a failing PasswordSafe call) must not escape: this runs
-        // on the daemon reader thread, and an escaped exception would kill the
-        // pump — core→host traffic stops forever, and once the stdout pipe fills
-        // the bridge wedges without exiting, so the crash supervisor never fires.
-        // If the frame was a request, also answer it: an unanswered request would
-        // otherwise leak the core's awaiting promise.
-        try {
-            dispatch(method, params, id)
-        } catch (e: Exception) {
-            log.warn("Failed to handle core message ($method): $line", e)
-            id?.let { replyError(it, e.message ?: "host handler failed") }
-        }
-    }
-
-    /** Routes one decoded core frame to its handler. See [onLine] for failure handling. */
-    private fun dispatch(method: String, params: JsonObject, id: Int?) {
-        when (method) {
-            "editor/postMessage" -> {
-                val editorId = params.get("editorId").asString
-                // `message` is a JSON object; re-serialise it as the postMessage payload.
-                val payload = gson.toJson(params.get("message"))
-                sessions[editorId]?.postToWebview(payload)
-            }
-            "diff/postMessage" -> {
-                val paneUri = params.get("paneUri").asString
-                val payload = gson.toJson(params.get("message"))
-                diffPanes[paneUri]?.invoke(payload)
-            }
-            "deployment/postMessage" -> {
-                val payload = gson.toJson(params.get("message"))
-                deploymentSink?.invoke(payload)
-            }
-            // PropertiesComponent writes are thread-safe and run on the reader
-            // thread here (same as the secretStore handlers below).
-            "deploymentState/saveAuthType" ->
-                deploymentState.saveAuthType(params.get("authType").asString)
-            "deploymentState/saveOAuth2Config" ->
-                deploymentState.saveOAuth2Config(
-                    params.get("tokenEndpoint").asString,
-                    params.get("audience").asString,
-                )
-            "deploymentState/save" ->
-                deploymentState.save(
-                    params.get("endpoint").asString,
-                    params.get("tenantId").asString,
-                )
-            // Inline-script editor: the host is a dumb surface keyed by scriptId.
-            // `completion` is optional and carries the kind-scoped catalog the
-            // bridge already resolved; fromJson tolerates a missing/null member.
-            "script/open" ->
-                scriptEditors.openScript(
-                    params.get("scriptId").asString,
-                    params.get("fileName").asString,
-                    params.get("content").asString,
-                    gson.fromJson(params.get("completion"), ScriptCompletionModel::class.java),
-                )
-            "script/close" -> scriptEditors.closeScript(params.get("scriptId").asString)
-            // Live variable model push: swap the script tab's completion catalog
-            // so the next completion invocation sees the current variables.
-            "script/updateVariables" ->
-                scriptEditors.updateVariables(
-                    params.get("scriptId").asString,
-                    gson.fromJson(
-                        params.get("variables"),
-                        Array<VariableInfo>::class.java,
-                    ).orEmpty().toList(),
-                )
-            "document/write" -> handleWrite(params, id)
-            "document/save" -> handleSave(params, id)
-            "picker/show" -> handlePick(params, id)
-            "clipboard/read" -> handleClipboardRead(id)
-            "clipboard/write" -> handleClipboardWrite(params)
-            "statusBar/showEngineVersion" -> {
-                val label = if (params.get("platform")?.asString == "c7") "Camunda 7" else "Camunda 8"
-                EngineStatusBarWidget.updateEngine(project, "$label ${params.get("version")?.asString}")
-            }
-            "statusBar/hideEngineVersion", "statusBar/disposeEngineVersion" ->
-                EngineStatusBarWidget.updateEngine(project, null)
-            "statusBar/templatesReady" ->
-                EngineStatusBarWidget.updateTemplateCount(project, params.get("count")?.asInt ?: 0)
-            "statusBar/templatesHide" -> EngineStatusBarWidget.updateTemplateCount(project, null)
-            "statusBar/templatesLoading" -> Unit // transient; the count frame follows
-            "notifier/showInfo" -> notifications.showInfo(params.get("message").asString)
-            "notifier/showError" -> notifications.showError(params.get("message").asString)
-            "notifier/notifyError" ->
-                notifications.notifyError(params.get("context").asString, params.get("message").asString)
-            "notifier/openConsole" -> notifications.openLoggingConsole()
-            "notifier/openDocument" -> notifications.openDocument(params.get("path").asString)
-            "notifier/log" ->
-                notifications.log(params.get("level")?.asString, params.get("message")?.asString.orEmpty())
-            "notifier/progressStart", "notifier/progressEnd" ->
-                log.debug("$method: ${params.get("title")?.asString}")
-            // PasswordSafe get/set block and must stay off the EDT; onLine runs on
-            // the background reader thread, so calling them inline here is safe.
-            "secretStore/saveBasicAuth" -> {
-                secretStore.saveBasicAuth(params.get("username").asString, params.get("password").asString)
-                id?.let { reply(it, null) }
-            }
-            "secretStore/getBasicAuth" -> {
-                val creds = secretStore.getBasicAuth()
-                val username = creds?.userName
-                val password = creds?.getPasswordAsString()
-                id?.let {
-                    reply(
-                        it,
-                        if (username != null && password != null) {
-                            mapOf("username" to username, "password" to password)
-                        } else {
-                            null
-                        },
-                    )
-                }
-            }
-            "secretStore/saveOAuth2" -> {
-                secretStore.saveOAuth2(params.get("clientId").asString, params.get("clientSecret").asString)
-                id?.let { reply(it, null) }
-            }
-            "secretStore/getOAuth2" -> {
-                val creds = secretStore.getOAuth2()
-                val clientId = creds?.userName
-                val clientSecret = creds?.getPasswordAsString()
-                id?.let {
-                    reply(
-                        it,
-                        if (clientId != null && clientSecret != null) {
-                            mapOf("clientId" to clientId, "clientSecret" to clientSecret)
-                        } else {
-                            null
-                        },
-                    )
-                }
-            }
-            else -> log.debug("Unhandled core method: $method")
-        }
-    }
-
-    /**
-     * Writes core-supplied XML into the in-memory Document on the EDT, then replies
-     * with whether the content actually changed (the `DocumentPort.write` contract).
-     * IntelliJ Documents require `\n`; webview XML may carry `\r\n`.
-     */
-    private fun handleWrite(params: JsonObject, id: Int?) {
-        val editorId = params.get("editorId").asString
-        val content = StringUtil.convertLineSeparators(params.get("content").asString)
-        val session = sessions[editorId]
-        if (session == null) {
-            id?.let { reply(it, mapOf("changed" to false)) }
-            return
-        }
-        ApplicationManager.getApplication().invokeLater {
-            var changed = false
-            if (!session.project.isDisposed) {
-                val document = FileDocumentManager.getInstance().getDocument(session.file)
-                if (document != null && document.text != content) {
-                    WriteCommandAction.runWriteCommandAction(session.project) {
-                        document.setText(content)
-                    }
-                    changed = true
-                }
-            }
-            id?.let { reply(it, mapOf("changed" to changed)) }
-        }
-    }
-
-    private fun handleSave(params: JsonObject, id: Int?) {
-        val editorId = params.get("editorId").asString
-        val session = sessions[editorId]
-        ApplicationManager.getApplication().invokeLater {
-            if (session != null && !session.project.isDisposed) {
-                val document = FileDocumentManager.getInstance().getDocument(session.file)
-                if (document != null) FileDocumentManager.getInstance().saveDocument(document)
-            }
-            id?.let { reply(it, mapOf("saved" to true)) }
-        }
-    }
-
-    /**
-     * Shows a native list popup for the core's `PickerPort` and replies with the
-     * chosen item indices, or `null` on dismissal. The host renders only the
-     * chooser; the cancel-vs-throw convention is applied core-side.
-     */
-    private fun handlePick(params: JsonObject, id: Int?) {
-        // A picker prompt is always a request expecting a reply; a missing id
-        // would mean nothing to answer, so there is nothing to do.
-        if (id == null) return
-        val title = params.get("title")?.takeIf { !it.isJsonNull }?.asString
-        val placeholder = params.get("placeholder")?.takeIf { !it.isJsonNull }?.asString.orEmpty()
-        val canPickMany = params.get("canPickMany")?.takeIf { !it.isJsonNull }?.asBoolean ?: false
-        val items =
-            params.getAsJsonArray("items").mapIndexed { index, element ->
-                val obj = element.asJsonObject
-                HostPicker.PickItem(
-                    index,
-                    obj.get("label").asString,
-                    obj.get("description")?.takeIf { !it.isJsonNull }?.asString,
-                )
-            }
-        ApplicationManager.getApplication().invokeLater {
-            if (project.isDisposed) {
-                reply(id, mapOf("selected" to null))
-                return@invokeLater
-            }
-            HostPicker.show(project, title, placeholder, canPickMany, items) { selected ->
-                reply(id, mapOf("selected" to selected))
-            }
-        }
-    }
-
-    /**
-     * Reads the system clipboard for the webview's copy/paste mediator. The
-     * sandboxed JCEF page can't touch the clipboard and the core is a separate
-     * process, so the host reads on their behalf and replies with the text.
-     * `runCatching` → `""` keeps a denied/empty/non-text clipboard from breaking
-     * paste — an empty string is a valid "nothing to paste" answer.
-     */
-    private fun handleClipboardRead(id: Int?) {
-        ApplicationManager.getApplication().invokeLater {
-            val text =
-                runCatching {
-                    CopyPasteManager.getInstance().getContents<String>(DataFlavor.stringFlavor)
-                }.getOrNull().orEmpty()
-            id?.let { reply(it, mapOf("text" to text)) }
-        }
-    }
-
-    /** Writes the webview's copied text onto the system clipboard (fire-and-forget). */
-    private fun handleClipboardWrite(params: JsonObject) {
-        val text = params.get("text")?.takeIf { !it.isJsonNull }?.asString.orEmpty()
-        ApplicationManager.getApplication().invokeLater {
-            CopyPasteManager.getInstance().setContents(StringSelection(text))
-        }
-    }
-
-    // ── outbound transport (single writer thread + coalescing backpressure) ───
-
-    private fun notify(method: String, params: Any?, coalesceKey: String? = null) =
-        enqueue(gson.toJson(linkedMapOf("method" to method, "params" to params)), coalesceKey)
-
-    private fun reply(id: Int, result: Any?) =
-        enqueue(gson.toJson(linkedMapOf("id" to id, "result" to result)), null)
-
-    // The bridge's `rpc.ts` turns `{id, error}` into a rejected promise, so a
-    // handler that throws still settles the core's awaiting request instead of
-    // leaking it.
-    private fun replyError(id: Int, message: String) =
-        enqueue(gson.toJson(linkedMapOf("id" to id, "error" to message)), null)
-
-    private fun enqueue(line: String, coalesceKey: String?) {
-        synchronized(outboundMonitor) {
-            if (coalesceKey != null) {
-                val iterator = outbound.iterator()
-                while (iterator.hasNext()) {
-                    if (iterator.next().coalesceKey == coalesceKey) iterator.remove()
-                }
-            }
-            if (outbound.size >= OUTBOUND_CAPACITY) {
-                outbound.removeFirst()
-                log.warn("Outbound bridge queue full ($OUTBOUND_CAPACITY); dropped oldest frame (backpressure)")
-            }
-            outbound.addLast(OutFrame(line, coalesceKey))
-            outboundMonitor.notifyAll()
-        }
-    }
-
-    private fun ensureWriterThread() {
-        if (writerThread != null) return
-        writerThread =
-            Thread({ writerLoop() }, "modeler-bridge-writer").apply {
-                isDaemon = true
-                start()
-            }
-    }
-
-    private fun writerLoop() {
-        while (!disposed.get()) {
-            val frame =
-                synchronized(outboundMonitor) {
-                    while (outbound.isEmpty() && !disposed.get()) outboundMonitor.wait()
-                    if (disposed.get()) return else outbound.removeFirst()
-                }
-            val target = synchronized(writeLock) { writer }
-            if (target == null) {
-                // No live bridge stdin (restart window). Drop rather than spin:
-                // sessions are re-seeded from the authoritative Document on restart.
-                log.debug("No bridge writer; dropped a queued frame during restart")
-                continue
-            }
-            try {
-                synchronized(writeLock) {
-                    target.write(frame.line)
-                    target.write("\n")
-                    target.flush()
-                }
-            } catch (e: Exception) {
-                log.warn("Failed to write to bridge stdin", e)
-            }
-        }
-    }
-
-    // ── binary resolution + plumbing ──────────────────────────────────────────
-
-    /**
-     * Returns the path to a runnable bridge binary: a dev override if set, else
-     * the bundled per-platform binary extracted to a stable, version-keyed cache
-     * under the IDE system dir, made executable, and cached for this service's
-     * lifetime.
-     *
-     * The stable path is load-bearing on Windows. Extracting to a brand-new
-     * `%TEMP%` file every session (the old behaviour) defeats Defender's scan
-     * cache: launching a never-before-seen executable triggers a synchronous
-     * on-execution scan *inside* `CreateProcess` that can freeze the caller for
-     * seconds. Keying the path by plugin version means Defender re-scans only on
-     * the first launch after an install/upgrade, then reuses its verdict.
-     */
-    private fun resolveBridgeBinary(): Path {
-        (System.getProperty("miragon.bridge") ?: System.getenv("MIRAGON_BRIDGE"))?.let {
-            return Path.of(it)
-        }
-        cachedBinary?.let { return it }
-
-        val platform = platformDir()
-        // Windows refuses to launch an executable without the `.exe` suffix. Bun's
-        // `--target=bun-windows-x64` produces `modeler-bridge.exe` and Gradle
-        // stages it under the same name, so we mirror that here.
-        val isWindows = platform.startsWith("windows")
-        val binaryName = if (isWindows) "$BRIDGE_BINARY_NAME.exe" else BRIDGE_BINARY_NAME
-        val resource = "/bin/$platform/$binaryName"
-
-        val cacheDir = Path.of(PathManager.getSystemPath(), CACHE_SUBDIR, bridgeCacheKey())
-        val target = cacheDir.resolve(binaryName)
-        if (!Files.isRegularFile(target)) {
-            extractBridge(resource, cacheDir, target)
-            pruneStaleCaches(cacheDir)
-        }
-        // Re-assert the exec bit cheaply in case a prior session extracted the file
-        // but failed to set it (or the bit was cleared out from under us).
-        target.toFile().setExecutable(true, true)
-        cachedBinary = target
-        return target
-    }
-
-    /**
-     * Materialises the bundled bridge at [target] atomically: extraction goes to a
-     * sibling temp file, then an atomic move into place, so a crash mid-copy never
-     * leaves a truncated binary that would fail to launch. Two IDE windows (each
-     * with its own project-level service) can race here; the loser's move fails
-     * with [FileAlreadyExistsException] and simply reuses the winner's file.
-     */
-    private fun extractBridge(resource: String, cacheDir: Path, target: Path) {
-        val stream =
-            javaClass.getResourceAsStream(resource)
-                ?: error(
-                    "No bundled modeler bridge ($resource). " +
-                        "Build it with `corepack yarn workspace @miragon/bpmn-modeler-bridge compile`.",
-                )
-        Files.createDirectories(cacheDir)
-        val temp = Files.createTempFile(cacheDir, BRIDGE_BINARY_NAME, ".tmp")
-        try {
-            stream.use { Files.copy(it, temp, StandardCopyOption.REPLACE_EXISTING) }
-            temp.toFile().setExecutable(true, true)
-            try {
-                Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE)
-            } catch (e: FileAlreadyExistsException) {
-                // Another IDE window extracted it first; its copy is authoritative.
-                log.debug("Bridge already extracted by a concurrent window: ${e.message}")
-            }
-        } finally {
-            Files.deleteIfExists(temp)
-        }
-    }
-
-    /**
-     * Cache-directory segment that changes whenever the shipped binary might
-     * differ. Keyed by plugin version so an upgrade re-extracts (and Defender
-     * re-scans once); falls back to `"dev"` when the version is unavailable — fine
-     * because dev runs use the `MIRAGON_BRIDGE` override checked above.
-     */
-    private fun bridgeCacheKey(): String = PluginManager.getPluginByClass(javaClass)?.version ?: "dev"
-
-    /**
-     * Best-effort removal of *other* version dirs so extracted binaries don't
-     * accumulate (~tens of MB each) across plugin upgrades. Runs only right after a
-     * fresh extraction — i.e. once per new version. Deleting a binary another IDE
-     * window (running an older plugin version) is currently executing is safe:
-     * POSIX keeps the running inode alive after unlink, and Windows locks the file
-     * so the delete simply fails and is retried on the next upgrade. Hence all
-     * failures are swallowed.
-     */
-    private fun pruneStaleCaches(currentVersionDir: Path) {
-        val root = currentVersionDir.parent ?: return
-        runCatching {
-            Files.list(root).use { entries ->
-                entries
-                    .filter { Files.isDirectory(it) && it != currentVersionDir }
-                    .forEach { stale ->
-                        runCatching {
-                            Files.walk(stale).use { paths ->
-                                // Deepest-first so directories are emptied before removal.
-                                paths.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
-                            }
-                        }
-                    }
-            }
-        }
-    }
-
-    private fun platformDir(): String {
-        val os = System.getProperty("os.name").lowercase()
-        val arch = System.getProperty("os.arch").lowercase()
-        val osPart =
-            when {
-                os.contains("mac") || os.contains("darwin") -> "darwin"
-                os.contains("win") -> "windows"
-                else -> "linux"
-            }
-        val archPart = if (arch.contains("aarch64") || arch.contains("arm")) "arm64" else "x64"
-        return "$osPart-$archPart"
-    }
-
-    private fun ensureShutdownHook() {
-        if (shutdownHook != null) return
-        // On JVM exit the service's own dispose() may not run, so this hook is the
-        // only teardown. Mark `disposed` first so the process-exit handler treats
-        // the kill as intentional shutdown (not a crash to restart from), then
-        // close stdin so the bridge exits cleanly on EOF; destroyForcibly is the
-        // bounded fallback for a bridge that ignores the EOF.
-        val hook =
-            Thread {
-                disposed.set(true)
-                synchronized(writeLock) { runCatching { writer?.close() } }
-                val dying = process
-                if (dying != null && !dying.waitFor(500, TimeUnit.MILLISECONDS)) {
-                    runCatching { dying.destroyForcibly() }
-                }
-            }
-        shutdownHook = hook
-        runCatching { Runtime.getRuntime().addShutdownHook(hook) }
-    }
-
-    private fun pump(input: InputStream, onLine: (String) -> Unit) {
-        val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
-        Thread({
-            reader.useLines { lines -> lines.forEach(onLine) }
-        }, "modeler-bridge-reader").apply {
-            isDaemon = true
-            start()
-        }
-    }
+    fun disposeDiff(diffId: String) = diffRouter.disposeDiff(diffId)
 
     override fun dispose() {
-        disposed.set(true)
-        synchronized(outboundMonitor) { outboundMonitor.notifyAll() }
-        shutdownHook?.let { runCatching { Runtime.getRuntime().removeShutdownHook(it) } }
-        shutdownHook = null
-
-        synchronized(writeLock) {
-            runCatching { writer?.close() }
-            writer = null
-        }
-        val dying = process
-        process = null
-        if (dying != null) {
-            // Closing stdin makes the bridge exit on EOF; give it a moment, then force.
-            dying.destroy()
-            if (!dying.waitFor(2, TimeUnit.SECONDS)) dying.destroyForcibly()
-        }
-        sessions.clear()
-        diffPanes.clear()
-        diffPaneUris.clear()
-        deploymentSink = null
-    }
-
-    private companion object {
-        const val OUTBOUND_CAPACITY = 512
-        const val MAX_RESTARTS = 5
-        const val RESTART_BACKOFF_MS = 500L
-        const val STABLE_RUN_MS = 15_000L
-        const val BRIDGE_BINARY_NAME = "modeler-bridge"
-
-        // Version-keyed extraction root under PathManager.getSystemPath(); the
-        // version segment is appended per [bridgeCacheKey].
-        const val CACHE_SUBDIR = "miragon-bpmn-modeler/bridge"
-        const val GET_BPMN_FILE_COMMAND = "{\"type\":\"GetBpmnFileCommand\"}"
+        supervisor.dispose()
+        editorRouter.clear()
+        diffRouter.clear()
+        deploymentRouter.clear()
     }
 }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeBinaryResolver.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeBinaryResolver.kt
@@ -1,0 +1,147 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.intellij.ide.plugins.PluginManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Resolves a runnable bridge binary and caches it for the resolver's lifetime.
+ * Pure file I/O with no concurrency of its own (the one cross-window race is the
+ * atomic-move in [extractBridge]).
+ */
+internal class BridgeBinaryResolver {
+    private val log = Logger.getInstance(BridgeBinaryResolver::class.java)
+
+    @Volatile
+    private var cachedBinary: Path? = null
+
+    /**
+     * Returns the path to a runnable bridge binary: a dev override if set, else
+     * the bundled per-platform binary extracted to a stable, version-keyed cache
+     * under the IDE system dir, made executable, and cached for this resolver's
+     * lifetime.
+     *
+     * The stable path is load-bearing on Windows. Extracting to a brand-new
+     * `%TEMP%` file every session (the old behaviour) defeats Defender's scan
+     * cache: launching a never-before-seen executable triggers a synchronous
+     * on-execution scan *inside* `CreateProcess` that can freeze the caller for
+     * seconds. Keying the path by plugin version means Defender re-scans only on
+     * the first launch after an install/upgrade, then reuses its verdict.
+     */
+    fun resolve(): Path {
+        (System.getProperty("miragon.bridge") ?: System.getenv("MIRAGON_BRIDGE"))?.let {
+            return Path.of(it)
+        }
+        cachedBinary?.let { return it }
+
+        val platform = platformDir()
+        // Windows refuses to launch an executable without the `.exe` suffix. Bun's
+        // `--target=bun-windows-x64` produces `modeler-bridge.exe` and Gradle
+        // stages it under the same name, so we mirror that here.
+        val isWindows = platform.startsWith("windows")
+        val binaryName = if (isWindows) "$BRIDGE_BINARY_NAME.exe" else BRIDGE_BINARY_NAME
+        val resource = "/bin/$platform/$binaryName"
+
+        val cacheDir = Path.of(PathManager.getSystemPath(), CACHE_SUBDIR, bridgeCacheKey())
+        val target = cacheDir.resolve(binaryName)
+        if (!Files.isRegularFile(target)) {
+            extractBridge(resource, cacheDir, target)
+            pruneStaleCaches(cacheDir)
+        }
+        // Re-assert the exec bit cheaply in case a prior session extracted the file
+        // but failed to set it (or the bit was cleared out from under us).
+        target.toFile().setExecutable(true, true)
+        cachedBinary = target
+        return target
+    }
+
+    /**
+     * Materialises the bundled bridge at [target] atomically: extraction goes to a
+     * sibling temp file, then an atomic move into place, so a crash mid-copy never
+     * leaves a truncated binary that would fail to launch. Two IDE windows (each
+     * with its own project-level service) can race here; the loser's move fails
+     * with [FileAlreadyExistsException] and simply reuses the winner's file.
+     */
+    private fun extractBridge(resource: String, cacheDir: Path, target: Path) {
+        val stream =
+            javaClass.getResourceAsStream(resource)
+                ?: error(
+                    "No bundled modeler bridge ($resource). " +
+                        "Build it with `corepack yarn workspace @miragon/bpmn-modeler-bridge compile`.",
+                )
+        Files.createDirectories(cacheDir)
+        val temp = Files.createTempFile(cacheDir, BRIDGE_BINARY_NAME, ".tmp")
+        try {
+            stream.use { Files.copy(it, temp, StandardCopyOption.REPLACE_EXISTING) }
+            temp.toFile().setExecutable(true, true)
+            try {
+                Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE)
+            } catch (e: FileAlreadyExistsException) {
+                // Another IDE window extracted it first; its copy is authoritative.
+                log.debug("Bridge already extracted by a concurrent window: ${e.message}")
+            }
+        } finally {
+            Files.deleteIfExists(temp)
+        }
+    }
+
+    /**
+     * Cache-directory segment that changes whenever the shipped binary might
+     * differ. Keyed by plugin version so an upgrade re-extracts (and Defender
+     * re-scans once); falls back to `"dev"` when the version is unavailable — fine
+     * because dev runs use the `MIRAGON_BRIDGE` override checked above.
+     */
+    private fun bridgeCacheKey(): String = PluginManager.getPluginByClass(javaClass)?.version ?: "dev"
+
+    /**
+     * Best-effort removal of *other* version dirs so extracted binaries don't
+     * accumulate (~tens of MB each) across plugin upgrades. Runs only right after a
+     * fresh extraction — i.e. once per new version. Deleting a binary another IDE
+     * window (running an older plugin version) is currently executing is safe:
+     * POSIX keeps the running inode alive after unlink, and Windows locks the file
+     * so the delete simply fails and is retried on the next upgrade. Hence all
+     * failures are swallowed.
+     */
+    private fun pruneStaleCaches(currentVersionDir: Path) {
+        val root = currentVersionDir.parent ?: return
+        runCatching {
+            Files.list(root).use { entries ->
+                entries
+                    .filter { Files.isDirectory(it) && it != currentVersionDir }
+                    .forEach { stale ->
+                        runCatching {
+                            Files.walk(stale).use { paths ->
+                                // Deepest-first so directories are emptied before removal.
+                                paths.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+                            }
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun platformDir(): String {
+        val os = System.getProperty("os.name").lowercase()
+        val arch = System.getProperty("os.arch").lowercase()
+        val osPart =
+            when {
+                os.contains("mac") || os.contains("darwin") -> "darwin"
+                os.contains("win") -> "windows"
+                else -> "linux"
+            }
+        val archPart = if (arch.contains("aarch64") || arch.contains("arm")) "arm64" else "x64"
+        return "$osPart-$archPart"
+    }
+
+    private companion object {
+        const val BRIDGE_BINARY_NAME = "modeler-bridge"
+
+        // Version-keyed extraction root under PathManager.getSystemPath(); the
+        // version segment is appended per [bridgeCacheKey].
+        const val CACHE_SUBDIR = "miragon-bpmn-modeler/bridge"
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeDeps.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeDeps.kt
@@ -1,0 +1,31 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.Gson
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import io.miragon.intellij.bpmn.HostNotifications
+
+/**
+ * Shared dependency bundle handed to every feature router (mirrors the TS
+ * `sharedDeps.ts`). Bundling these lets each router declare a single
+ * constructor parameter and keeps `CoreProcess` wiring to one object.
+ *
+ * @param channel Outbound transport (notify/reply) the routers send through.
+ * @param handlers Registry each router populates in its `register()`.
+ * @param gson The channel's single Gson instance, reused for (de)serialisation.
+ * @param isProcessAlive Liveness gate for no-op-when-down sends.
+ * @param ensureStartedAsync Off-EDT spawn trigger for first-frame senders.
+ * @param parentDisposable The `CoreProcess` service — parent for the script
+ *   editor manager's listeners.
+ * @param notifications Lazy host UI surface; constructed on first error/notifier.
+ */
+internal class BridgeDeps(
+    val project: Project,
+    val channel: RpcChannel,
+    val handlers: RpcHandlerRegistry,
+    val gson: Gson,
+    val isProcessAlive: () -> Boolean,
+    val ensureStartedAsync: () -> Unit,
+    val parentDisposable: Disposable,
+    val notifications: Lazy<HostNotifications>,
+)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/DeploymentRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/DeploymentRouter.kt
@@ -1,0 +1,91 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.JsonParser
+import com.intellij.openapi.diagnostic.Logger
+import io.miragon.intellij.bpmn.IntellijDeploymentState
+
+/**
+ * Routes the deployment tool window: a single core→webview sink (one tool window
+ * per project) plus the deployment-state mirror the core's synchronous getters
+ * read. The mirror is (re-)seeded on every spawn and on window registration.
+ */
+internal class DeploymentRouter(private val deps: BridgeDeps) {
+    private val log = Logger.getInstance(DeploymentRouter::class.java)
+
+    private val deploymentState by lazy { IntellijDeploymentState.getInstance(deps.project) }
+
+    // The deployment tool window's core→webview sink. One tool window per project,
+    // so a later register replaces the previous sink (null when closed).
+    @Volatile
+    private var deploymentSink: ((String) -> Unit)? = null
+
+    fun register() {
+        deps.handlers
+            .on("deployment/postMessage") { params, _ ->
+                val payload = deps.gson.toJson(params.get("message"))
+                deploymentSink?.invoke(payload)
+            }
+            // PropertiesComponent writes are thread-safe and run on the reader
+            // thread here (same as the secretStore handlers).
+            .on("deploymentState/saveAuthType") { params, _ ->
+                deploymentState.saveAuthType(params.get("authType").asString)
+            }
+            .on("deploymentState/saveOAuth2Config") { params, _ ->
+                deploymentState.saveOAuth2Config(
+                    params.get("tokenEndpoint").asString,
+                    params.get("audience").asString,
+                )
+            }
+            .on("deploymentState/save") { params, _ ->
+                deploymentState.save(
+                    params.get("endpoint").asString,
+                    params.get("tenantId").asString,
+                )
+            }
+    }
+
+    /**
+     * Registers the deployment tool window's core→webview sink and (re-)seeds the
+     * deployment-state mirror. One tool window per project, so a later register
+     * replaces the previous sink.
+     */
+    fun registerDeploymentWindow(sink: (String) -> Unit) {
+        deploymentSink = sink
+        // Seed now if the bridge is already up; otherwise spawn() re-seeds on start.
+        // Spawning runs off the EDT so the tool window opens without blocking.
+        sendSeed()
+        deps.ensureStartedAsync()
+    }
+
+    /** Drops the deployment sink and marks the panel closed (stops default refreshes). */
+    fun unregisterDeploymentWindow() {
+        deploymentSink = null
+        deps.channel.notify("deployment/open", linkedMapOf("open" to false))
+    }
+
+    /** Forwards one raw deployment-webview message (already JSON) to the core untouched. */
+    fun forwardDeploymentMessage(rawMessage: String) {
+        val parsed =
+            try {
+                JsonParser.parseString(rawMessage)
+            } catch (e: Exception) {
+                log.warn("Discarding malformed deployment message: $rawMessage", e)
+                return
+            }
+        deps.channel.notify("deployment/webviewMessage", linkedMapOf("message" to parsed))
+    }
+
+    /** Tells the core whether the deployment panel is visible (drives form-default refresh). */
+    fun setDeploymentOpen(open: Boolean) {
+        deps.channel.notify("deployment/open", linkedMapOf("open" to open))
+    }
+
+    fun sendSeed() {
+        if (!deps.isProcessAlive()) return
+        deps.channel.notify("deploymentState/seed", linkedMapOf("state" to deploymentState.snapshotMap()))
+    }
+
+    fun clear() {
+        deploymentSink = null
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/DiffRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/DiffRouter.kt
@@ -1,0 +1,88 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.JsonParser
+import com.intellij.openapi.diagnostic.Logger
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Routes host-originated BPMN diff sessions. A diff has two JCEF browsers and is
+ * keyed by `paneUri` (not editor id); [diffPanes] maps each pane's URI to its
+ * core→webview sink, and [diffPaneUris] lets [disposeDiff] drop both panes of a
+ * diff at once.
+ */
+internal class DiffRouter(private val deps: BridgeDeps) {
+    private val log = Logger.getInstance(DiffRouter::class.java)
+
+    private val diffPanes = ConcurrentHashMap<String, (String) -> Unit>()
+    private val diffPaneUris = ConcurrentHashMap<String, List<String>>()
+
+    fun register() {
+        deps.handlers.on("diff/postMessage") { params, _ ->
+            val paneUri = params.get("paneUri").asString
+            val payload = deps.gson.toJson(params.get("message"))
+            diffPanes[paneUri]?.invoke(payload)
+        }
+    }
+
+    /**
+     * Starts a host-originated diff session in the core. Both sides are known up
+     * front (IntelliJ resolves the diff with HEAD and working-tree contents in
+     * hand), so the core arms a fully-paired diff session immediately — no
+     * VS Code-style out-of-order pane resolution. `postToBefore`/`postToAfter`
+     * sink core→webview messages into each side's JCEF browser; `beforeUri`/
+     * `afterUri` are the diff-scoped pane identities the core routes replies by.
+     */
+    fun openDiff(
+        diffId: String,
+        origin: String,
+        beforeUri: String,
+        beforeContent: String,
+        postToBefore: (String) -> Unit,
+        afterUri: String,
+        afterContent: String,
+        postToAfter: (String) -> Unit,
+    ) {
+        diffPanes[beforeUri] = postToBefore
+        diffPanes[afterUri] = postToAfter
+        diffPaneUris[diffId] = listOf(beforeUri, afterUri)
+        // Route the panes, enqueue diff/open, then spawn off the EDT (the queue
+        // holds the frame until the writer exists), so opening a diff never blocks.
+        deps.channel.notify(
+            "diff/open",
+            linkedMapOf(
+                "diffId" to diffId,
+                "origin" to origin,
+                "before" to linkedMapOf("uri" to beforeUri, "content" to beforeContent),
+                "after" to linkedMapOf("uri" to afterUri, "content" to afterContent),
+            ),
+        )
+        deps.ensureStartedAsync()
+    }
+
+    /** Forwards one raw diff-pane webview message (already JSON) to the core. */
+    fun forwardDiffMessage(paneUri: String, rawMessage: String) {
+        val message =
+            try {
+                JsonParser.parseString(rawMessage)
+            } catch (e: Exception) {
+                log.warn("Discarding malformed diff message: $rawMessage", e)
+                return
+            }
+        deps.channel.notify("diff/webviewMessage", linkedMapOf("paneUri" to paneUri, "message" to message))
+    }
+
+    /**
+     * Tears a diff down: drops both panes' sinks (so a stray late reply can't
+     * resurrect a closed pane) and tells the core to retire the session. Called
+     * on tab close and, with an immediate re-`openDiff`, on swap.
+     */
+    fun disposeDiff(diffId: String) {
+        diffPaneUris.remove(diffId)?.forEach { diffPanes.remove(it) }
+        deps.channel.notify("diff/dispose", linkedMapOf("diffId" to diffId))
+    }
+
+    fun clear() {
+        diffPanes.clear()
+        diffPaneUris.clear()
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
@@ -1,0 +1,185 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.util.text.StringUtil
+import io.miragon.intellij.bpmn.CoreSession
+import io.miragon.intellij.bpmn.ModelerSettingsStore
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Routes the BPMN-editor feature: open-session registration, document-port
+ * fulfilment (`document/write` / `document/save`) against the real IntelliJ
+ * `Document`, and core→webview message delivery. Sessions are keyed by editor id
+ * so messages reach the right JCEF browser when several `.bpmn` files are open.
+ */
+internal class EditorSessionRouter(private val deps: BridgeDeps) {
+    private val log = Logger.getInstance(EditorSessionRouter::class.java)
+
+    private val sessions = ConcurrentHashMap<String, CoreSession>()
+
+    fun register() {
+        deps.handlers
+            .on("editor/postMessage") { params, _ ->
+                val editorId = params.get("editorId").asString
+                // `message` is a JSON object; re-serialise it as the postMessage payload.
+                val payload = deps.gson.toJson(params.get("message"))
+                sessions[editorId]?.postToWebview(payload)
+            }
+            .on("document/write") { params, id -> handleWrite(params, id) }
+            .on("document/save") { params, id -> handleSave(params, id) }
+    }
+
+    // ── host → core ────────────────────────────────────────────────────────────
+
+    /** Registers an editor and tells the core to open it (seeding the document mirror). */
+    fun registerSession(session: CoreSession) {
+        sessions[session.editorId] = session
+        // Enqueue the register frame now and spawn off the EDT: the outbound queue
+        // buffers it until the writer exists, so editor construction never blocks on
+        // the (occasionally seconds-long) process start.
+        sendRegister(session)
+        deps.ensureStartedAsync()
+    }
+
+    private fun sendRegister(session: CoreSession) {
+        val content =
+            ReadAction.compute<String, RuntimeException> {
+                FileDocumentManager.getInstance().getDocument(session.file)?.text.orEmpty()
+            }
+        deps.channel.notify(
+            "session/register",
+            linkedMapOf(
+                "editorId" to session.editorId,
+                "uriString" to session.editorId,
+                "path" to session.file.path,
+                "fsPath" to session.file.path,
+                "scheme" to "file",
+                // Authoritative IntelliJ project root for element-template
+                // discovery; falls back to the file's dir for light-edit
+                // projects where basePath is null.
+                "workspaceRoot" to (deps.project.basePath ?: session.file.parent?.path),
+                // Seed the core's SettingsPort before it scans templates, so the
+                // very first discovery uses the configured folder, not the default.
+                "settings" to ModelerSettingsStore.getInstance().snapshotMap(),
+                "content" to content,
+            ),
+        )
+    }
+
+    /**
+     * Pushes the current settings snapshot to the running core so an open editor
+     * reacts live (language re-render, configFolder template reload). No-ops when
+     * no bridge is alive: the snapshot is re-seeded on the next [sendRegister].
+     */
+    fun pushSettings() {
+        if (!deps.isProcessAlive()) return
+        deps.channel.notify("settings/didChange", linkedMapOf("settings" to ModelerSettingsStore.getInstance().snapshotMap()))
+    }
+
+    /** Forwards one raw webview message (already JSON) to the core untouched. */
+    fun forwardWebviewMessage(editorId: String, rawMessage: String) {
+        val parsed =
+            try {
+                JsonParser.parseString(rawMessage)
+            } catch (e: Exception) {
+                log.warn("Discarding malformed webview message: $rawMessage", e)
+                return
+            }
+        val type = (parsed as? JsonObject)?.get("type")?.takeIf { !it.isJsonNull }?.asString
+        // Document syncs fire once per diagram edit and supersede each other —
+        // only the latest XML matters for write-back — so collapse queued ones.
+        val coalesceKey = if (type == "SyncDocumentCommand") "sync:$editorId" else null
+        deps.channel.notify("webview/message", linkedMapOf("editorId" to editorId, "message" to parsed), coalesceKey)
+    }
+
+    /**
+     * Forwards a document change to the core so external edits (git revert/
+     * checkout, the plain-text tab, another tool) re-render the diagram. The host
+     * stays dumb: it reports *every* change, including the echo of its own
+     * `document/write`. The bridge tells the two apart — re-rendering our own
+     * write would loop, so it is filtered there, not here.
+     */
+    fun notifyDocumentChanged(editorId: String, content: String) {
+        if (!sessions.containsKey(editorId)) return
+        deps.channel.notify("document/didChange", linkedMapOf("editorId" to editorId, "content" to content))
+    }
+
+    /** Tells the core which open editor is focused (drives its active-editor pointer). */
+    fun setActiveEditor(editorId: String) {
+        if (!sessions.containsKey(editorId)) return
+        deps.channel.notify("session/setActive", linkedMapOf("editorId" to editorId))
+    }
+
+    fun disposeSession(editorId: String) {
+        sessions.remove(editorId)
+        deps.channel.notify("session/dispose", linkedMapOf("editorId" to editorId))
+    }
+
+    /**
+     * Re-seeds every open session into a freshly spawned bridge (the document
+     * mirror is rebuilt from the live IntelliJ `Document`, the authoritative
+     * source) and replays `GetBpmnFileCommand` so the still-alive JCEF page
+     * re-renders without a reload.
+     */
+    fun reregisterLiveSessions() {
+        if (!deps.isProcessAlive()) return
+        sessions.values.forEach { session ->
+            sendRegister(session)
+            forwardWebviewMessage(session.editorId, GET_BPMN_FILE_COMMAND)
+        }
+    }
+
+    fun clear() = sessions.clear()
+
+    // ── core → host ────────────────────────────────────────────────────────────
+
+    /**
+     * Writes core-supplied XML into the in-memory Document on the EDT, then replies
+     * with whether the content actually changed (the `DocumentPort.write` contract).
+     * IntelliJ Documents require `\n`; webview XML may carry `\r\n`.
+     */
+    private fun handleWrite(params: JsonObject, id: Int?) {
+        val editorId = params.get("editorId").asString
+        val content = StringUtil.convertLineSeparators(params.get("content").asString)
+        val session = sessions[editorId]
+        if (session == null) {
+            id?.let { deps.channel.reply(it, mapOf("changed" to false)) }
+            return
+        }
+        ApplicationManager.getApplication().invokeLater {
+            var changed = false
+            if (!session.project.isDisposed) {
+                val document = FileDocumentManager.getInstance().getDocument(session.file)
+                if (document != null && document.text != content) {
+                    WriteCommandAction.runWriteCommandAction(session.project) {
+                        document.setText(content)
+                    }
+                    changed = true
+                }
+            }
+            id?.let { deps.channel.reply(it, mapOf("changed" to changed)) }
+        }
+    }
+
+    private fun handleSave(params: JsonObject, id: Int?) {
+        val editorId = params.get("editorId").asString
+        val session = sessions[editorId]
+        ApplicationManager.getApplication().invokeLater {
+            if (session != null && !session.project.isDisposed) {
+                val document = FileDocumentManager.getInstance().getDocument(session.file)
+                if (document != null) FileDocumentManager.getInstance().saveDocument(document)
+            }
+            id?.let { deps.channel.reply(it, mapOf("saved" to true)) }
+        }
+    }
+
+    private companion object {
+        const val GET_BPMN_FILE_COMMAND = "{\"type\":\"GetBpmnFileCommand\"}"
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/HostUiRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/HostUiRouter.kt
@@ -1,0 +1,110 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.JsonObject
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.ide.CopyPasteManager
+import io.miragon.intellij.bpmn.EngineStatusBarWidget
+import io.miragon.intellij.bpmn.HostPicker
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+
+/**
+ * Routes the core's host-UI ports — `PickerPort`, clipboard, `StatusBarPort`,
+ * and `NotifierPort` — onto native IntelliJ surfaces. Stateless: every handler
+ * delegates to a project-scoped widget, the system clipboard, or the lazy
+ * [io.miragon.intellij.bpmn.HostNotifications].
+ */
+internal class HostUiRouter(private val deps: BridgeDeps) {
+    private val log = Logger.getInstance(HostUiRouter::class.java)
+
+    private val notifications get() = deps.notifications.value
+    private val project get() = deps.project
+
+    fun register() {
+        deps.handlers
+            .on("picker/show") { params, id -> handlePick(params, id) }
+            .on("clipboard/read") { _, id -> handleClipboardRead(id) }
+            .on("clipboard/write") { params, _ -> handleClipboardWrite(params) }
+            .on("statusBar/showEngineVersion") { params, _ ->
+                val label = if (params.get("platform")?.asString == "c7") "Camunda 7" else "Camunda 8"
+                EngineStatusBarWidget.updateEngine(project, "$label ${params.get("version")?.asString}")
+            }
+            .on("statusBar/hideEngineVersion") { _, _ -> EngineStatusBarWidget.updateEngine(project, null) }
+            .on("statusBar/disposeEngineVersion") { _, _ -> EngineStatusBarWidget.updateEngine(project, null) }
+            .on("statusBar/templatesReady") { params, _ ->
+                EngineStatusBarWidget.updateTemplateCount(project, params.get("count")?.asInt ?: 0)
+            }
+            .on("statusBar/templatesHide") { _, _ -> EngineStatusBarWidget.updateTemplateCount(project, null) }
+            .on("statusBar/templatesLoading") { _, _ -> } // transient; the count frame follows
+            .on("notifier/showInfo") { params, _ -> notifications.showInfo(params.get("message").asString) }
+            .on("notifier/showError") { params, _ -> notifications.showError(params.get("message").asString) }
+            .on("notifier/notifyError") { params, _ ->
+                notifications.notifyError(params.get("context").asString, params.get("message").asString)
+            }
+            .on("notifier/openConsole") { _, _ -> notifications.openLoggingConsole() }
+            .on("notifier/openDocument") { params, _ -> notifications.openDocument(params.get("path").asString) }
+            .on("notifier/log") { params, _ ->
+                notifications.log(params.get("level")?.asString, params.get("message")?.asString.orEmpty())
+            }
+            .on("notifier/progressStart") { params, _ -> log.debug("notifier/progressStart: ${params.get("title")?.asString}") }
+            .on("notifier/progressEnd") { params, _ -> log.debug("notifier/progressEnd: ${params.get("title")?.asString}") }
+    }
+
+    /**
+     * Shows a native list popup for the core's `PickerPort` and replies with the
+     * chosen item indices, or `null` on dismissal. The host renders only the
+     * chooser; the cancel-vs-throw convention is applied core-side.
+     */
+    private fun handlePick(params: JsonObject, id: Int?) {
+        // A picker prompt is always a request expecting a reply; a missing id
+        // would mean nothing to answer, so there is nothing to do.
+        if (id == null) return
+        val title = params.get("title")?.takeIf { !it.isJsonNull }?.asString
+        val placeholder = params.get("placeholder")?.takeIf { !it.isJsonNull }?.asString.orEmpty()
+        val canPickMany = params.get("canPickMany")?.takeIf { !it.isJsonNull }?.asBoolean ?: false
+        val items =
+            params.getAsJsonArray("items").mapIndexed { index, element ->
+                val obj = element.asJsonObject
+                HostPicker.PickItem(
+                    index,
+                    obj.get("label").asString,
+                    obj.get("description")?.takeIf { !it.isJsonNull }?.asString,
+                )
+            }
+        ApplicationManager.getApplication().invokeLater {
+            if (project.isDisposed) {
+                deps.channel.reply(id, mapOf("selected" to null))
+                return@invokeLater
+            }
+            HostPicker.show(project, title, placeholder, canPickMany, items) { selected ->
+                deps.channel.reply(id, mapOf("selected" to selected))
+            }
+        }
+    }
+
+    /**
+     * Reads the system clipboard for the webview's copy/paste mediator. The
+     * sandboxed JCEF page can't touch the clipboard and the core is a separate
+     * process, so the host reads on their behalf and replies with the text.
+     * `runCatching` → `""` keeps a denied/empty/non-text clipboard from breaking
+     * paste — an empty string is a valid "nothing to paste" answer.
+     */
+    private fun handleClipboardRead(id: Int?) {
+        ApplicationManager.getApplication().invokeLater {
+            val text =
+                runCatching {
+                    CopyPasteManager.getInstance().getContents<String>(DataFlavor.stringFlavor)
+                }.getOrNull().orEmpty()
+            id?.let { deps.channel.reply(it, mapOf("text" to text)) }
+        }
+    }
+
+    /** Writes the webview's copied text onto the system clipboard (fire-and-forget). */
+    private fun handleClipboardWrite(params: JsonObject) {
+        val text = params.get("text")?.takeIf { !it.isJsonNull }?.asString.orEmpty()
+        ApplicationManager.getApplication().invokeLater {
+            CopyPasteManager.getInstance().setContents(StringSelection(text))
+        }
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisor.kt
@@ -1,0 +1,204 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.util.concurrency.AppExecutorUtil
+import io.miragon.intellij.bpmn.HostNotifications
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Owns the bridge subprocess lifecycle: lazy spawn, crash detection with
+ * backoff respawn, the JVM shutdown hook, and teardown.
+ *
+ * **Locking.** [stateLock] guards [process] assignment and is held across the
+ * paired [RpcChannel.attach]/[RpcChannel.detach] calls, preserving the
+ * cross-cutting invariant the former single lock provided: [handleExit]'s
+ * "`process !== dead` → return, else detach" check-and-act stays atomic w.r.t. a
+ * concurrent [spawn] attaching the new writer. Lock order is always
+ * `stateLock → channel.ioLock`.
+ *
+ * `@Synchronized ensureStarted()` and the backoff respawn's `synchronized(this)`
+ * share this instance's monitor (as they shared the `CoreProcess` instance's
+ * before); no external code synchronises on the supervisor.
+ *
+ * @param notifications Lazy provider so a spawn failure surfaces UI without
+ *   forcing [HostNotifications] construction on the happy path.
+ * @param onSpawned Runs after every (re)spawn — seeds the deployment mirror.
+ * @param onRespawned Runs after a *crash* respawn — re-registers live sessions.
+ */
+internal class ProcessSupervisor(
+    private val channel: RpcChannel,
+    private val binaryResolver: BridgeBinaryResolver,
+    private val notifications: () -> HostNotifications,
+    private val onSpawned: () -> Unit,
+    private val onRespawned: () -> Unit,
+) {
+    private val log = Logger.getInstance(ProcessSupervisor::class.java)
+
+    private val stateLock = Any()
+
+    // Read unsynchronized from the routers/dispose and the shutdown hook, so its
+    // writes must publish safely across threads.
+    @Volatile
+    private var process: Process? = null
+
+    private val disposed = AtomicBoolean(false)
+    private val restartAttempts = AtomicInteger(0)
+
+    @Volatile
+    private var lastSpawnAt = 0L
+
+    private var shutdownHook: Thread? = null
+
+    val isAlive: Boolean get() = process?.isAlive == true
+
+    // ── lifecycle ────────────────────────────────────────────────────────────
+
+    @Synchronized
+    fun ensureStarted() {
+        if (process?.isAlive == true) return
+        spawn()
+    }
+
+    /**
+     * Brings the bridge up **off the EDT** when it isn't already running.
+     *
+     * `spawn()` does blocking process I/O — `ProcessBuilder.start()` can stall for
+     * seconds on Windows while Defender scans the freshly materialised binary — so
+     * it must never run on the caller's thread when that caller is the EDT (editor,
+     * diff, or tool-window construction). Callers enqueue their first frame
+     * synchronously instead; the writer thread drains it once the process is up, so
+     * nothing is lost by deferring the spawn.
+     */
+    fun ensureStartedAsync() {
+        if (process?.isAlive == true) return
+        AppExecutorUtil.getAppScheduledExecutorService().execute {
+            if (disposed.get()) return@execute
+            ensureStarted()
+        }
+    }
+
+    /**
+     * Pre-warms the bridge at project open so the first `.bpmn` tab, diff, or
+     * deployment panel renders against an already-running process instead of
+     * waiting on a cold spawn. Safe to call repeatedly — no-ops once alive.
+     */
+    fun prewarm() = ensureStartedAsync()
+
+    private fun spawn() {
+        val binary =
+            try {
+                binaryResolver.resolve()
+            } catch (e: Exception) {
+                log.error("Failed to resolve the bundled modeler bridge binary", e)
+                notifications().showError("Could not start the BPMN modeler engine: ${e.message}")
+                return
+            }
+        try {
+            val started = ProcessBuilder(binary.toString()).redirectErrorStream(false).start()
+            synchronized(stateLock) {
+                process = started
+                channel.attach(started.outputStream, started.inputStream)
+            }
+            lastSpawnAt = System.currentTimeMillis()
+            // stderr is the core's diagnostic channel (stdout is reserved for RPC).
+            channel.pump(started.errorStream, "modeler-bridge-stderr") { log.info("[bridge stderr] $it") }
+            started.onExit().thenAccept { handleExit(started) }
+            ensureShutdownHook()
+            // Seed the deployment-state mirror up front so the bridge's synchronous
+            // getters are correct; re-runs on every (re)spawn, rebuilding the mirror.
+            onSpawned()
+            log.info("Miragon modeler bridge started: $binary")
+        } catch (e: Exception) {
+            log.error("Failed to start the modeler bridge", e)
+            notifications().showError("Could not start the BPMN modeler engine. See idea.log.")
+        }
+    }
+
+    /**
+     * Reacts to the bridge process dying. Distinguishes a stable run that
+     * crashed (reset the attempt counter) from a rapid restart loop (give up
+     * after [MAX_RESTARTS]); on a survivable crash, respawns with linear backoff
+     * and recovers every open editor.
+     */
+    private fun handleExit(dead: Process) {
+        if (disposed.get()) return
+        synchronized(stateLock) {
+            if (process !== dead) return // already replaced by a newer spawn
+            channel.detach()
+        }
+
+        if (System.currentTimeMillis() - lastSpawnAt > STABLE_RUN_MS) {
+            restartAttempts.set(0)
+        }
+        val attempt = restartAttempts.incrementAndGet()
+        if (attempt > MAX_RESTARTS) {
+            log.error("Modeler bridge exited $attempt times in quick succession; giving up.")
+            notifications().showError(
+                "The BPMN modeler engine crashed repeatedly and will not be restarted. " +
+                    "Reopen the file or restart the IDE. See idea.log.",
+            )
+            return
+        }
+        log.warn(
+            "Modeler bridge exited (code ${runCatching { dead.exitValue() }.getOrNull()}); " +
+                "restart attempt $attempt/$MAX_RESTARTS",
+        )
+
+        // Respawn off this thread, not via Thread.sleep: handleExit runs on the
+        // Process.onExit() CompletableFuture callback (ForkJoinPool.commonPool),
+        // and blocking it for the backoff would hold a shared platform pool
+        // thread for up to seconds. Re-check disposed/liveness at fire time.
+        AppExecutorUtil.getAppScheduledExecutorService().schedule(
+            {
+                if (disposed.get()) return@schedule
+                synchronized(this) { if (process?.isAlive != true) spawn() }
+                onRespawned()
+            },
+            RESTART_BACKOFF_MS * attempt,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    private fun ensureShutdownHook() {
+        if (shutdownHook != null) return
+        // On JVM exit the service's own dispose() may not run, so this hook is the
+        // only teardown. Mark `disposed` first so the process-exit handler treats
+        // the kill as intentional shutdown (not a crash to restart from), then
+        // close stdin so the bridge exits cleanly on EOF; destroyForcibly is the
+        // bounded fallback for a bridge that ignores the EOF.
+        val hook =
+            Thread {
+                disposed.set(true)
+                channel.closeFromShutdownHook()
+                val dying = process
+                if (dying != null && !dying.waitFor(500, TimeUnit.MILLISECONDS)) {
+                    runCatching { dying.destroyForcibly() }
+                }
+            }
+        shutdownHook = hook
+        runCatching { Runtime.getRuntime().addShutdownHook(hook) }
+    }
+
+    fun dispose() {
+        disposed.set(true)
+        channel.close()
+        shutdownHook?.let { runCatching { Runtime.getRuntime().removeShutdownHook(it) } }
+        shutdownHook = null
+
+        val dying = process
+        process = null
+        if (dying != null) {
+            // Closing stdin makes the bridge exit on EOF; give it a moment, then force.
+            dying.destroy()
+            if (!dying.waitFor(2, TimeUnit.SECONDS)) dying.destroyForcibly()
+        }
+    }
+
+    private companion object {
+        const val MAX_RESTARTS = 5
+        const val RESTART_BACKOFF_MS = 500L
+        const val STABLE_RUN_MS = 15_000L
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
@@ -1,0 +1,199 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import com.intellij.openapi.diagnostic.Logger
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Bidirectional, newline-delimited JSON-RPC transport over the bridge's
+ * stdin/stdout (the peer of the TS `Rpc`). It owns *only* framing and threading;
+ * routing of inbound frames is the injected [dispatch] lambda's job.
+ *
+ * Outbound (host→core) frames are drained by a single writer thread so the EDT /
+ * JCEF threads never block on the bridge's stdin. The deque also enables
+ * coalescing: a flood of document syncs collapses to its latest frame.
+ *
+ * **Locking.** [ioLock] guards the [writer] reference and every write/flush — the
+ * writer half of the former single `writeLock`. The supervisor's `stateLock`
+ * guards process identity and is held across the paired [attach]/[detach] calls;
+ * lock order is always `stateLock → ioLock`, and [writerLoop] only ever takes
+ * [ioLock], so the split cannot deadlock.
+ */
+internal class RpcChannel(
+    private val dispatch: (method: String, params: JsonObject, id: Int?) -> Unit,
+) {
+    private val log = Logger.getInstance(RpcChannel::class.java)
+
+    /** Shared with the routers so the whole bridge uses one Gson, as before. */
+    val gson = Gson()
+
+    private data class OutFrame(val line: String, val coalesceKey: String?)
+
+    private val outbound = ArrayDeque<OutFrame>()
+    private val outboundMonitor = Object()
+    private var writerThread: Thread? = null
+
+    private val ioLock = Any()
+    private var writer: BufferedWriter? = null
+
+    // Stops the writer loop. Set by close()/closeFromShutdownHook(); the supervisor
+    // keeps its own `disposed` flag for the process-lifecycle half.
+    private val closed = AtomicBoolean(false)
+
+    // ── outbound ──────────────────────────────────────────────────────────────
+
+    fun notify(method: String, params: Any?, coalesceKey: String? = null) =
+        enqueue(gson.toJson(linkedMapOf("method" to method, "params" to params)), coalesceKey)
+
+    fun reply(id: Int, result: Any?) =
+        enqueue(gson.toJson(linkedMapOf("id" to id, "result" to result)), null)
+
+    // The bridge's `rpc.ts` turns `{id, error}` into a rejected promise, so a
+    // handler that throws still settles the core's awaiting request instead of
+    // leaking it.
+    fun replyError(id: Int, message: String) =
+        enqueue(gson.toJson(linkedMapOf("id" to id, "error" to message)), null)
+
+    private fun enqueue(line: String, coalesceKey: String?) {
+        synchronized(outboundMonitor) {
+            if (coalesceKey != null) {
+                val iterator = outbound.iterator()
+                while (iterator.hasNext()) {
+                    if (iterator.next().coalesceKey == coalesceKey) iterator.remove()
+                }
+            }
+            if (outbound.size >= OUTBOUND_CAPACITY) {
+                outbound.removeFirst()
+                log.warn("Outbound bridge queue full ($OUTBOUND_CAPACITY); dropped oldest frame (backpressure)")
+            }
+            outbound.addLast(OutFrame(line, coalesceKey))
+            outboundMonitor.notifyAll()
+        }
+    }
+
+    private fun ensureWriterThread() {
+        if (writerThread != null) return
+        writerThread =
+            Thread({ writerLoop() }, "modeler-bridge-writer").apply {
+                isDaemon = true
+                start()
+            }
+    }
+
+    private fun writerLoop() {
+        while (!closed.get()) {
+            val frame =
+                synchronized(outboundMonitor) {
+                    while (outbound.isEmpty() && !closed.get()) outboundMonitor.wait()
+                    if (closed.get()) return else outbound.removeFirst()
+                }
+            val target = synchronized(ioLock) { writer }
+            if (target == null) {
+                // No live bridge stdin (restart window). Drop rather than spin:
+                // sessions are re-seeded from the authoritative Document on restart.
+                log.debug("No bridge writer; dropped a queued frame during restart")
+                continue
+            }
+            try {
+                synchronized(ioLock) {
+                    target.write(frame.line)
+                    target.write("\n")
+                    target.flush()
+                }
+            } catch (e: Exception) {
+                log.warn("Failed to write to bridge stdin", e)
+            }
+        }
+    }
+
+    // ── inbound ───────────────────────────────────────────────────────────────
+
+    /** Dispatches one line received from the core's stdout. */
+    private fun onLine(line: String) {
+        val message =
+            try {
+                gson.fromJson(line, JsonObject::class.java)
+            } catch (e: Exception) {
+                log.warn("Discarding malformed core message: $line", e)
+                return
+            }
+        // The host issues no requests to the core, so a frame without `method`
+        // (i.e. a response) is never expected and is ignored.
+        val method = message.get("method")?.takeIf { !it.isJsonNull }?.asString ?: return
+        val params = message.getAsJsonObject("params")
+        val id = message.get("id")?.takeIf { !it.isJsonNull }?.asInt
+
+        // A malformed/unexpected frame (missing member, wrong type, a throwing
+        // handler such as a failing PasswordSafe call) must not escape: this runs
+        // on the daemon reader thread, and an escaped exception would kill the
+        // pump — core→host traffic stops forever, and once the stdout pipe fills
+        // the bridge wedges without exiting, so the crash supervisor never fires.
+        // If the frame was a request, also answer it: an unanswered request would
+        // otherwise leak the core's awaiting promise.
+        try {
+            dispatch(method, params, id)
+        } catch (e: Exception) {
+            log.warn("Failed to handle core message ($method): $line", e)
+            id?.let { replyError(it, e.message ?: "host handler failed") }
+        }
+    }
+
+    // ── attach / detach / shutdown ────────────────────────────────────────────
+
+    /** Wraps the new process's stdin and starts the writer thread (once) + stdout pump. */
+    fun attach(stdin: OutputStream, stdout: InputStream) {
+        synchronized(ioLock) {
+            writer = BufferedWriter(OutputStreamWriter(stdin, StandardCharsets.UTF_8))
+        }
+        pump(stdout, "modeler-bridge-reader") { onLine(it) }
+        ensureWriterThread()
+    }
+
+    /** Drops the writer during a restart window; queued frames are dropped, as before. */
+    fun detach() {
+        synchronized(ioLock) { writer = null }
+    }
+
+    /** Dispose path: stop the loop, wake the waiting writer, close stdin. */
+    fun close() {
+        closed.set(true)
+        synchronized(outboundMonitor) { outboundMonitor.notifyAll() }
+        synchronized(ioLock) {
+            runCatching { writer?.close() }
+            writer = null
+        }
+    }
+
+    /**
+     * Shutdown-hook path: stop the loop and close stdin so the bridge exits on
+     * EOF, but do *not* notify the outbound monitor — the JVM is exiting and the
+     * old hook never woke the writer either.
+     */
+    fun closeFromShutdownHook() {
+        closed.set(true)
+        synchronized(ioLock) { runCatching { writer?.close() } }
+    }
+
+    /** Reads [input] line by line on a daemon thread; also used for the bridge's stderr. */
+    fun pump(input: InputStream, threadName: String, onLine: (String) -> Unit) {
+        val reader = BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8))
+        Thread({
+            reader.useLines { lines -> lines.forEach(onLine) }
+        }, threadName).apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    private companion object {
+        const val OUTBOUND_CAPACITY = 512
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcHandlerRegistry.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcHandlerRegistry.kt
@@ -1,0 +1,34 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.JsonObject
+
+/** Handles one decoded core→host RPC frame, addressed by its `method` string. */
+internal fun interface RpcHandler {
+    fun handle(params: JsonObject, id: Int?)
+}
+
+/**
+ * String-keyed registry of core→host RPC handlers — the dispatch mechanism that
+ * replaces the monolithic `when (method)`.
+ *
+ * Handlers are registered via chainable [on] during `CoreProcess` construction,
+ * which is single-threaded and strictly precedes the reader thread that calls
+ * [dispatch], so the map is safely published without synchronisation (writes
+ * happen-before the reader thread starts; the reader only reads). A duplicate
+ * registration is a wiring bug, not a runtime condition, so it fails fast.
+ */
+internal class RpcHandlerRegistry {
+    private val handlers = HashMap<String, RpcHandler>()
+
+    fun on(method: String, handler: RpcHandler): RpcHandlerRegistry {
+        require(handlers.put(method, handler) == null) { "Duplicate RPC handler for '$method'" }
+        return this
+    }
+
+    /** @return false when no handler is registered (caller logs the debug line). */
+    fun dispatch(method: String, params: JsonObject, id: Int?): Boolean {
+        val handler = handlers[method] ?: return false
+        handler.handle(params, id)
+        return true
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ScriptRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ScriptRouter.kt
@@ -1,0 +1,55 @@
+package io.miragon.intellij.bpmn.bridge
+
+import io.miragon.intellij.bpmn.ScriptCompletionModel
+import io.miragon.intellij.bpmn.ScriptEditorManager
+import io.miragon.intellij.bpmn.VariableInfo
+
+/**
+ * Routes the inline "Edit Script" feature. The host is a dumb surface keyed by
+ * opaque `scriptId`: it opens a script as an editor tab and streams keystrokes
+ * back as `script/didChange`, a user-initiated tab close as `script/didClose`.
+ *
+ * The [ScriptEditorManager] is lazy so opening a `.bpmn` file that never edits a
+ * script touches no editor-manager machinery; it parents to the `CoreProcess`
+ * service so its listeners die with the project.
+ */
+internal class ScriptRouter(private val deps: BridgeDeps) {
+    private val scriptEditors by lazy {
+        ScriptEditorManager(
+            deps.project,
+            deps.parentDisposable,
+            onChange = { scriptId, content ->
+                deps.channel.notify("script/didChange", linkedMapOf("scriptId" to scriptId, "content" to content))
+            },
+            onUserClose = { scriptId ->
+                deps.channel.notify("script/didClose", linkedMapOf("scriptId" to scriptId))
+            },
+        )
+    }
+
+    fun register() {
+        deps.handlers
+            // `completion` is optional and carries the kind-scoped catalog the
+            // bridge already resolved; fromJson tolerates a missing/null member.
+            .on("script/open") { params, _ ->
+                scriptEditors.openScript(
+                    params.get("scriptId").asString,
+                    params.get("fileName").asString,
+                    params.get("content").asString,
+                    deps.gson.fromJson(params.get("completion"), ScriptCompletionModel::class.java),
+                )
+            }
+            .on("script/close") { params, _ -> scriptEditors.closeScript(params.get("scriptId").asString) }
+            // Live variable model push: swap the script tab's completion catalog
+            // so the next completion invocation sees the current variables.
+            .on("script/updateVariables") { params, _ ->
+                scriptEditors.updateVariables(
+                    params.get("scriptId").asString,
+                    deps.gson.fromJson(
+                        params.get("variables"),
+                        Array<VariableInfo>::class.java,
+                    ).orEmpty().toList(),
+                )
+            }
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/SecretStoreRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/SecretStoreRouter.kt
@@ -1,0 +1,55 @@
+package io.miragon.intellij.bpmn.bridge
+
+import io.miragon.intellij.bpmn.IntellijSecretStore
+
+/**
+ * Routes the core's `SecretStorePort` to IntelliJ's PasswordSafe. These are the
+ * only reply-bearing inbound handlers: get/set both block, and PasswordSafe must
+ * not be touched on the EDT — `onLine` runs them on the background reader thread,
+ * so calling them inline is safe.
+ */
+internal class SecretStoreRouter(private val deps: BridgeDeps) {
+    private val secretStore by lazy { IntellijSecretStore() }
+
+    fun register() {
+        deps.handlers
+            .on("secretStore/saveBasicAuth") { params, id ->
+                secretStore.saveBasicAuth(params.get("username").asString, params.get("password").asString)
+                id?.let { deps.channel.reply(it, null) }
+            }
+            .on("secretStore/getBasicAuth") { _, id ->
+                val creds = secretStore.getBasicAuth()
+                val username = creds?.userName
+                val password = creds?.getPasswordAsString()
+                id?.let {
+                    deps.channel.reply(
+                        it,
+                        if (username != null && password != null) {
+                            mapOf("username" to username, "password" to password)
+                        } else {
+                            null
+                        },
+                    )
+                }
+            }
+            .on("secretStore/saveOAuth2") { params, id ->
+                secretStore.saveOAuth2(params.get("clientId").asString, params.get("clientSecret").asString)
+                id?.let { deps.channel.reply(it, null) }
+            }
+            .on("secretStore/getOAuth2") { _, id ->
+                val creds = secretStore.getOAuth2()
+                val clientId = creds?.userName
+                val clientSecret = creds?.getPasswordAsString()
+                id?.let {
+                    deps.channel.reply(
+                        it,
+                        if (clientId != null && clientSecret != null) {
+                            mapOf("clientId" to clientId, "clientSecret" to clientSecret)
+                        } else {
+                            null
+                        },
+                    )
+                }
+            }
+    }
+}


### PR DESCRIPTION
**Issue**

Closes #1103

**Description**

`CoreProcess` (956 lines) mixed four responsibilities — process supervision, RPC transport, message routing, and host-port adapters — so every new port grew the class and the hardest concurrency was interleaved with feature logic. This extracts those seams into a new `io.miragon.intellij.bpmn.bridge` package (`RpcHandlerRegistry`, `RpcChannel`, `ProcessSupervisor`, `BridgeBinaryResolver`, `BridgeDeps`, and six per-feature routers), leaving `CoreProcess` as a ~206-line `@Service` façade + composition root with an unchanged FQN and public API, mirroring the TS-side `bridge.ts`/`composition/` split. There is no behavior change: the former single `writeLock` splits into `RpcChannel.ioLock` and `ProcessSupervisor.stateLock` (held across attach/detach, lock order `stateLock → ioLock`) to keep `handleExit`'s check-and-act atomic, and lazy-init timing of every port adapter is preserved inside its owning router. The only intentional micro-differences are a benign `dispose()` ordering swap (writer closes just before shutdown-hook removal) and the stderr pump thread renamed to `modeler-bridge-stderr`.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented (out of scope — unit tests tracked separately per #1103)
* Documentation was created (KDoc added to every new class/method)