### PR TITLE
chore(ci): mint App token for intellij publish instead of RELEASE_PAT

### DIFF
--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -174,32 +174,72 @@ jobs:
             --version "${{ steps.tag.outputs.version }}" \
             --download-url "$DOWNLOAD_URL"
 
-      # Push the regenerated XML to main so deploy-docs.yml picks it up and
-      # republishes Pages. The IDE polls the Pages URL — no XML refresh, no
-      # update notification. We stash the generated file across the branch
-      # switch because the working tree is currently on the release tag.
+      # Commit the regenerated XML to main via the GraphQL
+      # createCommitOnBranch mutation instead of a local `git push`. A pushed
+      # local commit is unsigned and would only land by punching through the
+      # branch ruleset's required_signatures rule; an API-created commit is
+      # signed with GitHub's key (verified), so it satisfies that rule honestly.
+      # The App installation token (not GITHUB_TOKEN) authors it, so the
+      # resulting push to main still triggers deploy-docs.yml. No working-tree
+      # branch switch is needed — we send the file the previous step generated.
       - name: Commit updatePlugins.xml to main
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}"
-          cp -f docs/public/updatePlugins.xml /tmp/updatePlugins.xml
-          git fetch origin main
-          # The regenerated XML differs from the tag's tracked copy, so a plain
-          # `git checkout main` aborts with "local changes would be
-          # overwritten" on any re-publish of an older tag. The file is already
-          # stashed to /tmp, so discarding the worktree change with -f is safe.
-          git checkout -f main
-          git pull --ff-only origin main
-          mkdir -p docs/public
-          cp -f /tmp/updatePlugins.xml docs/public/updatePlugins.xml
-          git add docs/public/updatePlugins.xml
-          if git diff --cached --quiet; then
-            echo "updatePlugins.xml is unchanged on main; nothing to commit."
-          else
-            git commit -m "chore(release): refresh updatePlugins.xml for v${{ steps.tag.outputs.version }}"
-            git push origin main
-          fi
+          set -euo pipefail
+          XML_PATH="docs/public/updatePlugins.xml"
+          NEW_B64=$(base64 -w0 "$XML_PATH")
+
+          commit_xml() {
+            # expectedHeadOid makes this an optimistic-concurrency write: the
+            # mutation is rejected if main moved since we read its head. gh
+            # exits 0 on a GraphQL-level error (HTTP 200 with an `errors`
+            # array), so we must inspect the body, not just the exit code.
+            local head_oid="$1" resp
+            resp=$(jq -n \
+              --arg repo "${{ github.repository }}" \
+              --arg oid "$head_oid" \
+              --arg path "$XML_PATH" \
+              --arg contents "$NEW_B64" \
+              --arg headline "chore(release): refresh updatePlugins.xml for v${{ steps.tag.outputs.version }}" \
+              '{query: "mutation($i: CreateCommitOnBranchInput!){createCommitOnBranch(input:$i){commit{oid}}}",
+                variables: {i: {
+                  branch: {repositoryNameWithOwner: $repo, branchName: "main"},
+                  expectedHeadOid: $oid,
+                  message: {headline: $headline},
+                  fileChanges: {additions: [{path: $path, contents: $contents}]}
+                }}}' \
+              | gh api graphql --input - 2>&1) || { echo "$resp" >&2; return 1; }
+            if printf '%s' "$resp" | grep -q '"errors"'; then
+              echo "$resp" >&2
+              return 1
+            fi
+          }
+
+          for attempt in 1 2 3; do
+            HEAD_OID=$(gh api "repos/${{ github.repository }}/branches/main" --jq .commit.sha)
+
+            # Skip when main already carries this exact XML so re-publishing an
+            # unchanged descriptor doesn't create a no-op commit (and an
+            # unnecessary deploy-docs run). A 404 (file absent) leaves
+            # CURRENT_B64 empty and falls through to the commit.
+            CURRENT_B64=$(gh api "repos/${{ github.repository }}/contents/${XML_PATH}?ref=main" --jq .content 2>/dev/null | tr -d '\n' || true)
+            if [ -n "$CURRENT_B64" ] && [ "$(printf '%s' "$CURRENT_B64" | base64 -d | base64 -w0)" = "$NEW_B64" ]; then
+              echo "updatePlugins.xml is unchanged on main; nothing to commit."
+              exit 0
+            fi
+
+            if commit_xml "$HEAD_OID"; then
+              echo "Committed updatePlugins.xml to main (was head ${HEAD_OID})."
+              exit 0
+            fi
+
+            echo "createCommitOnBranch attempt ${attempt} failed (main head may have moved); retrying." >&2
+            sleep 3
+          done
+
+          echo "Failed to commit updatePlugins.xml to main after 3 attempts." >&2
+          exit 1
 
       # Record a per-host deployment so the repo Environments page shows the
       # IntelliJ plugin's last-published version. The environment auto-creates

--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -29,9 +29,12 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     # Gate the production publish behind the jetbrains-marketplace environment
-    # so RELEASE_PAT is only readable after the environment's protection rules
-    # (required reviewers / branch restrictions) pass. No dry-run input — every
-    # run publishes — so the gate applies unconditionally.
+    # so the publish action itself only proceeds after the environment's
+    # protection rules (required reviewers / branch restrictions) pass. The
+    # credential is now the miragon-release-please App key (a repo/org secret,
+    # readable by env-gated jobs), so the gate protects the act of publishing,
+    # not a PAT-scoped secret. No dry-run input — every run publishes — so the
+    # gate applies unconditionally.
     environment: jetbrains-marketplace
 
     steps:
@@ -52,7 +55,6 @@ jobs:
           ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
           persist-credentials: false
-          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Check pinned dependencies
         uses: Miragon/pin-npm-dependencies@v1
@@ -143,9 +145,22 @@ jobs:
             done
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # Mint the App token here, after the long cross-compile + Gradle build,
+      # rather than at job start: installation tokens expire after 1 hour and
+      # the build alone could approach that window. A late token gives a fresh
+      # ~1h for the quick tail (release upload + push to main). The push needs a
+      # non-GITHUB_TOKEN credential so the resulting commit triggers
+      # deploy-docs.yml — same reason release-please uses this App.
+      - name: Generate App token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+
       - name: Upload ZIP to release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release upload "${{ steps.tag.outputs.tag }}" "${{ steps.zip.outputs.path }}" --clobber
 
@@ -167,7 +182,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/${{ github.repository }}"
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}"
           cp -f docs/public/updatePlugins.xml /tmp/updatePlugins.xml
           git fetch origin main
           # The regenerated XML differs from the tag's tracked copy, so a plain

--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -217,7 +217,15 @@ jobs:
           }
 
           for attempt in 1 2 3; do
-            HEAD_OID=$(gh api "repos/${{ github.repository }}/branches/main" --jq .commit.sha)
+            # Guard the head read so a transient API error (5xx / secondary
+            # rate limit) retries instead of aborting the step via `set -e` —
+            # the retry loop must cover the read it depends on, not just the
+            # commit mutation below.
+            HEAD_OID=$(gh api "repos/${{ github.repository }}/branches/main" --jq .commit.sha) || {
+              echo "Reading main head failed on attempt ${attempt}; retrying." >&2
+              sleep 3
+              continue
+            }
 
             # Skip when main already carries this exact XML so re-publishing an
             # unchanged descriptor doesn't create a no-op commit (and an

--- a/apps/standalone/README.md
+++ b/apps/standalone/README.md
@@ -160,7 +160,6 @@ whole chain.
 | `APPLE_ID` | Apple ID email of a Miragon team member |
 | `APPLE_APP_SPECIFIC_PASSWORD` | generated at appleid.apple.com |
 | `APPLE_TEAM_ID` | `G5JZQ328LJ` |
-| `RELEASE_PAT` | PAT with `repo` scope, used by `prepare` to push commits/tags |
 | `HOMEBREW_TAP_TOKEN` | PAT with `repo` scope on `Miragon/homebrew-tap` (recommended: scope to the `homebrew-tap` environment, see below) |
 
 ### Approval gate / environment setup


### PR DESCRIPTION
**Issue**

Retires the last consumer of the \`RELEASE_PAT\` personal access token. After #1146 moved release-please to the \`miragon-release-please\` GitHub App, \`publish-intellij.yml\` was the only workflow still referencing the PAT.

**Description**

\`publish-intellij.yml\` now mints a short-lived \`miragon-release-please\` App installation token (mirroring release-please), generated late in the job so its 1-hour lifetime covers the quick tail (release upload + XML refresh). The checkout drops the explicit token and falls back to the default \`github.token\`. The \`updatePlugins.xml\` refresh no longer does a local \`git push\` — it commits via the GraphQL \`createCommitOnBranch\` mutation, so the commit is **signed with GitHub's key** (satisfying the \`main\` ruleset's \`required_signatures\` rule) and, because the App token authors it, the resulting push still triggers \`deploy-docs.yml\`. **Before relying on this:** the App must be in \`main\`'s ruleset bypass list (the ruleset requires PRs, so a direct write still needs bypass) and its installation must grant \`contents: write\`.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created