### PR TITLE
chore(modeler-bridge): single-source-of-truth for the host↔core RPC protocol

### DIFF
--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -35,6 +35,16 @@ import {
 
 import { BridgeSettings } from "./nodeAdapters";
 import { Rpc } from "./rpc";
+import { METHODS } from "./protocol/descriptor";
+import {
+    BasicAuthCredentials,
+    ClipboardReadResult,
+    DocumentSaveResult,
+    DocumentWriteResult,
+    OAuth2Credentials,
+    PickerShowParams,
+    PickerShowResult,
+} from "./protocol/types";
 
 /** Per-editor metadata + cached document text, keyed by `editorId` (the URI string). */
 export interface SessionMeta {
@@ -135,18 +145,18 @@ export class RpcEditorHandle implements EditorHandle {
     }
 
     async writeContent(content: string): Promise<boolean> {
-        const result = (await this.rpc.request("document/write", {
+        const result = (await this.rpc.request(METHODS.documentWrite, {
             editorId: this.id,
             content,
-        })) as { changed?: boolean } | null;
+        })) as DocumentWriteResult | null;
         this.mirror.setContent(this.id, content);
         return result?.changed ?? false;
     }
 
     async save(): Promise<boolean> {
-        const result = (await this.rpc.request("document/save", { editorId: this.id })) as {
-            saved?: boolean;
-        } | null;
+        const result = (await this.rpc.request(METHODS.documentSave, {
+            editorId: this.id,
+        })) as DocumentSaveResult | null;
         return result?.saved ?? false;
     }
 
@@ -157,7 +167,7 @@ export class RpcEditorHandle implements EditorHandle {
      * (the VS Code handle returns webview visibility here).
      */
     async postMessage(message: Command | Query): Promise<boolean> {
-        this.rpc.notify("editor/postMessage", { editorId: this.id, message });
+        this.rpc.notify(METHODS.editorPostMessage, { editorId: this.id, message });
         return true;
     }
 
@@ -232,18 +242,19 @@ export class RpcDocumentPort implements DocumentPort {
     }
 
     async write(editorId: string, content: string): Promise<boolean> {
-        const result = (await this.rpc.request("document/write", { editorId, content })) as {
-            changed?: boolean;
-        } | null;
+        const result = (await this.rpc.request(METHODS.documentWrite, {
+            editorId,
+            content,
+        })) as DocumentWriteResult | null;
         // Keep the mirror current so a later synchronous getContent() is correct.
         this.mirror.setContent(editorId, content);
         return result?.changed ?? false;
     }
 
     async save(editorId: string): Promise<boolean> {
-        const result = (await this.rpc.request("document/save", { editorId })) as {
-            saved?: boolean;
-        } | null;
+        const result = (await this.rpc.request(METHODS.documentSave, {
+            editorId,
+        })) as DocumentSaveResult | null;
         return result?.saved ?? false;
     }
 }
@@ -258,37 +269,37 @@ export class RpcNotifier implements NotifierPort {
     constructor(private readonly rpc: Rpc) {}
 
     showInfo(message: string): void {
-        this.rpc.notify("notifier/showInfo", { message });
+        this.rpc.notify(METHODS.notifierShowInfo, { message });
     }
 
     showError(message: string): void {
-        this.rpc.notify("notifier/showError", { message });
+        this.rpc.notify(METHODS.notifierShowError, { message });
     }
 
     notifyError(context: string, error: Error): void {
         // Preserve the log-then-toast convention: the host logs the detail and
         // shows a balloon pairing the caller's context with the error message.
-        this.rpc.notify("notifier/log", {
+        this.rpc.notify(METHODS.notifierLog, {
             level: "error",
             message: `${context}: ${error.message}`,
         });
-        this.rpc.notify("notifier/notifyError", { context, message: error.message });
+        this.rpc.notify(METHODS.notifierNotifyError, { context, message: error.message });
     }
 
     openLoggingConsole(): void {
-        this.rpc.notify("notifier/openConsole", {});
+        this.rpc.notify(METHODS.notifierOpenConsole, {});
     }
 
     logInfo(message: string): void {
-        this.rpc.notify("notifier/log", { level: "info", message });
+        this.rpc.notify(METHODS.notifierLog, { level: "info", message });
     }
 
     logWarning(message: string): void {
-        this.rpc.notify("notifier/log", { level: "warn", message });
+        this.rpc.notify(METHODS.notifierLog, { level: "warn", message });
     }
 
     logError(error: Error): void {
-        this.rpc.notify("notifier/log", { level: "error", message: error.message });
+        this.rpc.notify(METHODS.notifierLog, { level: "error", message: error.message });
     }
 
     /**
@@ -297,16 +308,16 @@ export class RpcNotifier implements NotifierPort {
      * notifications and `finally` guarantees the spinner clears even on throw.
      */
     async withProgress<T>(title: string, task: () => Promise<T>): Promise<T> {
-        this.rpc.notify("notifier/progressStart", { title });
+        this.rpc.notify(METHODS.notifierProgressStart, { title });
         try {
             return await task();
         } finally {
-            this.rpc.notify("notifier/progressEnd", { title });
+            this.rpc.notify(METHODS.notifierProgressEnd, { title });
         }
     }
 
     async openDocument(absolutePath: string): Promise<void> {
-        this.rpc.notify("notifier/openDocument", { path: absolutePath });
+        this.rpc.notify(METHODS.notifierOpenDocument, { path: absolutePath });
     }
 }
 
@@ -319,27 +330,27 @@ export class RpcStatusBar implements StatusBarPort {
     constructor(private readonly rpc: Rpc) {}
 
     showElementTemplatesLoading(): void {
-        this.rpc.notify("statusBar/templatesLoading", {});
+        this.rpc.notify(METHODS.statusBarTemplatesLoading, {});
     }
 
     showElementTemplatesReady(count: number): void {
-        this.rpc.notify("statusBar/templatesReady", { count });
+        this.rpc.notify(METHODS.statusBarTemplatesReady, { count });
     }
 
     hideElementTemplatesStatus(): void {
-        this.rpc.notify("statusBar/templatesHide", {});
+        this.rpc.notify(METHODS.statusBarTemplatesHide, {});
     }
 
     showEngineVersion(platform: Engine, version: string): void {
-        this.rpc.notify("statusBar/showEngineVersion", { platform, version });
+        this.rpc.notify(METHODS.statusBarShowEngineVersion, { platform, version });
     }
 
     hideEngineVersion(): void {
-        this.rpc.notify("statusBar/hideEngineVersion", {});
+        this.rpc.notify(METHODS.statusBarHideEngineVersion, {});
     }
 
     disposeEngineVersionStatus(): void {
-        this.rpc.notify("statusBar/disposeEngineVersion", {});
+        this.rpc.notify(METHODS.statusBarDisposeEngineVersion, {});
     }
 }
 
@@ -357,14 +368,15 @@ export class RpcClipboard implements ClipboardPort {
     constructor(private readonly rpc: Rpc) {}
 
     async readClipboard(): Promise<string> {
-        const result = (await this.rpc.request("clipboard/read", {})) as {
-            text?: string;
-        } | null;
+        const result = (await this.rpc.request(
+            METHODS.clipboardRead,
+            {},
+        )) as ClipboardReadResult | null;
         return result?.text ?? "";
     }
 
     async writeClipboard(text: string): Promise<void> {
-        this.rpc.notify("clipboard/write", { text });
+        this.rpc.notify(METHODS.clipboardWrite, { text });
     }
 }
 
@@ -380,26 +392,26 @@ export class RpcSecretStore implements SecretStorePort {
     constructor(private readonly rpc: Rpc) {}
 
     async saveBasicAuth(username: string, password: string): Promise<void> {
-        await this.rpc.request("secretStore/saveBasicAuth", { username, password });
+        await this.rpc.request(METHODS.secretStoreSaveBasicAuth, { username, password });
     }
 
-    async getBasicAuth(): Promise<{ username: string; password: string } | undefined> {
-        const result = (await this.rpc.request("secretStore/getBasicAuth", {})) as {
-            username: string;
-            password: string;
-        } | null;
+    async getBasicAuth(): Promise<BasicAuthCredentials | undefined> {
+        const result = (await this.rpc.request(
+            METHODS.secretStoreGetBasicAuth,
+            {},
+        )) as BasicAuthCredentials | null;
         return result ?? undefined;
     }
 
     async saveOAuth2(clientId: string, clientSecret: string): Promise<void> {
-        await this.rpc.request("secretStore/saveOAuth2", { clientId, clientSecret });
+        await this.rpc.request(METHODS.secretStoreSaveOAuth2, { clientId, clientSecret });
     }
 
-    async getOAuth2(): Promise<{ clientId: string; clientSecret: string } | undefined> {
-        const result = (await this.rpc.request("secretStore/getOAuth2", {})) as {
-            clientId: string;
-            clientSecret: string;
-        } | null;
+    async getOAuth2(): Promise<OAuth2Credentials | undefined> {
+        const result = (await this.rpc.request(
+            METHODS.secretStoreGetOAuth2,
+            {},
+        )) as OAuth2Credentials | null;
         return result ?? undefined;
     }
 }
@@ -465,17 +477,17 @@ export class RpcDeploymentState implements DeploymentStatePort {
 
     async saveAuthType(authType: AuthTypePayload): Promise<void> {
         this.snapshot = { ...this.snapshot, authType };
-        this.rpc.notify("deploymentState/saveAuthType", { authType });
+        this.rpc.notify(METHODS.deploymentStateSaveAuthType, { authType });
     }
 
     async saveOAuth2Config(tokenEndpoint: string, audience: string): Promise<void> {
         this.snapshot = { ...this.snapshot, tokenEndpoint, audience };
-        this.rpc.notify("deploymentState/saveOAuth2Config", { tokenEndpoint, audience });
+        this.rpc.notify(METHODS.deploymentStateSaveOAuth2Config, { tokenEndpoint, audience });
     }
 
     async save(endpoint: string, tenantId: string): Promise<void> {
         this.snapshot = { ...this.snapshot, endpoint, tenantId };
-        this.rpc.notify("deploymentState/save", { endpoint, tenantId });
+        this.rpc.notify(METHODS.deploymentStateSave, { endpoint, tenantId });
     }
 }
 
@@ -487,12 +499,6 @@ export class RpcDeploymentState implements DeploymentStatePort {
  */
 export interface FileFinder {
     findFiles(pattern: string, exclude?: string | null, limit?: number): Promise<string[]>;
-}
-
-/** One row offered to the host popup: a label plus optional greyed detail. */
-interface PickItem {
-    label: string;
-    description?: string;
 }
 
 /**
@@ -511,15 +517,11 @@ export class RpcPicker implements PickerPort {
     ) {}
 
     /** Round-trips one popup; returns the chosen indices or `null` on cancel. */
-    private async show(opts: {
-        title?: string;
-        placeholder: string;
-        canPickMany: boolean;
-        items: PickItem[];
-    }): Promise<number[] | null> {
-        const result = (await this.rpc.request("picker/show", opts)) as {
-            selected?: number[] | null;
-        } | null;
+    private async show(opts: PickerShowParams): Promise<number[] | null> {
+        const result = (await this.rpc.request(
+            METHODS.pickerShow,
+            opts,
+        )) as PickerShowResult | null;
         return result?.selected ?? null;
     }
 

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -15,22 +15,13 @@
  * `createBridge` is a pure composition root: it builds the shared collaborators
  * once ({@link buildSharedDeps}) and lets each `composition/*Feature.ts` module
  * wire its own services and register its own slice of the protocol. Each
- * Host→Core method group below is implemented by the matching feature module;
- * this table is the index (a seed for a later protocol-typing effort).
+ * Host→Core method group is implemented by the matching feature module.
  *
- * Protocol (see {@link Rpc} for framing):
- *   Host → Core (notifications): session/register, webview/message,
- *                                document/didChange, settings/didChange,
- *                                session/setActive, session/dispose,
- *                                diff/open, diff/webviewMessage, diff/dispose,
- *                                deploymentState/seed, deployment/webviewMessage,
- *                                deployment/open, script/didChange, script/didClose
- *   Core → Host (requests):      document/write, document/save, picker/show,
- *                                secretStore/*
- *   Core → Host (notifications): editor/postMessage, diff/postMessage,
- *                                deployment/postMessage, deploymentState/save*,
- *                                notifier/*, statusBar/*, script/open, script/close,
- *                                script/updateVariables
+ * The full RPC surface — method names, direction, and param/result shapes — is
+ * the single source of truth in `protocol/descriptor.ts` (with `METHODS.*`
+ * constants consumed at every call-site), kept honest by `protocol.spec.ts` and
+ * the checked-in `protocol/protocol.json` snapshot. `protocolTable()` renders
+ * the canonical, un-rottable method index that used to live in this comment.
  *
  * DMN is deliberately out of scope here — it has no IntelliJ editor yet; this
  * covers the BPMN editor, diff and deployment. The

--- a/apps/modeler-bridge/src/composition/deploymentFeature.ts
+++ b/apps/modeler-bridge/src/composition/deploymentFeature.ts
@@ -1,4 +1,3 @@
-import { Command } from "@miragon/bpmn-modeler-shared";
 import {
     AuthHeaderResolver,
     Camunda7RestClient,
@@ -10,7 +9,13 @@ import {
     StartInstanceService,
 } from "@miragon/bpmn-modeler-core";
 
-import { DeploymentStateSnapshot, RpcDeploymentState, RpcSecretStore } from "../adapters";
+import { RpcDeploymentState, RpcSecretStore } from "../adapters";
+import { METHODS } from "../protocol/descriptor";
+import {
+    DeploymentOpenParams,
+    DeploymentSeedParams,
+    DeploymentWebviewMessageParams,
+} from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
 
 /**
@@ -61,7 +66,7 @@ export function register(deps: BridgeSharedDeps): void {
         deploymentService,
         startInstanceService,
         deps.notifier,
-        (message) => deps.rpc.notify("deployment/postMessage", { message }),
+        (message) => deps.rpc.notify(METHODS.deploymentPostMessage, { message }),
     );
 
     // The form's defaults track the active editor, but only while the panel is
@@ -76,19 +81,19 @@ export function register(deps: BridgeSharedDeps): void {
 
     // Seed the deployment-state mirror once at startup (and after a persisted
     // save, if the host chooses to re-seed); getters then read it synchronously.
-    deps.rpc.on("deploymentState/seed", (params: { state: Partial<DeploymentStateSnapshot> }) => {
+    deps.rpc.on(METHODS.deploymentStateSeed, (params: DeploymentSeedParams) => {
         deploymentState.seed(params.state);
     });
 
     // Inbound deployment-webview message → the shared dispatch core. Errors are
     // caught inside each handler, so this never rejects.
-    deps.rpc.on("deployment/webviewMessage", (params: { message: Command }) => {
+    deps.rpc.on(METHODS.deploymentWebviewMessage, (params: DeploymentWebviewMessageParams) => {
         void deploymentDispatcher.handle(params.message);
     });
 
     // The host reports the tool window's visibility; on open, push the current
     // form defaults so the panel reflects the active diagram immediately.
-    deps.rpc.on("deployment/open", (params: { open: boolean }) => {
+    deps.rpc.on(METHODS.deploymentOpen, (params: DeploymentOpenParams) => {
         deploymentPanelOpen = params.open;
         if (params.open) {
             deploymentDispatcher.sendFormDefaults();

--- a/apps/modeler-bridge/src/composition/diffFeature.ts
+++ b/apps/modeler-bridge/src/composition/diffFeature.ts
@@ -1,21 +1,9 @@
-import { Command, DiffOrigin } from "@miragon/bpmn-modeler-shared";
 import { BpmnDiffService, DiffPaneStore, DiffSession } from "@miragon/bpmn-modeler-core";
 
 import { RpcDiffPaneHandle, dispatchDiffMessage } from "../diffAdapters";
+import { METHODS } from "../protocol/descriptor";
+import { DiffDisposeParams, DiffOpenParams, DiffWebviewMessageParams } from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
-
-interface DiffPaneInput {
-    /** Stable, diff-scoped pane identity (host appends `#<diffId>-<role>`). */
-    uri: string;
-    content: string;
-}
-
-interface DiffOpenParams {
-    diffId: string;
-    origin: DiffOrigin;
-    before: DiffPaneInput;
-    after: DiffPaneInput;
-}
 
 /**
  * The diff feature owns the production diff brain (`DiffPaneStore` +
@@ -47,7 +35,7 @@ export function register(deps: BridgeSharedDeps): { rebroadcastLanguage: () => v
      * assigned by the host, so the `forScm`/`forCompareFiles` choice is made by
      * origin alone — only so the legend's origin-specific chrome stays correct.
      */
-    deps.rpc.on("diff/open", (params: DiffOpenParams) => {
+    deps.rpc.on(METHODS.diffOpen, (params: DiffOpenParams) => {
         const beforeHandle = new RpcDiffPaneHandle(
             params.before.uri,
             params.before.content,
@@ -70,14 +58,14 @@ export function register(deps: BridgeSharedDeps): { rebroadcastLanguage: () => v
         deps.log(`diff opened: ${params.diffId} (${params.origin})`);
     });
 
-    deps.rpc.on("diff/webviewMessage", (params: { paneUri: string; message: Command }) => {
+    deps.rpc.on(METHODS.diffWebviewMessage, (params: DiffWebviewMessageParams) => {
         const handle = diffPanes.get(params.paneUri);
         if (handle) {
             void dispatchDiffMessage(diffService, handle, params.message);
         }
     });
 
-    deps.rpc.on("diff/dispose", (params: { diffId: string }) => {
+    deps.rpc.on(METHODS.diffDispose, (params: DiffDisposeParams) => {
         const session = diffSessions.get(params.diffId);
         if (!session) {
             return;

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -2,8 +2,15 @@ import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-share
 import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
 
 import { RpcEditorHandle } from "../adapters";
+import { METHODS } from "../protocol/descriptor";
+import {
+    DocumentDidChangeParams,
+    EditorRefParams,
+    RegisterParams,
+    WebviewMessageParams,
+} from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
-import { RegisterParams, SessionHooks } from "./sessionHooks";
+import { SessionHooks } from "./sessionHooks";
 
 /** Builds a typed-but-stub host reply. The webview only reads `.type`, so a plain object is enough. */
 function query(type: string, fields: Record<string, unknown>): Query {
@@ -51,7 +58,7 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
             deps.store.postMessage(editorId, query("PropertiesPanelStateQuery", { visible: true }));
         });
 
-    deps.rpc.on("session/register", async (params: RegisterParams) => {
+    deps.rpc.on(METHODS.sessionRegister, async (params: RegisterParams) => {
         // Seed settings before any discovery so `getConfigFolder()` is correct on
         // the first template scan/watcher. Snapshots are host-global; applying the
         // same one on each register is idempotent. Kept inline (settings is a
@@ -90,7 +97,7 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
         deps.log(`session registered: ${params.editorId}`);
     });
 
-    deps.rpc.on("webview/message", (params: { editorId: string; message: Command }) => {
+    deps.rpc.on(METHODS.webviewMessage, (params: WebviewMessageParams) => {
         handles.get(params.editorId)?.receive(params.message);
     });
 
@@ -101,7 +108,7 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
     // mirror to the core-originated content before the RPC round-trip, so an
     // unchanged compare means this is that echo and re-rendering would loop.
     // Only a genuinely different text is an external edit worth displaying.
-    deps.rpc.on("document/didChange", async (params: { editorId: string; content: string }) => {
+    deps.rpc.on(METHODS.documentDidChange, async (params: DocumentDidChangeParams) => {
         if (deps.mirror.content(params.editorId) === params.content) {
             return;
         }
@@ -112,11 +119,11 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
     // The host reports which editor tab is focused so the store's active-editor
     // pointer stays correct with several `.bpmn` files open (commands/diff that
     // target "the active editor" depend on it).
-    deps.rpc.on("session/setActive", (params: { editorId: string }) => {
+    deps.rpc.on(METHODS.sessionSetActive, (params: EditorRefParams) => {
         deps.store.setActiveEditor(params.editorId);
     });
 
-    deps.rpc.on("session/dispose", (params: { editorId: string }) => {
+    deps.rpc.on(METHODS.sessionDispose, (params: EditorRefParams) => {
         bpmnService.disposeSession(params.editorId);
 
         // Per-session teardown owned by sibling features (script tabs, code-link

--- a/apps/modeler-bridge/src/composition/scriptFeature.ts
+++ b/apps/modeler-bridge/src/composition/scriptFeature.ts
@@ -5,6 +5,8 @@ import {
 } from "@miragon/bpmn-modeler-shared";
 
 import { BridgeScriptEditor } from "../scriptAdapters";
+import { METHODS } from "../protocol/descriptor";
+import { ScriptCloseParams, ScriptDidChangeParams } from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
 import { SessionHooks } from "./sessionHooks";
 
@@ -38,13 +40,13 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
 
     // The host edited an open script tab → push the new content into the owning
     // BPMN webview, which writes it to the moddle property via bpmn-js.
-    deps.rpc.on("script/didChange", (params: { scriptId: string; content: string }) => {
+    deps.rpc.on(METHODS.scriptDidChange, (params: ScriptDidChangeParams) => {
         void scriptEditor.didChange(params.scriptId, params.content);
     });
 
     // The user closed a script tab on the host → drop tracking so a re-open
     // re-reads the current BPMN content rather than revealing a stale tab.
-    deps.rpc.on("script/didClose", (params: { scriptId: string }) => {
+    deps.rpc.on(METHODS.scriptDidClose, (params: ScriptCloseParams) => {
         scriptEditor.didClose(params.scriptId);
     });
 

--- a/apps/modeler-bridge/src/composition/templatesSettingsFeature.ts
+++ b/apps/modeler-bridge/src/composition/templatesSettingsFeature.ts
@@ -1,9 +1,10 @@
 import { Command } from "@miragon/bpmn-modeler-shared";
 import { BpmnElementTemplatesService, BpmnSettingsBroadcaster } from "@miragon/bpmn-modeler-core";
 
-import { SettingsSnapshot } from "../nodeAdapters";
+import { METHODS } from "../protocol/descriptor";
+import { RegisterParams, SettingsDidChangeParams } from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
-import { RegisterParams, SessionHooks } from "./sessionHooks";
+import { SessionHooks } from "./sessionHooks";
 
 /**
  * The templates/settings feature owns element-template discovery
@@ -57,7 +58,7 @@ export function register(
     // each session's broadcaster + configFolder listener turn into webview pushes.
     // Diff panes aren't editor sessions, so they need an explicit locale re-push,
     // delivered via the diff feature's `rebroadcastLanguage` callback.
-    deps.rpc.on("settings/didChange", (params: { settings: Partial<SettingsSnapshot> }) => {
+    deps.rpc.on(METHODS.settingsDidChange, (params: SettingsDidChangeParams) => {
         deps.settings.apply(params.settings);
         handles.onSettingsApplied();
     });

--- a/apps/modeler-bridge/src/diffAdapters.ts
+++ b/apps/modeler-bridge/src/diffAdapters.ts
@@ -23,6 +23,7 @@ import {
 import { BpmnDiffService, DiffPaneHandle } from "@miragon/bpmn-modeler-core";
 
 import { Rpc } from "./rpc";
+import { METHODS } from "./protocol/descriptor";
 
 /**
  * One diff pane as the core sees it. `getText()` reads a content cache seeded by
@@ -57,7 +58,7 @@ export class RpcDiffPaneHandle implements DiffPaneHandle {
     }
 
     async postMessage(message: unknown): Promise<boolean> {
-        this.rpc.notify("diff/postMessage", { paneUri: this.uri, message });
+        this.rpc.notify(METHODS.diffPostMessage, { paneUri: this.uri, message });
         return true;
     }
 

--- a/apps/modeler-bridge/src/protocol/descriptor.ts
+++ b/apps/modeler-bridge/src/protocol/descriptor.ts
@@ -1,0 +1,532 @@
+/**
+ * The single literal source of truth for the host↔core RPC surface: one flat
+ * {@link PROTOCOL} array pairing every method with its direction, kind, and a
+ * representative param (and, for requests, result) fixture. The TS side owns
+ * this contract; the IntelliJ Kotlin host verifies against the derived
+ * {@link protocolSnapshot} (committed as `protocol.json`).
+ *
+ * Drift is caught two ways. Compile-time: each fixture is checked against its
+ * named param/result type via `satisfies`, so renaming a field in `types.ts`
+ * without updating the fixture is a build error. Runtime: `protocol.spec.ts`
+ * pins the method set, directions, and per-method key sets against the snapshot.
+ *
+ * Adding a method = add a {@link METHODS} entry + a {@link PROTOCOL} entry +
+ * refresh `protocol.json`; the contract test fails until all three agree.
+ */
+
+import { Command, Query } from "@miragon/bpmn-modeler-shared";
+
+import {
+    BasicAuthCredentials,
+    ClipboardReadResult,
+    ClipboardWriteParams,
+    DeploymentOpenParams,
+    DeploymentPostMessageParams,
+    DeploymentSaveAuthTypeParams,
+    DeploymentSaveOAuth2ConfigParams,
+    DeploymentSaveParams,
+    DeploymentSeedParams,
+    DeploymentWebviewMessageParams,
+    DiffDisposeParams,
+    DiffOpenParams,
+    DiffPostMessageParams,
+    DiffWebviewMessageParams,
+    DocumentDidChangeParams,
+    DocumentSaveParams,
+    DocumentSaveResult,
+    DocumentWriteParams,
+    DocumentWriteResult,
+    EditorPostMessageParams,
+    EditorRefParams,
+    EmptyParams,
+    NotifierLogParams,
+    NotifierMessageParams,
+    NotifierNotifyErrorParams,
+    NotifierOpenDocumentParams,
+    NotifierProgressParams,
+    OAuth2Credentials,
+    PickerShowParams,
+    PickerShowResult,
+    RegisterParams,
+    ScriptCloseNotifyParams,
+    ScriptCloseParams,
+    ScriptDidChangeParams,
+    ScriptOpenParams,
+    ScriptUpdateVariablesParams,
+    SettingsDidChangeParams,
+    StatusBarEngineVersionParams,
+    StatusBarTemplatesReadyParams,
+    WebviewMessageParams,
+} from "./types";
+
+/** Which peer initiates the call. Requests are only ever Core→Host (see the contract test). */
+export type Direction = "hostToCore" | "coreToHost";
+
+/** Whether a reply is expected. */
+export type Kind = "notification" | "request";
+
+/**
+ * Ergonomic name constants for call-sites (`METHODS.sessionRegister`). Hand-kept
+ * in lockstep with {@link PROTOCOL}: the contract test asserts the two method
+ * sets are identical, so neither can gain a method the other lacks.
+ */
+export const METHODS = {
+    // Host → Core notifications
+    sessionRegister: "session/register",
+    webviewMessage: "webview/message",
+    documentDidChange: "document/didChange",
+    sessionSetActive: "session/setActive",
+    sessionDispose: "session/dispose",
+    settingsDidChange: "settings/didChange",
+    diffOpen: "diff/open",
+    diffWebviewMessage: "diff/webviewMessage",
+    diffDispose: "diff/dispose",
+    deploymentStateSeed: "deploymentState/seed",
+    deploymentWebviewMessage: "deployment/webviewMessage",
+    deploymentOpen: "deployment/open",
+    scriptDidChange: "script/didChange",
+    scriptDidClose: "script/didClose",
+
+    // Core → Host requests
+    documentWrite: "document/write",
+    documentSave: "document/save",
+    pickerShow: "picker/show",
+    clipboardRead: "clipboard/read",
+    secretStoreSaveBasicAuth: "secretStore/saveBasicAuth",
+    secretStoreGetBasicAuth: "secretStore/getBasicAuth",
+    secretStoreSaveOAuth2: "secretStore/saveOAuth2",
+    secretStoreGetOAuth2: "secretStore/getOAuth2",
+
+    // Core → Host notifications
+    editorPostMessage: "editor/postMessage",
+    clipboardWrite: "clipboard/write",
+    notifierShowInfo: "notifier/showInfo",
+    notifierShowError: "notifier/showError",
+    notifierNotifyError: "notifier/notifyError",
+    notifierOpenConsole: "notifier/openConsole",
+    notifierOpenDocument: "notifier/openDocument",
+    notifierLog: "notifier/log",
+    notifierProgressStart: "notifier/progressStart",
+    notifierProgressEnd: "notifier/progressEnd",
+    statusBarTemplatesLoading: "statusBar/templatesLoading",
+    statusBarTemplatesReady: "statusBar/templatesReady",
+    statusBarTemplatesHide: "statusBar/templatesHide",
+    statusBarShowEngineVersion: "statusBar/showEngineVersion",
+    statusBarHideEngineVersion: "statusBar/hideEngineVersion",
+    statusBarDisposeEngineVersion: "statusBar/disposeEngineVersion",
+    diffPostMessage: "diff/postMessage",
+    deploymentStateSaveAuthType: "deploymentState/saveAuthType",
+    deploymentStateSaveOAuth2Config: "deploymentState/saveOAuth2Config",
+    deploymentStateSave: "deploymentState/save",
+    deploymentPostMessage: "deployment/postMessage",
+    scriptOpen: "script/open",
+    scriptUpdateVariables: "script/updateVariables",
+    scriptClose: "script/close",
+} as const;
+
+// Plain-object stand-ins for the opaque message payloads. The snapshot only
+// records top-level param keys, so the message body's shape is irrelevant — but
+// it must be a structural `Command`/`Query` (just `{ type: string }`) and a JSON
+// round-trippable plain object (no class instance), which these are.
+const SAMPLE_COMMAND: Command = { type: "GetBpmnFileCommand" };
+const SAMPLE_QUERY: Query = { type: "FormDefaultsQuery" };
+
+/**
+ * Every RPC method, in a fixed order. `paramsFixture`/`resultFixture` are bound
+ * to their named types via `satisfies` (compile-time drift guard); `as const`
+ * keeps `method`/`direction`/`kind` literal so the union types below can be
+ * derived and filtered by direction.
+ */
+export const PROTOCOL = [
+    // ── Host → Core notifications ────────────────────────────────────────────
+    {
+        method: METHODS.sessionRegister,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: {
+            editorId: "file:///a.bpmn",
+            uriString: "file:///a.bpmn",
+            path: "/a.bpmn",
+            fsPath: "/a.bpmn",
+            scheme: "file",
+            workspaceRoot: "/repo",
+            content: "<bpmn/>",
+            settings: {},
+        } satisfies RegisterParams,
+    },
+    {
+        method: METHODS.webviewMessage,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { editorId: "e1", message: SAMPLE_COMMAND } satisfies WebviewMessageParams,
+    },
+    {
+        method: METHODS.documentDidChange,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { editorId: "e1", content: "<bpmn/>" } satisfies DocumentDidChangeParams,
+    },
+    {
+        method: METHODS.sessionSetActive,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { editorId: "e1" } satisfies EditorRefParams,
+    },
+    {
+        method: METHODS.sessionDispose,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { editorId: "e1" } satisfies EditorRefParams,
+    },
+    {
+        method: METHODS.settingsDidChange,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { settings: {} } satisfies SettingsDidChangeParams,
+    },
+    {
+        method: METHODS.diffOpen,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: {
+            diffId: "d1",
+            origin: "scm",
+            before: { uri: "u#d1-before", content: "<bpmn/>" },
+            after: { uri: "u#d1-after", content: "<bpmn/>" },
+        } satisfies DiffOpenParams,
+    },
+    {
+        method: METHODS.diffWebviewMessage,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: {
+            paneUri: "u#d1-before",
+            message: SAMPLE_COMMAND,
+        } satisfies DiffWebviewMessageParams,
+    },
+    {
+        method: METHODS.diffDispose,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { diffId: "d1" } satisfies DiffDisposeParams,
+    },
+    {
+        method: METHODS.deploymentStateSeed,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { state: {} } satisfies DeploymentSeedParams,
+    },
+    {
+        method: METHODS.deploymentWebviewMessage,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { message: SAMPLE_COMMAND } satisfies DeploymentWebviewMessageParams,
+    },
+    {
+        method: METHODS.deploymentOpen,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { open: true } satisfies DeploymentOpenParams,
+    },
+    {
+        method: METHODS.scriptDidChange,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { scriptId: "s1", content: "x" } satisfies ScriptDidChangeParams,
+    },
+    {
+        method: METHODS.scriptDidClose,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: { scriptId: "s1" } satisfies ScriptCloseParams,
+    },
+
+    // ── Core → Host requests ─────────────────────────────────────────────────
+    {
+        method: METHODS.documentWrite,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: { editorId: "e1", content: "<bpmn/>" } satisfies DocumentWriteParams,
+        resultFixture: { changed: true } satisfies DocumentWriteResult,
+    },
+    {
+        method: METHODS.documentSave,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: { editorId: "e1" } satisfies DocumentSaveParams,
+        resultFixture: { saved: true } satisfies DocumentSaveResult,
+    },
+    {
+        method: METHODS.pickerShow,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: {
+            title: "Pick",
+            placeholder: "Pick one",
+            canPickMany: false,
+            items: [{ label: "a", description: "/a" }],
+        } satisfies PickerShowParams,
+        resultFixture: { selected: [0] } satisfies PickerShowResult,
+    },
+    {
+        method: METHODS.clipboardRead,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: {} satisfies EmptyParams,
+        resultFixture: { text: "copied" } satisfies ClipboardReadResult,
+    },
+    {
+        method: METHODS.secretStoreSaveBasicAuth,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: { username: "u", password: "p" } satisfies BasicAuthCredentials,
+        // No result: the host acks an empty reply; the core awaits only the round-trip.
+    },
+    {
+        method: METHODS.secretStoreGetBasicAuth,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: {} satisfies EmptyParams,
+        resultFixture: { username: "u", password: "p" } satisfies BasicAuthCredentials,
+    },
+    {
+        method: METHODS.secretStoreSaveOAuth2,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: { clientId: "id", clientSecret: "secret" } satisfies OAuth2Credentials,
+    },
+    {
+        method: METHODS.secretStoreGetOAuth2,
+        direction: "coreToHost",
+        kind: "request",
+        paramsFixture: {} satisfies EmptyParams,
+        resultFixture: { clientId: "id", clientSecret: "secret" } satisfies OAuth2Credentials,
+    },
+
+    // ── Core → Host notifications ────────────────────────────────────────────
+    {
+        method: METHODS.editorPostMessage,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { editorId: "e1", message: SAMPLE_QUERY } satisfies EditorPostMessageParams,
+    },
+    {
+        method: METHODS.clipboardWrite,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { text: "copied" } satisfies ClipboardWriteParams,
+    },
+    {
+        method: METHODS.notifierShowInfo,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { message: "ready" } satisfies NotifierMessageParams,
+    },
+    {
+        method: METHODS.notifierShowError,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { message: "boom" } satisfies NotifierMessageParams,
+    },
+    {
+        method: METHODS.notifierNotifyError,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { context: "save", message: "boom" } satisfies NotifierNotifyErrorParams,
+    },
+    {
+        method: METHODS.notifierOpenConsole,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {} satisfies EmptyParams,
+    },
+    {
+        method: METHODS.notifierOpenDocument,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { path: "/a.bpmn" } satisfies NotifierOpenDocumentParams,
+    },
+    {
+        method: METHODS.notifierLog,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { level: "info", message: "hi" } satisfies NotifierLogParams,
+    },
+    {
+        method: METHODS.notifierProgressStart,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { title: "Working" } satisfies NotifierProgressParams,
+    },
+    {
+        method: METHODS.notifierProgressEnd,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { title: "Working" } satisfies NotifierProgressParams,
+    },
+    {
+        method: METHODS.statusBarTemplatesLoading,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {} satisfies EmptyParams,
+    },
+    {
+        method: METHODS.statusBarTemplatesReady,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { count: 3 } satisfies StatusBarTemplatesReadyParams,
+    },
+    {
+        method: METHODS.statusBarTemplatesHide,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {} satisfies EmptyParams,
+    },
+    {
+        method: METHODS.statusBarShowEngineVersion,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { platform: "c7", version: "7.20" } satisfies StatusBarEngineVersionParams,
+    },
+    {
+        method: METHODS.statusBarHideEngineVersion,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {} satisfies EmptyParams,
+    },
+    {
+        method: METHODS.statusBarDisposeEngineVersion,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {} satisfies EmptyParams,
+    },
+    {
+        method: METHODS.diffPostMessage,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {
+            paneUri: "u#d1-before",
+            message: SAMPLE_COMMAND,
+        } satisfies DiffPostMessageParams,
+    },
+    {
+        method: METHODS.deploymentStateSaveAuthType,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { authType: "basic" } satisfies DeploymentSaveAuthTypeParams,
+    },
+    {
+        method: METHODS.deploymentStateSaveOAuth2Config,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {
+            tokenEndpoint: "https://token",
+            audience: "aud",
+        } satisfies DeploymentSaveOAuth2ConfigParams,
+    },
+    {
+        method: METHODS.deploymentStateSave,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {
+            endpoint: "https://engine",
+            tenantId: "t1",
+        } satisfies DeploymentSaveParams,
+    },
+    {
+        method: METHODS.deploymentPostMessage,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { message: SAMPLE_QUERY } satisfies DeploymentPostMessageParams,
+    },
+    {
+        method: METHODS.scriptOpen,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: {
+            scriptId: "s1",
+            fileName: "script.js",
+            languageId: "javascript",
+            content: "x",
+            completion: { beans: [], variables: [] },
+        } satisfies ScriptOpenParams,
+    },
+    {
+        method: METHODS.scriptUpdateVariables,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { scriptId: "s1", variables: [] } satisfies ScriptUpdateVariablesParams,
+    },
+    {
+        method: METHODS.scriptClose,
+        direction: "coreToHost",
+        kind: "notification",
+        paramsFixture: { scriptId: "s1" } satisfies ScriptCloseNotifyParams,
+    },
+] as const;
+
+/** One descriptor entry, with literal `method`/`direction`/`kind`. */
+export type ProtocolEntry = (typeof PROTOCOL)[number];
+
+/** Union of every RPC method name. */
+export type RpcMethod = ProtocolEntry["method"];
+
+/** Methods the host sends to the core. */
+export type HostToCoreMethod = Extract<ProtocolEntry, { direction: "hostToCore" }>["method"];
+
+/** Methods the core sends to the host. */
+export type CoreToHostMethod = Extract<ProtocolEntry, { direction: "coreToHost" }>["method"];
+
+/** Language-neutral, per-method key contract — what the Kotlin host verifies against. */
+export interface ProtocolSnapshotEntry {
+    method: string;
+    direction: Direction;
+    kind: Kind;
+    /** Sorted top-level param keys actually carried on the wire. */
+    paramKeys: string[];
+    /** Sorted top-level result keys; absent for notifications and void requests. */
+    resultKeys?: string[];
+}
+
+/**
+ * Projects {@link PROTOCOL} to the JSON-serializable, key-level contract stored
+ * in `protocol.json`. Keys (not full types) are the part a different-language
+ * host can check — the Kotlin silent break is a `params.get("editorId")`
+ * field-name mismatch, which a key set catches and a type signature wouldn't.
+ */
+export function protocolSnapshot(): ProtocolSnapshotEntry[] {
+    return PROTOCOL.map((entry) => {
+        const snapshot: ProtocolSnapshotEntry = {
+            method: entry.method,
+            direction: entry.direction,
+            kind: entry.kind,
+            paramKeys: Object.keys(entry.paramsFixture).sort(),
+        };
+        if ("resultFixture" in entry && entry.resultFixture) {
+            snapshot.resultKeys = Object.keys(entry.resultFixture).sort();
+        }
+        return snapshot;
+    });
+}
+
+/** The three real groups; there is no Host→Core request (the contract test enforces it). */
+const TABLE_GROUPS = [
+    { direction: "hostToCore", kind: "notification", title: "Host → Core (notifications)" },
+    { direction: "coreToHost", kind: "request", title: "Core → Host (requests)" },
+    { direction: "coreToHost", kind: "notification", title: "Core → Host (notifications)" },
+] as const;
+
+/**
+ * Renders the canonical, human-readable protocol table from {@link PROTOCOL} so
+ * the prose in `bridge.ts` can never rot against the real surface. Kept
+ * branch-light (filter + map + join, no per-method special-casing) so the whole
+ * renderer is covered by asserting its full output once.
+ */
+export function protocolTable(): string {
+    return TABLE_GROUPS.map((group) => {
+        const methods = PROTOCOL.filter(
+            (entry) => entry.direction === group.direction && entry.kind === group.kind,
+        ).map((entry) => `  ${entry.method}`);
+        return [`${group.title}:`, ...methods].join("\n");
+    }).join("\n\n");
+}

--- a/apps/modeler-bridge/src/protocol/protocol.json
+++ b/apps/modeler-bridge/src/protocol/protocol.json
@@ -1,0 +1,406 @@
+[
+    {
+        "method": "session/register",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "content",
+            "editorId",
+            "fsPath",
+            "path",
+            "scheme",
+            "settings",
+            "uriString",
+            "workspaceRoot"
+        ]
+    },
+    {
+        "method": "webview/message",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "editorId",
+            "message"
+        ]
+    },
+    {
+        "method": "document/didChange",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "content",
+            "editorId"
+        ]
+    },
+    {
+        "method": "session/setActive",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "editorId"
+        ]
+    },
+    {
+        "method": "session/dispose",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "editorId"
+        ]
+    },
+    {
+        "method": "settings/didChange",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "settings"
+        ]
+    },
+    {
+        "method": "diff/open",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "after",
+            "before",
+            "diffId",
+            "origin"
+        ]
+    },
+    {
+        "method": "diff/webviewMessage",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "message",
+            "paneUri"
+        ]
+    },
+    {
+        "method": "diff/dispose",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "diffId"
+        ]
+    },
+    {
+        "method": "deploymentState/seed",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "state"
+        ]
+    },
+    {
+        "method": "deployment/webviewMessage",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "message"
+        ]
+    },
+    {
+        "method": "deployment/open",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "open"
+        ]
+    },
+    {
+        "method": "script/didChange",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "content",
+            "scriptId"
+        ]
+    },
+    {
+        "method": "script/didClose",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "scriptId"
+        ]
+    },
+    {
+        "method": "document/write",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [
+            "content",
+            "editorId"
+        ],
+        "resultKeys": [
+            "changed"
+        ]
+    },
+    {
+        "method": "document/save",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [
+            "editorId"
+        ],
+        "resultKeys": [
+            "saved"
+        ]
+    },
+    {
+        "method": "picker/show",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [
+            "canPickMany",
+            "items",
+            "placeholder",
+            "title"
+        ],
+        "resultKeys": [
+            "selected"
+        ]
+    },
+    {
+        "method": "clipboard/read",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [],
+        "resultKeys": [
+            "text"
+        ]
+    },
+    {
+        "method": "secretStore/saveBasicAuth",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [
+            "password",
+            "username"
+        ]
+    },
+    {
+        "method": "secretStore/getBasicAuth",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [],
+        "resultKeys": [
+            "password",
+            "username"
+        ]
+    },
+    {
+        "method": "secretStore/saveOAuth2",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [
+            "clientId",
+            "clientSecret"
+        ]
+    },
+    {
+        "method": "secretStore/getOAuth2",
+        "direction": "coreToHost",
+        "kind": "request",
+        "paramKeys": [],
+        "resultKeys": [
+            "clientId",
+            "clientSecret"
+        ]
+    },
+    {
+        "method": "editor/postMessage",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "editorId",
+            "message"
+        ]
+    },
+    {
+        "method": "clipboard/write",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "text"
+        ]
+    },
+    {
+        "method": "notifier/showInfo",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "message"
+        ]
+    },
+    {
+        "method": "notifier/showError",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "message"
+        ]
+    },
+    {
+        "method": "notifier/notifyError",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "context",
+            "message"
+        ]
+    },
+    {
+        "method": "notifier/openConsole",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": []
+    },
+    {
+        "method": "notifier/openDocument",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "path"
+        ]
+    },
+    {
+        "method": "notifier/log",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "level",
+            "message"
+        ]
+    },
+    {
+        "method": "notifier/progressStart",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "title"
+        ]
+    },
+    {
+        "method": "notifier/progressEnd",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "title"
+        ]
+    },
+    {
+        "method": "statusBar/templatesLoading",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": []
+    },
+    {
+        "method": "statusBar/templatesReady",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "count"
+        ]
+    },
+    {
+        "method": "statusBar/templatesHide",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": []
+    },
+    {
+        "method": "statusBar/showEngineVersion",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "platform",
+            "version"
+        ]
+    },
+    {
+        "method": "statusBar/hideEngineVersion",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": []
+    },
+    {
+        "method": "statusBar/disposeEngineVersion",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": []
+    },
+    {
+        "method": "diff/postMessage",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "message",
+            "paneUri"
+        ]
+    },
+    {
+        "method": "deploymentState/saveAuthType",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "authType"
+        ]
+    },
+    {
+        "method": "deploymentState/saveOAuth2Config",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "audience",
+            "tokenEndpoint"
+        ]
+    },
+    {
+        "method": "deploymentState/save",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "endpoint",
+            "tenantId"
+        ]
+    },
+    {
+        "method": "deployment/postMessage",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "message"
+        ]
+    },
+    {
+        "method": "script/open",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "completion",
+            "content",
+            "fileName",
+            "languageId",
+            "scriptId"
+        ]
+    },
+    {
+        "method": "script/updateVariables",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "scriptId",
+            "variables"
+        ]
+    },
+    {
+        "method": "script/close",
+        "direction": "coreToHost",
+        "kind": "notification",
+        "paramKeys": [
+            "scriptId"
+        ]
+    }
+]

--- a/apps/modeler-bridge/src/protocol/protocol.spec.ts
+++ b/apps/modeler-bridge/src/protocol/protocol.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * The host↔core RPC contract test. It pins the surface the rest of the bridge
+ * (and, via `protocol.json`, the IntelliJ Kotlin host) relies on, so any
+ * accidental drift — a renamed method, a flipped direction, a changed param key
+ * set — fails CI here rather than at runtime on a different host.
+ *
+ * The compile-time half (each fixture `satisfies` its named param/result type)
+ * lives in `descriptor.ts` and is enforced by `tsc`; this file covers the
+ * runtime half: internal consistency, JSON round-trippability, snapshot
+ * equality, and the rendered doc table.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { METHODS, PROTOCOL, protocolSnapshot, protocolTable } from "./descriptor";
+
+// `PROTOCOL` is `as const`, so the compiler already proves a request is never
+// Host→Core (its direction narrows to the literal `"coreToHost"`). Widen the
+// view here so the *runtime* assertion below stays a genuine, executable check
+// instead of a comparison the type-checker rejects as having no overlap.
+const ENTRIES: ReadonlyArray<{ method: string; direction: string; kind: string }> = PROTOCOL;
+
+describe("RPC protocol descriptor", () => {
+    describe("internal consistency", () => {
+        it("has a unique method name per entry", () => {
+            const methods = PROTOCOL.map((entry) => entry.method);
+            expect(new Set(methods).size).toBe(methods.length);
+        });
+
+        it("keeps METHODS and PROTOCOL method sets identical", () => {
+            const fromConstants = new Set<string>(Object.values(METHODS));
+            const fromDescriptor = new Set<string>(PROTOCOL.map((entry) => entry.method));
+            expect(fromConstants).toEqual(fromDescriptor);
+        });
+
+        it("uses only valid directions and kinds", () => {
+            for (const entry of PROTOCOL) {
+                expect(["hostToCore", "coreToHost"]).toContain(entry.direction);
+                expect(["notification", "request"]).toContain(entry.kind);
+            }
+        });
+
+        it("never declares a Host→Core request (requests are always Core→Host)", () => {
+            const hostRequests = ENTRIES.filter(
+                (entry) => entry.kind === "request" && entry.direction === "hostToCore",
+            );
+            expect(hostRequests).toEqual([]);
+        });
+
+        it("attaches a result fixture only to requests", () => {
+            for (const entry of PROTOCOL) {
+                if ("resultFixture" in entry) {
+                    expect(entry.kind).toBe("request");
+                }
+            }
+        });
+    });
+
+    describe("fixtures", () => {
+        it("are JSON-round-trippable plain objects", () => {
+            for (const entry of PROTOCOL) {
+                expect(JSON.parse(JSON.stringify(entry.paramsFixture))).toEqual(
+                    entry.paramsFixture,
+                );
+                if ("resultFixture" in entry && entry.resultFixture) {
+                    expect(JSON.parse(JSON.stringify(entry.resultFixture))).toEqual(
+                        entry.resultFixture,
+                    );
+                }
+            }
+        });
+    });
+
+    describe("snapshot", () => {
+        it("deep-equals the checked-in protocol.json", () => {
+            const committed = JSON.parse(readFileSync(resolve(__dirname, "protocol.json"), "utf8"));
+            expect(protocolSnapshot()).toEqual(committed);
+        });
+    });
+
+    describe("doc table", () => {
+        it("lists every method exactly once", () => {
+            const lines = protocolTable().split("\n");
+            for (const entry of PROTOCOL) {
+                const occurrences = lines.filter((line) => line === `  ${entry.method}`).length;
+                expect(occurrences, `method listed once: ${entry.method}`).toBe(1);
+            }
+        });
+
+        it("renders the canonical grouped table", () => {
+            expect(protocolTable()).toBe(
+                [
+                    "Host → Core (notifications):",
+                    "  session/register",
+                    "  webview/message",
+                    "  document/didChange",
+                    "  session/setActive",
+                    "  session/dispose",
+                    "  settings/didChange",
+                    "  diff/open",
+                    "  diff/webviewMessage",
+                    "  diff/dispose",
+                    "  deploymentState/seed",
+                    "  deployment/webviewMessage",
+                    "  deployment/open",
+                    "  script/didChange",
+                    "  script/didClose",
+                    "",
+                    "Core → Host (requests):",
+                    "  document/write",
+                    "  document/save",
+                    "  picker/show",
+                    "  clipboard/read",
+                    "  secretStore/saveBasicAuth",
+                    "  secretStore/getBasicAuth",
+                    "  secretStore/saveOAuth2",
+                    "  secretStore/getOAuth2",
+                    "",
+                    "Core → Host (notifications):",
+                    "  editor/postMessage",
+                    "  clipboard/write",
+                    "  notifier/showInfo",
+                    "  notifier/showError",
+                    "  notifier/notifyError",
+                    "  notifier/openConsole",
+                    "  notifier/openDocument",
+                    "  notifier/log",
+                    "  notifier/progressStart",
+                    "  notifier/progressEnd",
+                    "  statusBar/templatesLoading",
+                    "  statusBar/templatesReady",
+                    "  statusBar/templatesHide",
+                    "  statusBar/showEngineVersion",
+                    "  statusBar/hideEngineVersion",
+                    "  statusBar/disposeEngineVersion",
+                    "  diff/postMessage",
+                    "  deploymentState/saveAuthType",
+                    "  deploymentState/saveOAuth2Config",
+                    "  deploymentState/save",
+                    "  deployment/postMessage",
+                    "  script/open",
+                    "  script/updateVariables",
+                    "  script/close",
+                ].join("\n"),
+            );
+        });
+    });
+});

--- a/apps/modeler-bridge/src/protocol/types.ts
+++ b/apps/modeler-bridge/src/protocol/types.ts
@@ -1,0 +1,269 @@
+/**
+ * Param/result shapes for every host↔core RPC method, consolidated in one
+ * type-only module so the descriptor and the call-sites share a single
+ * definition instead of redeclaring anonymous inline shapes (the drift the
+ * protocol effort exists to kill). Nothing here emits runtime code; the whole
+ * module is erased by the compiler.
+ *
+ * The names mirror the method they carry (`WebviewMessageParams` ↔
+ * `webview/message`). Result types replace the inline `as { … } | null` casts
+ * the `Rpc.request` call-sites used to carry.
+ */
+
+import {
+    AuthTypePayload,
+    Command,
+    DiffOrigin,
+    Engine,
+    Query,
+    VariableDef,
+} from "@miragon/bpmn-modeler-shared";
+
+import { DeploymentStateSnapshot } from "../adapters";
+import { SettingsSnapshot } from "../nodeAdapters";
+
+// Re-export (don't move) the register payload: it extends `SessionMeta` from
+// `adapters.ts`, so relocating its definition would drag `SessionMeta`/settings
+// types across modules and risk an import cycle. Sharing the one definition is
+// all the descriptor needs.
+export type { RegisterParams } from "../composition/sessionHooks";
+
+/** Empty-body notification/request (e.g. `clipboard/read`, `statusBar/templatesHide`). */
+export type EmptyParams = Record<string, never>;
+
+// ── Host → Core notifications ────────────────────────────────────────────────
+
+/** `webview/message` — a webview {@link Command} the host forwards into the core. */
+export interface WebviewMessageParams {
+    editorId: string;
+    message: Command;
+}
+
+/** `document/didChange` — the host reports new on-disk/editor text for an editor. */
+export interface DocumentDidChangeParams {
+    editorId: string;
+    content: string;
+}
+
+/** `session/setActive`, `session/dispose` — address an editor by id alone. */
+export interface EditorRefParams {
+    editorId: string;
+}
+
+/** `settings/didChange` — a fresh `miragon.bpmnModeler.*` snapshot from the host. */
+export interface SettingsDidChangeParams {
+    settings: Partial<SettingsSnapshot>;
+}
+
+/** One side of a diff: a diff-scoped pane uri plus its cached XML. */
+export interface DiffPaneInput {
+    /** Stable, diff-scoped pane identity (host appends `#<diffId>-<role>`). */
+    uri: string;
+    content: string;
+}
+
+/** `diff/open` — the host opens a two-pane diff with both sides known up front. */
+export interface DiffOpenParams {
+    diffId: string;
+    origin: DiffOrigin;
+    before: DiffPaneInput;
+    after: DiffPaneInput;
+}
+
+/** `diff/webviewMessage` — a webview {@link Command} from one diff pane. */
+export interface DiffWebviewMessageParams {
+    paneUri: string;
+    message: Command;
+}
+
+/** `diff/dispose` — tear down both panes of a diff. */
+export interface DiffDisposeParams {
+    diffId: string;
+}
+
+/** `deploymentState/seed` — the host seeds the deployment-form mirror. */
+export interface DeploymentSeedParams {
+    state: Partial<DeploymentStateSnapshot>;
+}
+
+/** `deployment/webviewMessage` — a webview {@link Command} from the deployment panel. */
+export interface DeploymentWebviewMessageParams {
+    message: Command;
+}
+
+/** `deployment/open` — the host reports the deployment tool-window's visibility. */
+export interface DeploymentOpenParams {
+    open: boolean;
+}
+
+/** `script/didChange` — the host reports an edit in an open script tab. */
+export interface ScriptDidChangeParams {
+    scriptId: string;
+    content: string;
+}
+
+/** `script/didClose` — the user closed a script tab on the host. */
+export interface ScriptCloseParams {
+    scriptId: string;
+}
+
+// ── Core → Host requests (params + results) ──────────────────────────────────
+
+/** `document/write` — push core-originated text; result reports whether it changed. */
+export interface DocumentWriteParams {
+    editorId: string;
+    content: string;
+}
+export interface DocumentWriteResult {
+    changed?: boolean;
+}
+
+/** `document/save` — persist the editor; result reports whether a save happened. */
+export type DocumentSaveParams = EditorRefParams;
+export interface DocumentSaveResult {
+    saved?: boolean;
+}
+
+/** One row offered to the host popup: a label plus optional greyed detail. */
+export interface PickItem {
+    label: string;
+    description?: string;
+}
+
+/** `picker/show` — round-trip one native chooser; result is the chosen indices. */
+export interface PickerShowParams {
+    title?: string;
+    placeholder: string;
+    canPickMany: boolean;
+    items: PickItem[];
+}
+export interface PickerShowResult {
+    selected?: number[] | null;
+}
+
+/** `clipboard/read` — the host reads the system clipboard on the core's behalf. */
+export interface ClipboardReadResult {
+    text?: string;
+}
+
+/** `secretStore/saveBasicAuth` params and `secretStore/getBasicAuth` result. */
+export interface BasicAuthCredentials {
+    username: string;
+    password: string;
+}
+
+/** `secretStore/saveOAuth2` params and `secretStore/getOAuth2` result. */
+export interface OAuth2Credentials {
+    clientId: string;
+    clientSecret: string;
+}
+
+// ── Core → Host notifications ────────────────────────────────────────────────
+
+/** `editor/postMessage` — the core drives the host's editor browser. */
+export interface EditorPostMessageParams {
+    editorId: string;
+    message: Command | Query;
+}
+
+/** `clipboard/write` — fire-and-forget system-clipboard write. */
+export interface ClipboardWriteParams {
+    text: string;
+}
+
+/** `notifier/showInfo`, `notifier/showError` — a one-line balloon. */
+export interface NotifierMessageParams {
+    message: string;
+}
+
+/** `notifier/notifyError` — a context-tagged error balloon. */
+export interface NotifierNotifyErrorParams {
+    context: string;
+    message: string;
+}
+
+/** `notifier/openDocument` — reveal a file in the host. */
+export interface NotifierOpenDocumentParams {
+    path: string;
+}
+
+/** `notifier/log` — a leveled line to the IDE log/console. */
+export interface NotifierLogParams {
+    level: "info" | "warn" | "error";
+    message: string;
+}
+
+/** `notifier/progressStart`, `notifier/progressEnd` — bracket a host spinner. */
+export interface NotifierProgressParams {
+    title: string;
+}
+
+/** `statusBar/templatesReady` — element-template count for the status widget. */
+export interface StatusBarTemplatesReadyParams {
+    count: number;
+}
+
+/** `statusBar/showEngineVersion` — the resolved engine + version to display. */
+export interface StatusBarEngineVersionParams {
+    platform: Engine;
+    version: string;
+}
+
+/** `diff/postMessage` — the core drives one diff pane's host browser. */
+export interface DiffPostMessageParams {
+    paneUri: string;
+    message: unknown;
+}
+
+/** `deploymentState/saveAuthType` — persist the chosen auth type. */
+export interface DeploymentSaveAuthTypeParams {
+    authType: AuthTypePayload;
+}
+
+/** `deploymentState/saveOAuth2Config` — persist the OAuth2 endpoint/audience. */
+export interface DeploymentSaveOAuth2ConfigParams {
+    tokenEndpoint: string;
+    audience: string;
+}
+
+/** `deploymentState/save` — persist the endpoint/tenant pair. */
+export interface DeploymentSaveParams {
+    endpoint: string;
+    tenantId: string;
+}
+
+/** `deployment/postMessage` — the core pushes a {@link Query} into the deployment panel. */
+export interface DeploymentPostMessageParams {
+    message: Query;
+}
+
+/** Completion bean shipped to the host so it never needs BPMN/PSI knowledge. */
+export interface ScriptCompletionBean {
+    name: string;
+    type: string;
+    description: string;
+    methods: readonly unknown[];
+}
+
+/** `script/open` — open (or reveal) an inline script in a host text editor. */
+export interface ScriptOpenParams {
+    scriptId: string;
+    fileName: string;
+    languageId: string;
+    content: string;
+    completion: {
+        beans: readonly ScriptCompletionBean[];
+        variables: VariableDef[];
+    };
+}
+
+/** `script/updateVariables` — refresh one tab's process-variable completion. */
+export interface ScriptUpdateVariablesParams {
+    scriptId: string;
+    variables: VariableDef[];
+}
+
+/** `script/close` — the core tells the host to close a script tab it opened. */
+export interface ScriptCloseNotifyParams {
+    scriptId: string;
+}

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -34,6 +34,7 @@ import {
 } from "@miragon/bpmn-modeler-shared";
 
 import { Rpc } from "./rpc";
+import { METHODS } from "./protocol/descriptor";
 
 /** The element-addressing fields needed to route a host edit back to the webview. */
 interface TrackedScript {
@@ -114,7 +115,7 @@ export class BridgeScriptEditor {
         // `registerCompletionItemProvider` has no PSI-based analogue, so the host
         // drives a `CompletionContributor` off this payload instead). `variables`
         // rides alongside so the host can complete process-variable names too.
-        this.rpc.notify("script/open", {
+        this.rpc.notify(METHODS.scriptOpen, {
             scriptId,
             fileName: uri.filename,
             languageId: lang.languageId,
@@ -142,7 +143,7 @@ export class BridgeScriptEditor {
         this.variablesByEditor.set(editorId, variables);
         for (const [scriptId, entry] of this.scripts) {
             if (entry.editorId === editorId) {
-                this.rpc.notify("script/updateVariables", { scriptId, variables });
+                this.rpc.notify(METHODS.scriptUpdateVariables, { scriptId, variables });
             }
         }
     }
@@ -181,7 +182,7 @@ export class BridgeScriptEditor {
     disposeEditor(editorId: string): void {
         for (const [scriptId, entry] of this.scripts) {
             if (entry.editorId === editorId) {
-                this.rpc.notify("script/close", { scriptId });
+                this.rpc.notify(METHODS.scriptClose, { scriptId });
                 this.scripts.delete(scriptId);
             }
         }


### PR DESCRIPTION
**Issue**

Closes #1104

**Description**

The host↔core RPC protocol was maintained by hand in three places (TS handler strings + inline shapes, Kotlin string literals, and a prose table in `bridge.ts`) with no check that they agreed, so a typo or shape drift failed only at runtime. This makes the TS side the single source of truth: a new `src/protocol/` directory holds named param/result types, a literal `PROTOCOL` descriptor whose fixtures are bound to their types via `satisfies` (compile-time drift detection), `METHODS.*` constants now consumed at every call-site, a vitest contract test pinning the 46-method surface, and a checked-in `protocol.json` snapshot for a future Kotlin verification test. The `bridge.ts` prose table is replaced by a pointer to `protocolTable()`, removing the rot risk. No runtime behavior changes — all 109 existing specs pass unmodified and coverage holds (`descriptor.ts` is 100%, `types.ts` is type-only).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created