### PR TITLE
chore(release): drop redundant homebrew-tap approval gate

### DIFF
--- a/.github/workflows/publish-standalone-homebrew.yml
+++ b/.github/workflows/publish-standalone-homebrew.yml
@@ -8,8 +8,10 @@ name: Publish Standalone (Homebrew)
 #   - workflow_dispatch (manual rerun) — sha256 and filename are recomputed
 #     by downloading the DMG from the release.
 #
-# Required GitHub repo secret (or homebrew-tap environment secret):
+# Required GitHub repo (or org) secret:
 #   HOMEBREW_TAP_TOKEN   PAT with repo scope on Miragon/homebrew-tap
+#   This job is intentionally ungated (see update-tap below), so the token must
+#   be readable without the homebrew-tap environment.
 
 on:
   workflow_dispatch:
@@ -53,7 +55,11 @@ jobs:
   update-tap:
     name: Update Cask formula
     runs-on: ubuntu-latest
-    environment: homebrew-tap
+    # No environment gate: in the release chain this job runs after
+    # publish-standalone.yml, which is already approved via the `standalone`
+    # environment. A second `homebrew-tap` gate here would force a redundant
+    # approval (GitHub requires one approval per job that targets a protected
+    # environment). HOMEBREW_TAP_TOKEN must therefore be a repo/org secret.
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

During a release, the standalone path required **two** manual environment approvals — one for the `standalone` environment (gating `publish-standalone.yml`) and a second for the `homebrew-tap` environment (gating `publish-standalone-homebrew.yml`).

The homebrew job runs *after* the already-approved publish job (`needs: publish`), so the second gate only added a redundant prompt. GitHub requires one approval **per job** that targets a protected environment, so reusing the same environment name wouldn't help — the gate has to be removed entirely.

This removes `environment: homebrew-tap` from the `update-tap` job, collapsing the standalone path to a single up-front approval (the `standalone` environment).

## ⚠️ Required before merge

`HOMEBREW_TAP_TOKEN` must be available as a **repository (or org) secret**. With the environment gate gone, an environment-scoped secret on `homebrew-tap` would no longer be readable and the tap push would fail. `secrets: inherit` already forwards repo/org secrets through the release chain.

## Scope

This only removes the *extra* homebrew approval. A full release still prompts separately for `vscode-marketplace`, `jetbrains-marketplace`, and `standalone`, since each is a distinct protected environment on a distinct job. Reducing those is a GitHub environment-protection-rules decision, not a workflow change.