### PR TITLE
chore(ci): add cost-tuned CodeQL advanced-setup workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, reopened, synchronize ]
+  push:
+    branches: [ main ]
+  # Re-scan unchanged code against updated query packs
+  schedule:
+    - cron: '27 3 * * 1'  # Mondays 03:27 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ javascript-typescript, actions ]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Why

CodeQL currently runs via GitHub's **default setup**, which re-scans on every default-branch push + every PR with no concurrency cancellation, and analyses a **redundant language list** (`javascript`, `typescript`, *and* the combined `javascript-typescript`). The result is many overlapping runs and avoidable CI cost.

This replaces default setup with a committed **advanced-setup** workflow that we can tune.

## What changed

A single `.github/workflows/codeql.yml`:

- **Triggers** — `pull_request` → `main` (the gate that blocks bad code before merge), `push` → `main` (the run that writes the Security tab after squash-merge), and a **weekly** `schedule` (catches new findings in unchanged code as query packs update). No per-push scans on feature branches.
- **Concurrency** — cancels superseded PR scans, but **never** cancels `main`/`schedule` runs (the `refs/heads/main` guard, matching `build.yml`), so the authoritative alert state is never left partial.
- **Language matrix** — `javascript-typescript` + `actions` only. Drops the duplicate `javascript`/`typescript` entries that double-analysed the same code under default setup.
- Default query suite (matches the previous `query_suite: default` — no added cost).

No path/scope exclusions: `docs/` stays in scope on purpose — it's published to GitHub Pages and `DownloadPage.vue` fetches remote release data into `:href` sinks, which is exactly the `remote` taint flow CodeQL should cover.

## ⚠️ Required manual steps (cannot be done in this PR)

1. **Disable default setup** — advanced + default setup are mutually exclusive; this workflow will fail to upload results until default setup is turned off:
   Settings → Code security → Code scanning → CodeQL analysis → switch off / "Switch to advanced".
   Verify: `gh api repos/:owner/:repo/code-scanning/default-setup --jq '.state'` → `not-configured`.
2. **Branch protection** — switching renames the status check to `Analyze (javascript-typescript)` / `Analyze (actions)`. If code scanning is a *required* check, update the required-checks list to the new names, or the gate blocks on a check that never reports.