### PR TITLE
fix(intellij): give properties-panel inputs a contrasting fill in JCEF

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
@@ -63,22 +63,36 @@ class IdeThemeSignal : Disposable {
     fun bodyClass(): String = if (isDark()) "vscode-dark" else "vscode-light"
 
     /**
-     * The `:root { … }` block mapping the eight `--vscode-*` custom properties
-     * the webview's dark stylesheet actually reads onto live IDE colors. Safe to
-     * inject under a light LaF too: the light stylesheet references none of them,
-     * so the values are simply unused.
+     * The injected stylesheet: a `:root { … }` block mapping the eight
+     * `--vscode-*` custom properties the webview's dark stylesheet reads onto
+     * live IDE colors, plus a `.bio-properties-panel { … }` block forcing a
+     * contrasting input fill. The `:root` vars are safe under a light LaF (the
+     * light stylesheet references none of them); the input-fill block applies to
+     * both stylesheets, which is why it must be a direct, `!important` override
+     * rather than relying on the dark-only `--vscode-*` mapping.
      */
     fun themeVarsCss(): String {
         val scheme = EditorColorsManager.getInstance().globalScheme
         val editorBackground = ColorUtil.toHtmlColor(scheme.defaultBackground)
         val editorForeground = ColorUtil.toHtmlColor(scheme.defaultForeground)
-        val widgetBackground = ColorUtil.toHtmlColor(UIUtil.getPanelBackground())
+        val panelBg = UIUtil.getPanelBackground()
+        val widgetBackground = ColorUtil.toHtmlColor(panelBg)
         val inputBackground =
-            ColorUtil.toHtmlColor(JBColor.namedColor("TextField.background", UIUtil.getPanelBackground()))
+            ColorUtil.toHtmlColor(JBColor.namedColor("TextField.background", panelBg))
         val groupBorder = ColorUtil.toHtmlColor(JBColor.border())
         val errorForeground = ColorUtil.toHtmlColor(NamedColorUtil.getErrorForeground())
         val linkForeground = ColorUtil.toHtmlColor(JBUI.CurrentTheme.Link.Foreground.ENABLED)
         val disabledForeground = ColorUtil.toHtmlColor(NamedColorUtil.getInactiveTextColor())
+        // IntelliJ's New UI sets `TextField.background` to (almost) the panel
+        // background — native inputs are told apart by a border, not a fill — so
+        // the bpmn-js inputs, which rely on fill contrast (their border is mapped
+        // to the panel colour), visually merge into the panel. Force a fill
+        // derived from the live panel colour: lighter under a dark LaF, darker
+        // under a light one. `!important` beats both the dark stylesheet's
+        // `:root .bio-properties-panel` rule and the light stylesheet's stock
+        // bpmn-js definition regardless of selector specificity.
+        val inputContrast =
+            ColorUtil.toHtmlColor(if (isDark()) ColorUtil.brighter(panelBg, 2) else ColorUtil.darker(panelBg, 1))
         return listOf(
             ":root {",
             "  --vscode-editor-background: $editorBackground;",
@@ -89,6 +103,10 @@ class IdeThemeSignal : Disposable {
             "  --vscode-errorForeground: $errorForeground;",
             "  --vscode-textLink-foreground: $linkForeground;",
             "  --vscode-disabledForeground: $disabledForeground;",
+            "}",
+            ".bio-properties-panel {",
+            "  --input-background-color: $inputContrast !important;",
+            "  --input-focus-background-color: $inputContrast !important;",
             "}",
         ).joinToString("\n")
     }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
@@ -63,13 +63,10 @@ class IdeThemeSignal : Disposable {
     fun bodyClass(): String = if (isDark()) "vscode-dark" else "vscode-light"
 
     /**
-     * The injected stylesheet: a `:root { … }` block mapping the eight
-     * `--vscode-*` custom properties the webview's dark stylesheet reads onto
-     * live IDE colors, plus a `.bio-properties-panel { … }` block forcing a
-     * contrasting input fill. The `:root` vars are safe under a light LaF (the
-     * light stylesheet references none of them); the input-fill block applies to
-     * both stylesheets, which is why it must be a direct, `!important` override
-     * rather than relying on the dark-only `--vscode-*` mapping.
+     * The `:root` vars are read only by the webview's dark stylesheet, so
+     * they're inert under a light LaF. The `.bio-properties-panel` block applies
+     * to both stylesheets, which is why it overrides directly with `!important`
+     * instead of riding the dark-only `--vscode-*` mapping.
      */
     fun themeVarsCss(): String {
         val scheme = EditorColorsManager.getInstance().globalScheme
@@ -83,14 +80,9 @@ class IdeThemeSignal : Disposable {
         val errorForeground = ColorUtil.toHtmlColor(NamedColorUtil.getErrorForeground())
         val linkForeground = ColorUtil.toHtmlColor(JBUI.CurrentTheme.Link.Foreground.ENABLED)
         val disabledForeground = ColorUtil.toHtmlColor(NamedColorUtil.getInactiveTextColor())
-        // IntelliJ's New UI sets `TextField.background` to (almost) the panel
-        // background — native inputs are told apart by a border, not a fill — so
-        // the bpmn-js inputs, which rely on fill contrast (their border is mapped
-        // to the panel colour), visually merge into the panel. Force a fill
-        // derived from the live panel colour: lighter under a dark LaF, darker
-        // under a light one. `!important` beats both the dark stylesheet's
-        // `:root .bio-properties-panel` rule and the light stylesheet's stock
-        // bpmn-js definition regardless of selector specificity.
+        // The New UI sets `TextField.background` to ~the panel background, so
+        // bpmn-js inputs (which rely on fill contrast) merge into the panel.
+        // Derive a contrasting fill: lighter under a dark LaF, darker under light.
         val inputContrast =
             ColorUtil.toHtmlColor(if (isDark()) ColorUtil.brighter(panelBg, 2) else ColorUtil.darker(panelBg, 1))
         return listOf(


### PR DESCRIPTION
**Issue**

In the IntelliJ JCEF-hosted bpmn-webview, the properties-panel input fields (text fields, textareas, selects) had no visible background contrast against the panel and blended in — in both light and dark IDE themes. VS Code was unaffected.

**Description**

IntelliJ's New UI maps `TextField.background` to (almost) the panel background, distinguishing native inputs by a border rather than a fill, so the bpmn-js inputs (which rely on fill contrast) merged into the panel. `IdeThemeSignal.themeVarsCss()` now injects a `.bio-properties-panel` rule that forces `--input-background-color` to a contrasting fill derived from the live panel colour — lighter under a dark LaF, darker under a light one — via an `!important` override that wins over both the dark and light webview stylesheets. It rides the existing `#ide-theme-vars` re-apply path so it stays in sync on theme changes, and is host-side IntelliJ-only so VS Code and other hosts are untouched.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created