### PR TITLE
fix(modeler-bridge): poll on Windows so chokidar stops locking element-templates (#1148)

### DIFF
--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -226,6 +226,13 @@ export class NodeWorkspace implements WorkspacePort {
      * `node_modules`/`.git` are pruned so arming the recursive watch on a large
      * repo stays within the OS watch-descriptor budget (inotify on Linux).
      * Dot-dirs in general must stay watched — templates live under `.camunda/`.
+     *
+     * On Windows the watch runs in polling mode (`usePolling`). chokidar v3 has
+     * no native recursive Windows watch, so it opens a `ReadDirectoryChangesW`
+     * handle per directory; that handle locks `element-templates` against moves
+     * while a BPMN file is open (#1148). Polling via `fs.watchFile` holds no
+     * directory handle, releasing the lock — Bun implements `fs.watchFile`, so
+     * this works under the compiled bridge runtime.
      */
     createWatcher(
         rootPath: string,
@@ -274,6 +281,15 @@ export class NodeWorkspace implements WorkspacePort {
             // skip the synthetic `add` storm chokidar emits for existing files.
             ignoreInitial: true,
             ignored: /(^|[/\\])(node_modules|\.git)([/\\]|$)/,
+            // chokidar v3 has no native recursive watch on Windows, so it opens a
+            // `ReadDirectoryChangesW` handle per directory — including
+            // `element-templates`. That held handle makes Windows reject a `mv`
+            // into the folder while a BPMN file is open (#1148). Polling uses
+            // `fs.watchFile` (stat-based) and holds no directory handle, so the
+            // lock disappears; the cost is bounded by the node_modules/.git prune.
+            usePolling: process.platform === "win32",
+            interval: 300,
+            binaryInterval: 300,
         });
         watcher
             .on("add", (p) => fireDebounced(handlers.onCreate, p))

--- a/apps/modeler-bridge/src/nodeAdapters.watcherOptions.spec.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.watcherOptions.spec.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NodeWorkspace } from "./nodeAdapters";
+
+/**
+ * Mocks chokidar to capture the options object `createWatcher` hands to
+ * `watch(root, opts)`. The real-chokidar suite in `nodeAdapters.spec.ts`
+ * cannot assert this: `usePolling` is `false` on the macOS/Linux CI it runs on,
+ * so the Windows lock fix (#1148) would be unverified everywhere it actually
+ * matters. Mocking makes the assertion deterministic on every OS — it pins that
+ * the Windows branch sets stat-based polling instead of `fs.watch`.
+ */
+const { watchSpy } = vi.hoisted(() => ({
+    watchSpy: vi.fn((_root: string, _opts: Record<string, unknown>) => ({
+        on() {
+            return this;
+        },
+        close() {
+            return Promise.resolve();
+        },
+    })),
+}));
+
+vi.mock("chokidar", () => ({ watch: watchSpy }));
+
+describe("NodeWorkspace.createWatcher chokidar options", () => {
+    afterEach(() => {
+        watchSpy.mockClear();
+        vi.unstubAllGlobals();
+    });
+
+    /** Reads the options object passed to the single `watch()` call. */
+    function capturedOptions(): Record<string, unknown> {
+        new NodeWorkspace().createWatcher("/repo", "**/*.json", {});
+        expect(watchSpy).toHaveBeenCalledTimes(1);
+        return watchSpy.mock.calls[0][1];
+    }
+
+    it("enables stat polling on Windows so no directory handle locks element-templates", () => {
+        vi.stubGlobal("process", { ...process, platform: "win32" });
+
+        const opts = capturedOptions();
+
+        expect(opts.usePolling).toBe(true);
+        expect(opts.interval).toBe(300);
+        expect(opts.binaryInterval).toBe(300);
+    });
+
+    it("keeps native fs.watch on non-Windows platforms", () => {
+        vi.stubGlobal("process", { ...process, platform: "linux" });
+
+        expect(capturedOptions().usePolling).toBe(false);
+    });
+});


### PR DESCRIPTION
**Issue**

Closes #1148 — on Windows + IntelliJ, with a BPMN file open, moving a JSON file into `<configFolder>/element-templates` failed with `mv: ... Permission denied`.

**Description**

The IntelliJ `modeler-bridge` watches the workspace root with chokidar, which on Windows (no native recursive watch) opens a `ReadDirectoryChangesW` handle per directory — including `element-templates` — locking it against moves while a session is open. This enables chokidar's stat-based `usePolling` mode on Windows only (`fs.watchFile`, no directory handle), so the lock disappears while live-reload keeps working on every platform; the `node_modules`/`.git` prune keeps polling cost bounded. A new cross-platform unit test mocks chokidar and pins the `usePolling`/`interval` options per platform.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created