### PR TITLE
fix(bpmn-webview): fit diagram to viewport on fresh open (#1149)

### DIFF
--- a/apps/bpmn-webview/src/app/state.spec.ts
+++ b/apps/bpmn-webview/src/app/state.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { WebviewStateManager } from "./state";
+
+/**
+ * Builds a `WebviewStateManager` wired to spies for the only collaborators
+ * `restoreViewport` touches: `vscode.getState` (the saved-state source that
+ * discriminates fresh open from tab-switch rebuild) and the viewport methods.
+ */
+function setup(savedState: unknown) {
+    const getState = vi.fn().mockReturnValue(savedState);
+    const setViewport = vi.fn();
+    const fitViewport = vi.fn();
+    const vscode = { getState } as any;
+    const modeler = { viewport: { setViewport, fitViewport } } as any;
+    return {
+        manager: new WebviewStateManager(vscode, modeler),
+        setViewport,
+        fitViewport,
+    };
+}
+
+describe("WebviewStateManager.restoreViewport", () => {
+    it("restores the saved viewbox on a tab-switch rebuild", () => {
+        const viewport = { x: 10, y: 20, width: 800, height: 600 };
+        const { manager, setViewport, fitViewport } = setup({ viewport });
+
+        manager.restoreViewport();
+
+        expect(setViewport).toHaveBeenCalledWith(viewport);
+        expect(fitViewport).not.toHaveBeenCalled();
+    });
+
+    it("fits the diagram on a fresh open with no saved viewport", () => {
+        const { manager, setViewport, fitViewport } = setup(undefined);
+
+        manager.restoreViewport();
+
+        expect(fitViewport).toHaveBeenCalledOnce();
+        expect(setViewport).not.toHaveBeenCalled();
+    });
+
+    it("fits the diagram when saved state exists but carries no viewport", () => {
+        const { manager, setViewport, fitViewport } = setup({ selectedElementIds: ["a"] });
+
+        manager.restoreViewport();
+
+        expect(fitViewport).toHaveBeenCalledOnce();
+        expect(setViewport).not.toHaveBeenCalled();
+    });
+});

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -35,11 +35,19 @@ export class WebviewStateManager {
 
     /**
      * Must be called after importXML — the canvas does not exist before that.
+     *
+     * A saved viewbox only exists after a tab-switch rebuild (VS Code retains
+     * `getState()`); a fresh open/reopen starts with empty state. So the
+     * absence of a saved viewport discriminates a genuine fresh open, where we
+     * fit the diagram — bpmn-js leaves the canvas at the origin on importXML,
+     * which renders a diagram moved far from the origin off-screen (#1149).
      */
     restoreViewport(): void {
         const saved = this.getSavedState();
         if (saved?.viewport) {
             this.modeler.viewport.setViewport(saved.viewport);
+        } else {
+            this.modeler.viewport.fitViewport();
         }
     }
 

--- a/apps/bpmn-webview/src/app/viewport.spec.ts
+++ b/apps/bpmn-webview/src/app/viewport.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ViewportManager } from "./viewport";
+
+/**
+ * Builds a `ViewportManager` over a fake bpmn-js canvas whose `viewbox()`
+ * getter reports the given diagram bounding box (`inner`) and canvas pixel
+ * size (`outer`). The setter is a spy so the computed viewbox can be asserted.
+ */
+function setup(inner: Rect, outer: { width: number; height: number }) {
+    const viewbox = vi.fn((box?: unknown) => (box ? undefined : { inner, outer }));
+    const zoom = vi.fn();
+    const canvas = { viewbox, zoom };
+    const manager = new ViewportManager((name: string) => {
+        if (name === "canvas") return canvas as any;
+        throw new Error(`unexpected service: ${name}`);
+    });
+    return { manager, viewbox, zoom };
+}
+
+type Rect = { x: number; y: number; width: number; height: number };
+
+/** Screen position of a diagram point under the viewbox the setter received. */
+function project(point: number, boxOrigin: number, scale: number): number {
+    return (point - boxOrigin) * scale;
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("ViewportManager.fitViewport", () => {
+    it("falls back to bpmn-js fit for an empty diagram", () => {
+        const { manager, zoom, viewbox } = setup(
+            { x: 0, y: 0, width: 0, height: 0 },
+            { width: 1000, height: 800 },
+        );
+
+        manager.fitViewport();
+
+        expect(zoom).toHaveBeenCalledWith("fit-viewport");
+        // No manual viewbox is set in the degenerate case.
+        expect(viewbox).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the palette and never zooms in past 1.0", () => {
+        // Diagram authored far from the origin, smaller than the viewport.
+        const inner = { x: 5000, y: 4000, width: 400, height: 200 };
+        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
+
+        manager.fitViewport();
+
+        const box = viewbox.mock.calls.at(-1)?.[0] as Rect;
+        const scale = 1000 / box.width;
+        expect(scale).toBe(1); // fits comfortably → no zoom in
+
+        // Left edge of the diagram must land to the right of the 50px palette
+        // fallback (+20 margin), so no element hides behind it.
+        const leftPx = project(inner.x, box.x, scale);
+        expect(leftPx).toBeGreaterThanOrEqual(70);
+        const topPx = project(inner.y, box.y, scale);
+        expect(topPx).toBeGreaterThanOrEqual(40);
+    });
+
+    it("zooms out a diagram larger than the inset area to fit", () => {
+        const inner = { x: 0, y: 0, width: 4000, height: 3000 };
+        const { manager, viewbox } = setup(inner, { width: 1000, height: 800 });
+
+        manager.fitViewport();
+
+        const box = viewbox.mock.calls.at(-1)?.[0] as Rect;
+        const scale = 1000 / box.width;
+        expect(scale).toBeLessThan(1);
+        // The whole diagram width fits within the inset-reduced viewport.
+        const rightPx = project(inner.x + inner.width, box.x, scale);
+        expect(rightPx).toBeLessThanOrEqual(1000);
+    });
+});

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -35,12 +35,19 @@ export class ViewportManager {
     }
 
     /**
-     * Fits the whole diagram into the viewport, centering it. Used on a fresh
-     * file open (no saved viewbox) so a diagram authored far from the origin is
-     * not rendered off-screen. bpmn-js does not auto-fit on importXML.
+     * Fits the diagram into the viewport anchored at its top-left corner. Used
+     * on a fresh file open (no saved viewbox) so a diagram authored far from
+     * the origin is not rendered off-screen — bpmn-js does not auto-fit on
+     * importXML.
+     *
+     * Deliberately omits the `"auto"` center argument: centering pulls the left
+     * of larger diagrams behind the palette/properties-panel overlays (which
+     * sit on top of the canvas, not beside it). Top-left anchoring keeps the
+     * natural reading start in view and only zooms out when the diagram is
+     * larger than the viewport — it never zooms in past 1.0.
      */
     fitViewport(): void {
-        this.getService<any>("canvas").zoom("fit-viewport", "auto");
+        this.getService<any>("canvas").zoom("fit-viewport");
     }
 
     /**

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -35,19 +35,53 @@ export class ViewportManager {
     }
 
     /**
-     * Fits the diagram into the viewport anchored at its top-left corner. Used
-     * on a fresh file open (no saved viewbox) so a diagram authored far from
-     * the origin is not rendered off-screen — bpmn-js does not auto-fit on
-     * importXML.
+     * Fits the diagram into the viewport on a fresh file open (no saved
+     * viewbox) so a diagram authored far from the origin is not rendered
+     * off-screen — bpmn-js does not auto-fit on importXML.
      *
-     * Deliberately omits the `"auto"` center argument: centering pulls the left
-     * of larger diagrams behind the palette/properties-panel overlays (which
-     * sit on top of the canvas, not beside it). Top-left anchoring keeps the
-     * natural reading start in view and only zooms out when the diagram is
-     * larger than the viewport — it never zooms in past 1.0.
+     * bpmn-js's own `zoom("fit-viewport")` ignores the palette (left) and the
+     * token-simulation / minimap controls (top), which are painted *on top of*
+     * the canvas: centering pushes wide diagrams behind the palette, top-left
+     * anchoring jams the diagram under both. So we fit into an inset area that
+     * clears that chrome and center the diagram within it. The properties panel
+     * is a flex sibling of the canvas, not an overlay, so it is already
+     * excluded from `outer` and needs no inset.
+     *
+     * Scale is capped at 1.0 to match fit-to-page semantics — never zoom in.
      */
     fitViewport(): void {
-        this.getService<any>("canvas").zoom("fit-viewport");
+        const canvas = this.getService<any>("canvas");
+        const { inner, outer } = canvas.viewbox();
+
+        // No elements (or canvas not laid out yet) — nothing to fit; let
+        // bpmn-js handle the degenerate case.
+        if (!inner.width || !inner.height || !outer.width || !outer.height) {
+            canvas.zoom("fit-viewport");
+            return;
+        }
+
+        const paletteWidth =
+            document.querySelector(".djs-palette")?.getBoundingClientRect().width ?? 50;
+        const inset = { top: 40, right: 40, bottom: 40, left: paletteWidth + 20 };
+
+        const availableWidth = Math.max(1, outer.width - inset.left - inset.right);
+        const availableHeight = Math.max(1, outer.height - inset.top - inset.bottom);
+
+        const scale = Math.min(1, availableWidth / inner.width, availableHeight / inner.height);
+
+        // Center the diagram inside the inset area: split the leftover space
+        // evenly, then shift by the inset so each side keeps its own margin.
+        const marginX = inset.left + (availableWidth - inner.width * scale) / 2;
+        const marginY = inset.top + (availableHeight - inner.height * scale) / 2;
+
+        // Map diagram-space to a viewbox so the diagram's top-left lands at
+        // (marginX, marginY) px; box width/height pin the resulting scale.
+        canvas.viewbox({
+            x: inner.x - marginX / scale,
+            y: inner.y - marginY / scale,
+            width: outer.width / scale,
+            height: outer.height / scale,
+        });
     }
 
     /**

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -35,6 +35,15 @@ export class ViewportManager {
     }
 
     /**
+     * Fits the whole diagram into the viewport, centering it. Used on a fresh
+     * file open (no saved viewbox) so a diagram authored far from the origin is
+     * not rendered off-screen. bpmn-js does not auto-fit on importXML.
+     */
+    fitViewport(): void {
+        this.getService<any>("canvas").zoom("fit-viewport", "auto");
+    }
+
+    /**
      * Subscribes to canvas viewbox changes with a 100 ms debounce.
      *
      * The debounce prevents a flood of state writes while the user is actively


### PR DESCRIPTION
**Issue**

Closes #1149 — a BPMN diagram whose elements were moved far from the origin renders off-screen when the file is closed and reopened.

**Description**

bpmn-js does not auto-fit the viewport on `importXML`, so on a fresh open the canvas sits at the origin and a relocated diagram is partially or fully off-screen. `restoreViewport()` now fits the diagram when no saved viewbox exists, while the tab-switch rebuild path (where VS Code retains `getState()`) still restores the user's pan/zoom unchanged. The fix lives in the shared webview code, so it applies to both VS Code and IntelliJ; a new `fitViewport()` on `ViewportManager` mirrors the existing readonly `DiffViewer` call, and a `state.spec.ts` covers all three branches.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created