### PR TITLE
chore(intellij-plugin): add JUnit 5 bridge harness + PR test/coverage CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       modeler-bridge: ${{ steps.filter.outputs.modeler-bridge }}
       vscode-plugin: ${{ steps.filter.outputs.vscode-plugin }}
       vscode-plugin-src: ${{ steps.filter.outputs.vscode-plugin-src }}
+      intellij-plugin: ${{ steps.filter.outputs.intellij-plugin }}
       modeler-core-src: ${{ steps.filter.outputs.modeler-core-src }}
       modeler-bridge-src: ${{ steps.filter.outputs.modeler-bridge-src }}
       bpmn-webview: ${{ steps.filter.outputs.bpmn-webview }}
@@ -64,6 +65,12 @@ jobs:
               - 'apps/modeler-bridge/**'
             vscode-plugin:
               - 'apps/vscode-plugin/**'
+            # No `*-src` split: release-please bumps the version inside
+            # build.gradle.kts (not a dedicated file), so there is no clean way to
+            # exclude a version-only change — a redundant coverage upload on a
+            # version-bump PR is harmless (Codecov dedups by commit).
+            intellij-plugin:
+              - 'apps/intellij-plugin/**'
             # `*-src` mirror the package filters above but drop package.json, so a
             # version-bump-only PR (release-please) skips the Codecov coverage
             # report while build+test still run via the broad filters. Relies on
@@ -388,6 +395,40 @@ jobs:
           name: modeler-bridge
           verbose: true
 
+  test-intellij-plugin:
+    needs: detect-changes
+    # The IntelliJ plugin is a standalone Gradle/Kotlin build whose unit tests are
+    # pure-JVM and depend only on its own sources (it bundles the pre-built bridge
+    # and webviews at packaging time, not at test time), so trigger solely on its
+    # own files — unlike the VS Code plugin it shares no TS deps with core/shared.
+    if: needs.detect-changes.outputs.intellij-plugin == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+      # `jacocoTestReport` depends on `test`, so this runs the JUnit 5 suite and
+      # then writes the coverage XML. Resources (bridge binary, webview bundles)
+      # are absent on a clean checkout, so their Copy tasks are NO-SOURCE and the
+      # pure-JVM tests run without the JS/Bun toolchain.
+      - name: Run unit tests with coverage
+        working-directory: apps/intellij-plugin
+        run: ./gradlew jacocoTestReport --no-daemon
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/intellij-plugin/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+          flags: intellij-plugin
+          name: intellij-plugin
+          verbose: true
+
   # Extension-Host smoke test: the only job that runs the composition root
   # (`activate()` + custom-editor registration) end-to-end in a real VS Code.
   # Kept separate from lint/unit so their fast feedback is never delayed by
@@ -576,6 +617,7 @@ jobs:
       - test-vscode-plugin
       - test-modeler-core
       - test-modeler-bridge
+      - test-intellij-plugin
       - e2e-vscode-plugin
       - test-bpmn-webview
       - test-bpmn-i18n

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.intellij.platform)
+    jacoco
 }
 
 group = "io.miragon"
@@ -29,10 +30,33 @@ dependencies {
     // Hand-built strings are unsafe here: SyncDocumentCommand carries the full
     // BPMN XML, which must round-trip through proper escaping.
     implementation(libs.gson)
+
+    // Pure-JVM unit tests for the concurrency-critical bridge transport and
+    // process supervision. No IntelliJ platform test fixtures: the
+    // intellijPlatform compile dependency already supplies Logger + Gson on the
+    // test classpath, and the seams let tests inject a fake process/clock.
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 kotlin {
     jvmToolchain(21)
+}
+
+tasks.test {
+    useJUnitPlatform()
+    // Always refresh the coverage data so `jacocoTestReport` reflects the latest run.
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    // Codecov ingests the XML; the HTML report is dead weight in CI.
+    reports {
+        xml.required.set(true)
+        html.required.set(false)
+    }
 }
 
 intellijPlatform {

--- a/apps/intellij-plugin/gradle/libs.versions.toml
+++ b/apps/intellij-plugin/gradle/libs.versions.toml
@@ -2,9 +2,13 @@
 kotlin = "2.4.0"
 intellijPlatform = "2.16.0"
 gson = "2.14.0"
+junit = "5.11.4"
 
 [libraries]
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -5,8 +5,9 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
-import io.miragon.intellij.bpmn.bridge.BridgeBinaryResolver
 import io.miragon.intellij.bpmn.bridge.BridgeDeps
+import io.miragon.intellij.bpmn.bridge.BridgeErrorNotifier
+import io.miragon.intellij.bpmn.bridge.DefaultBridgeProcessLauncher
 import io.miragon.intellij.bpmn.bridge.DeploymentRouter
 import io.miragon.intellij.bpmn.bridge.DiffRouter
 import io.miragon.intellij.bpmn.bridge.EditorSessionRouter
@@ -61,8 +62,10 @@ class CoreProcess(private val project: Project) : Disposable {
     private val supervisor: ProcessSupervisor =
         ProcessSupervisor(
             channel = channel,
-            binaryResolver = BridgeBinaryResolver(),
-            notifications = { notifications.value },
+            launcher = DefaultBridgeProcessLauncher(),
+            // Adapt the host notifier behind the narrow port; `notifications` is
+            // lazy, so the UI surface is still built only on the first error.
+            notifier = BridgeErrorNotifier { message -> notifications.value.showError(message) },
             // Declared after the supervisor; safe because both lambdas only fire
             // post-construction, on the first (re)spawn.
             onSpawned = { deploymentRouter.sendSeed() },

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeErrorNotifier.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeErrorNotifier.kt
@@ -1,0 +1,15 @@
+package io.miragon.intellij.bpmn.bridge
+
+/**
+ * The one host-UI capability [ProcessSupervisor] needs: surface a fatal bridge
+ * error — a spawn failure or a repeated-crash give-up — to the user.
+ *
+ * Narrowing the dependency to this single method (rather than the whole
+ * `HostNotifications`) keeps the supervisor host-agnostic and lets tests assert
+ * error reporting with a trivial fake instead of a platform-coupled notifier
+ * that can't run outside a live IDE. Production adapts it to `HostNotifications`
+ * in `CoreProcess`, preserving the lazy construction on the happy path.
+ */
+internal fun interface BridgeErrorNotifier {
+    fun showError(message: String)
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeProcessLauncher.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeProcessLauncher.kt
@@ -1,0 +1,25 @@
+package io.miragon.intellij.bpmn.bridge
+
+/**
+ * Creates the bridge subprocess. Extracted from [ProcessSupervisor] so the
+ * supervisor's concurrency logic can be unit-tested against a scripted fake
+ * process instead of a real Bun binary, and so binary resolution + process
+ * construction live in one place (SRP) rather than inline in the supervisor.
+ */
+internal fun interface BridgeProcessLauncher {
+    fun launch(): Process
+}
+
+/**
+ * Production launcher: resolves the bundled per-platform bridge binary and
+ * starts it. [redirectErrorStream] is `false` because stdout is reserved for the
+ * RPC framing and stderr is the core's separate diagnostic channel.
+ */
+internal class DefaultBridgeProcessLauncher(
+    private val binaryResolver: BridgeBinaryResolver = BridgeBinaryResolver(),
+) : BridgeProcessLauncher {
+    override fun launch(): Process {
+        val binary = binaryResolver.resolve()
+        return ProcessBuilder(binary.toString()).redirectErrorStream(false).start()
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisor.kt
@@ -2,7 +2,7 @@ package io.miragon.intellij.bpmn.bridge
 
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.concurrency.AppExecutorUtil
-import io.miragon.intellij.bpmn.HostNotifications
+import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -22,17 +22,27 @@ import java.util.concurrent.atomic.AtomicInteger
  * share this instance's monitor (as they shared the `CoreProcess` instance's
  * before); no external code synchronises on the supervisor.
  *
- * @param notifications Lazy provider so a spawn failure surfaces UI without
- *   forcing [HostNotifications] construction on the happy path.
+ * @param launcher Creates the bridge subprocess. Injectable so tests drive a
+ *   scripted fake process; production resolves and starts the bundled binary.
+ * @param notifier Surfaces a fatal spawn/give-up error to the user. The
+ *   production adapter defers `HostNotifications` construction so the happy path
+ *   never builds the UI surface; tests pass a recording fake.
  * @param onSpawned Runs after every (re)spawn — seeds the deployment mirror.
  * @param onRespawned Runs after a *crash* respawn — re-registers live sessions.
+ * @param scheduler Runs the async pre-warm spawn and the backoff respawn.
+ *   Injectable so tests step time deterministically instead of waiting on the
+ *   shared platform pool.
+ * @param clock Wall-clock source for the stable-run window. Injectable so tests
+ *   cross [STABLE_RUN_MS] without sleeping.
  */
 internal class ProcessSupervisor(
     private val channel: RpcChannel,
-    private val binaryResolver: BridgeBinaryResolver,
-    private val notifications: () -> HostNotifications,
+    private val launcher: BridgeProcessLauncher,
+    private val notifier: BridgeErrorNotifier,
     private val onSpawned: () -> Unit,
     private val onRespawned: () -> Unit,
+    private val scheduler: ScheduledExecutorService = AppExecutorUtil.getAppScheduledExecutorService(),
+    private val clock: () -> Long = System::currentTimeMillis,
 ) {
     private val log = Logger.getInstance(ProcessSupervisor::class.java)
 
@@ -73,7 +83,7 @@ internal class ProcessSupervisor(
      */
     fun ensureStartedAsync() {
         if (process?.isAlive == true) return
-        AppExecutorUtil.getAppScheduledExecutorService().execute {
+        scheduler.execute {
             if (disposed.get()) return@execute
             ensureStarted()
         }
@@ -87,21 +97,13 @@ internal class ProcessSupervisor(
     fun prewarm() = ensureStartedAsync()
 
     private fun spawn() {
-        val binary =
-            try {
-                binaryResolver.resolve()
-            } catch (e: Exception) {
-                log.error("Failed to resolve the bundled modeler bridge binary", e)
-                notifications().showError("Could not start the BPMN modeler engine: ${e.message}")
-                return
-            }
         try {
-            val started = ProcessBuilder(binary.toString()).redirectErrorStream(false).start()
+            val started = launcher.launch()
             synchronized(stateLock) {
                 process = started
                 channel.attach(started.outputStream, started.inputStream)
             }
-            lastSpawnAt = System.currentTimeMillis()
+            lastSpawnAt = clock()
             // stderr is the core's diagnostic channel (stdout is reserved for RPC).
             channel.pump(started.errorStream, "modeler-bridge-stderr") { log.info("[bridge stderr] $it") }
             started.onExit().thenAccept { handleExit(started) }
@@ -109,10 +111,10 @@ internal class ProcessSupervisor(
             // Seed the deployment-state mirror up front so the bridge's synchronous
             // getters are correct; re-runs on every (re)spawn, rebuilding the mirror.
             onSpawned()
-            log.info("Miragon modeler bridge started: $binary")
+            log.info("Miragon modeler bridge started")
         } catch (e: Exception) {
             log.error("Failed to start the modeler bridge", e)
-            notifications().showError("Could not start the BPMN modeler engine. See idea.log.")
+            notifier.showError("Could not start the BPMN modeler engine. See idea.log.")
         }
     }
 
@@ -129,13 +131,13 @@ internal class ProcessSupervisor(
             channel.detach()
         }
 
-        if (System.currentTimeMillis() - lastSpawnAt > STABLE_RUN_MS) {
+        if (clock() - lastSpawnAt > STABLE_RUN_MS) {
             restartAttempts.set(0)
         }
         val attempt = restartAttempts.incrementAndGet()
         if (attempt > MAX_RESTARTS) {
             log.error("Modeler bridge exited $attempt times in quick succession; giving up.")
-            notifications().showError(
+            notifier.showError(
                 "The BPMN modeler engine crashed repeatedly and will not be restarted. " +
                     "Reopen the file or restart the IDE. See idea.log.",
             )
@@ -150,7 +152,7 @@ internal class ProcessSupervisor(
         // Process.onExit() CompletableFuture callback (ForkJoinPool.commonPool),
         // and blocking it for the backoff would hold a shared platform pool
         // thread for up to seconds. Re-check disposed/liveness at fire time.
-        AppExecutorUtil.getAppScheduledExecutorService().schedule(
+        scheduler.schedule(
             {
                 if (disposed.get()) return@schedule
                 synchronized(this) { if (process?.isAlive != true) spawn() }

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/DeterministicScheduler.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/DeterministicScheduler.kt
@@ -1,0 +1,106 @@
+package io.miragon.intellij.bpmn.bridge
+
+import java.util.concurrent.Callable
+import java.util.concurrent.Delayed
+import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+/**
+ * A hand-rolled [ScheduledExecutorService] that turns the supervisor's backoff
+ * scheduling into something tests can inspect and step. [schedule] records the
+ * requested delay (so tests assert the `500ms × attempt` curve) and parks the
+ * task until [runPending] fires it — making restart/give-up assertions instant
+ * and free of wall-clock waits. [execute] runs inline, since the supervisor only
+ * uses it to hop the spawn off the EDT, which is irrelevant under test.
+ *
+ * Only the two methods the supervisor calls are implemented; the rest of the
+ * interface throws, so an unexpected new dependency on the scheduler is loud
+ * rather than silently mis-tested.
+ */
+internal class DeterministicScheduler : ScheduledExecutorService {
+    private data class Pending(val task: Runnable, val delayMillis: Long)
+
+    private val pending = ArrayDeque<Pending>()
+
+    /** Every delay handed to [schedule], in order — never drained, so tests can assert the full curve. */
+    val recordedDelays = mutableListOf<Long>()
+
+    override fun execute(command: Runnable) = command.run()
+
+    override fun schedule(command: Runnable, delay: Long, unit: TimeUnit): ScheduledFuture<*> {
+        val millis = unit.toMillis(delay)
+        recordedDelays += millis
+        pending.addLast(Pending(command, millis))
+        return NoopScheduledFuture
+    }
+
+    /**
+     * Fires every currently-pending task in FIFO order. Tasks are drained before
+     * running so a task that schedules another (a respawn that crashes again)
+     * queues for the *next* [runPending] rather than looping here.
+     */
+    fun runPending() {
+        val due = pending.toList()
+        pending.clear()
+        due.forEach { it.task.run() }
+    }
+
+    // ── unused surface ──────────────────────────────────────────────────────────
+
+    override fun <V : Any?> schedule(callable: Callable<V>, delay: Long, unit: TimeUnit): ScheduledFuture<V> = unsupported()
+
+    override fun scheduleAtFixedRate(command: Runnable, initialDelay: Long, period: Long, unit: TimeUnit): ScheduledFuture<*> =
+        unsupported()
+
+    override fun scheduleWithFixedDelay(command: Runnable, initialDelay: Long, delay: Long, unit: TimeUnit): ScheduledFuture<*> =
+        unsupported()
+
+    override fun shutdown() = unsupported()
+
+    override fun shutdownNow(): MutableList<Runnable> = unsupported()
+
+    override fun isShutdown(): Boolean = unsupported()
+
+    override fun isTerminated(): Boolean = unsupported()
+
+    override fun awaitTermination(timeout: Long, unit: TimeUnit): Boolean = unsupported()
+
+    override fun <T : Any?> submit(task: Callable<T>): Future<T> = unsupported()
+
+    override fun <T : Any?> submit(task: Runnable, result: T): Future<T> = unsupported()
+
+    override fun submit(task: Runnable): Future<*> = unsupported()
+
+    override fun <T : Any?> invokeAll(tasks: MutableCollection<out Callable<T>>): MutableList<Future<T>> = unsupported()
+
+    override fun <T : Any?> invokeAll(
+        tasks: MutableCollection<out Callable<T>>,
+        timeout: Long,
+        unit: TimeUnit,
+    ): MutableList<Future<T>> = unsupported()
+
+    override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>): T = unsupported()
+
+    override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>, timeout: Long, unit: TimeUnit): T = unsupported()
+
+    private fun unsupported(): Nothing = throw UnsupportedOperationException("DeterministicScheduler: not needed by the code under test")
+}
+
+/** The supervisor ignores the returned handle, so a do-nothing future suffices. */
+private object NoopScheduledFuture : ScheduledFuture<Any?> {
+    override fun getDelay(unit: TimeUnit): Long = 0
+
+    override fun compareTo(other: Delayed): Int = 0
+
+    override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+
+    override fun isCancelled(): Boolean = false
+
+    override fun isDone(): Boolean = true
+
+    override fun get(): Any? = null
+
+    override fun get(timeout: Long, unit: TimeUnit): Any? = null
+}

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/FakeProcess.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/FakeProcess.kt
@@ -11,8 +11,8 @@ import java.io.PipedInputStream
 import java.io.PipedOutputStream
 import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.TimeoutException
 
 /**
  * A scripted [Process] standing in for the real Bun bridge so the supervisor and
@@ -37,6 +37,15 @@ internal class FakeProcess : Process() {
     private val stdinView = PipedInputStream(stdinSink, pipeBuffer)
     private val stdinReader = BufferedReader(InputStreamReader(stdinView, StandardCharsets.UTF_8))
 
+    // One daemon pump per fake drains every host→core line into this queue, so
+    // tests read frames with a plain blocking poll. This deliberately avoids both
+    // a per-read thread (the back-pressure test would spawn 512) and any shared
+    // executor: an `expectNoFrame` poll that times out by design must not leave a
+    // blocked `readLine()` task on `ForkJoinPool.commonPool()`, whose parallelism
+    // is 1 on a 2-core CI runner — one such leak starves the pool and a later
+    // test's `nextFrame` times out even though its frame is already in the pipe.
+    private val inboundFrames = LinkedBlockingQueue<String>()
+
     // Core stdout: core → host. Tests write here; the host's reader pump consumes.
     private val stdoutSource = PipedOutputStream()
     private val stdoutView = PipedInputStream(stdoutSource, pipeBuffer)
@@ -52,6 +61,17 @@ internal class FakeProcess : Process() {
 
     @Volatile
     private var exitCode = 0
+
+    init {
+        Thread({
+            // forEachLine ends on EOF/close; runCatching swallows the interrupt
+            // when the test JVM tears the fake down.
+            runCatching { stdinReader.forEachLine(inboundFrames::add) }
+        }, "fake-bridge-stdin-pump").apply {
+            isDaemon = true
+            start()
+        }
+    }
 
     override fun getOutputStream(): OutputStream = stdinSink
 
@@ -83,24 +103,16 @@ internal class FakeProcess : Process() {
 
     /**
      * Returns the next frame the host wrote to stdin, failing fast on timeout so a
-     * never-arriving frame surfaces as an error instead of hanging the suite. The
-     * read runs on a pooled daemon thread, so a timeout leaks no test thread.
+     * never-arriving frame surfaces as an error instead of hanging the suite.
      */
-    fun nextFrame(timeoutMillis: Long = 2_000): String {
-        val read = CompletableFuture.supplyAsync { stdinReader.readLine() }
-        val line = read.get(timeoutMillis, TimeUnit.MILLISECONDS)
-        return line ?: error("bridge stdin reached EOF; no frame")
-    }
+    fun nextFrame(timeoutMillis: Long = 2_000): String =
+        inboundFrames.poll(timeoutMillis, TimeUnit.MILLISECONDS)
+            ?: error("no frame on bridge stdin within ${timeoutMillis}ms")
 
     /** Asserts no frame is written within [timeoutMillis] (e.g. after detach). */
     fun expectNoFrame(timeoutMillis: Long = 250) {
-        val read = CompletableFuture.supplyAsync { stdinReader.readLine() }
-        try {
-            val line = read.get(timeoutMillis, TimeUnit.MILLISECONDS)
-            error("expected no frame, but got: $line")
-        } catch (_: TimeoutException) {
-            // Expected: nothing was written.
-        }
+        val line = inboundFrames.poll(timeoutMillis, TimeUnit.MILLISECONDS)
+        if (line != null) error("expected no frame, but got: $line")
     }
 
     /**

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/FakeProcess.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/FakeProcess.kt
@@ -1,0 +1,123 @@
+package io.miragon.intellij.bpmn.bridge
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * A scripted [Process] standing in for the real Bun bridge so the supervisor and
+ * transport can be driven deterministically: tests [emit] core→host frames, read
+ * back the host→core frames the writer produced, and [kill] the process on demand
+ * to assert crash/restart behavior — with no real binary, sockets, or sleeps.
+ *
+ * Stream directions follow the *core's* point of view, matching [Process]:
+ *  - [getOutputStream] is the core's stdin — the host writes frames here; tests
+ *    read them back via [nextFrame].
+ *  - [getInputStream] is the core's stdout — tests push frames via [emit]; the
+ *    host's reader pump consumes them.
+ *
+ * Pipe buffers are oversized so a flood of outbound frames never blocks the
+ * writer waiting on a reader (the back-pressure/coalescing tests enqueue many).
+ */
+internal class FakeProcess : Process() {
+    private val pipeBuffer = 1 shl 20
+
+    // Core stdin: host → core. The writer thread writes here; tests read it back.
+    private val stdinSink = PipedOutputStream()
+    private val stdinView = PipedInputStream(stdinSink, pipeBuffer)
+    private val stdinReader = BufferedReader(InputStreamReader(stdinView, StandardCharsets.UTF_8))
+
+    // Core stdout: core → host. Tests write here; the host's reader pump consumes.
+    private val stdoutSource = PipedOutputStream()
+    private val stdoutView = PipedInputStream(stdoutSource, pipeBuffer)
+    private val stdoutWriter = BufferedWriter(OutputStreamWriter(stdoutSource, StandardCharsets.UTF_8))
+
+    // The real bridge keeps stderr separate; nothing under test reads it.
+    private val stderr = ByteArrayInputStream(ByteArray(0))
+
+    private val exit = CompletableFuture<Process>()
+
+    @Volatile
+    private var alive = true
+
+    @Volatile
+    private var exitCode = 0
+
+    override fun getOutputStream(): OutputStream = stdinSink
+
+    override fun getInputStream(): InputStream = stdoutView
+
+    override fun getErrorStream(): InputStream = stderr
+
+    override fun waitFor(): Int {
+        exit.join()
+        return exitCode
+    }
+
+    override fun exitValue(): Int = if (alive) throw IllegalThreadStateException() else exitCode
+
+    override fun isAlive(): Boolean = alive
+
+    override fun destroy() = kill(SIGTERM)
+
+    override fun onExit(): CompletableFuture<Process> = exit
+
+    // ── test API ──────────────────────────────────────────────────────────────
+
+    /** Pushes one newline-delimited frame onto the core's stdout. */
+    fun emit(frame: String) {
+        stdoutWriter.write(frame)
+        stdoutWriter.write("\n")
+        stdoutWriter.flush()
+    }
+
+    /**
+     * Returns the next frame the host wrote to stdin, failing fast on timeout so a
+     * never-arriving frame surfaces as an error instead of hanging the suite. The
+     * read runs on a pooled daemon thread, so a timeout leaks no test thread.
+     */
+    fun nextFrame(timeoutMillis: Long = 2_000): String {
+        val read = CompletableFuture.supplyAsync { stdinReader.readLine() }
+        val line = read.get(timeoutMillis, TimeUnit.MILLISECONDS)
+        return line ?: error("bridge stdin reached EOF; no frame")
+    }
+
+    /** Asserts no frame is written within [timeoutMillis] (e.g. after detach). */
+    fun expectNoFrame(timeoutMillis: Long = 250) {
+        val read = CompletableFuture.supplyAsync { stdinReader.readLine() }
+        try {
+            val line = read.get(timeoutMillis, TimeUnit.MILLISECONDS)
+            error("expected no frame, but got: $line")
+        } catch (_: TimeoutException) {
+            // Expected: nothing was written.
+        }
+    }
+
+    /**
+     * Simulates the process dying. Closing the stdout source EOFs the host's
+     * reader pump (as a real exit would), and completing [exit] fires the
+     * supervisor's `onExit` callback synchronously on the caller's thread — the
+     * property that makes restart assertions deterministic.
+     */
+    fun kill(code: Int = 1) {
+        if (!alive) return
+        alive = false
+        exitCode = code
+        runCatching { stdoutWriter.close() }
+        exit.complete(this)
+    }
+
+    private companion object {
+        const val SIGTERM = 143
+    }
+}

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/MutableClock.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/MutableClock.kt
@@ -1,0 +1,17 @@
+package io.miragon.intellij.bpmn.bridge
+
+/**
+ * A settable wall-clock source (`() -> Long`) so supervisor tests cross the
+ * stable-run boundary by [advance]-ing time instead of sleeping.
+ */
+internal class MutableClock(private var nowMillis: Long = 0L) : () -> Long {
+    override fun invoke(): Long = nowMillis
+
+    fun advance(millis: Long) {
+        nowMillis += millis
+    }
+
+    fun set(millis: Long) {
+        nowMillis = millis
+    }
+}

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisorTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/ProcessSupervisorTest.kt
@@ -1,0 +1,177 @@
+package io.miragon.intellij.bpmn.bridge
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+/**
+ * Drives [ProcessSupervisor] through its crash/restart logic with a scripted
+ * [FakeProcess], a [DeterministicScheduler], and a [MutableClock] so backoff,
+ * the give-up threshold, the stable-run reset, dispose safety, and the
+ * re-register contract are asserted instantly and without real processes or
+ * sleeps. The injection seams make the production wiring identical while letting
+ * tests control time, scheduling, process birth/death, and error reporting.
+ *
+ * Session re-registration is covered only at the *contract* level (the supervisor
+ * invokes [onRespawned] exactly when it should); the router content it triggers
+ * is IntelliJ-coupled and out of scope here.
+ */
+@ExtendWith(TestLoggerSetup::class)
+class ProcessSupervisorTest {
+    /** Records the user-facing errors the supervisor surfaces, so tests can assert what (and how often) it reported. */
+    private class RecordingErrorNotifier : BridgeErrorNotifier {
+        val errors = mutableListOf<String>()
+
+        override fun showError(message: String) {
+            errors += message
+        }
+    }
+
+    /** A notifier that fails the test if invoked — used on happy paths that must surface no error. */
+    private val failOnError = BridgeErrorNotifier { fail("unexpected error notification: $it") }
+
+    /**
+     * Each crash within the stable window respawns at `500ms × attempt`; once the
+     * attempts exceed `MAX_RESTARTS` the supervisor gives up — no further spawn —
+     * and surfaces exactly one user-facing error.
+     */
+    @Test
+    fun `crashes within the stable window respawn with linear backoff then give up`() {
+        val processes = mutableListOf<FakeProcess>()
+        val scheduler = DeterministicScheduler()
+        val notifier = RecordingErrorNotifier()
+        val supervisor =
+            ProcessSupervisor(
+                channel = RpcChannel { _, _, _ -> },
+                launcher = { FakeProcess().also { processes += it } },
+                notifier = notifier,
+                onSpawned = {},
+                onRespawned = {},
+                scheduler = scheduler,
+                clock = MutableClock(),
+            )
+
+        supervisor.ensureStarted()
+        assertEquals(1, processes.size)
+
+        repeat(5) {
+            processes.last().kill()
+            scheduler.runPending()
+        }
+
+        assertEquals(6, processes.size, "5 respawns followed the initial spawn")
+        assertEquals(listOf(500L, 1000L, 1500L, 2000L, 2500L), scheduler.recordedDelays)
+        assertEquals(emptyList<String>(), notifier.errors, "no error before the give-up threshold")
+
+        processes.last().kill()
+        scheduler.runPending()
+        assertEquals(6, processes.size, "no respawn past the give-up threshold")
+        assertEquals(1, notifier.errors.size, "give-up surfaced exactly one user-facing error")
+        assertTrue(notifier.errors.single().contains("crashed repeatedly"), "the error explains the give-up")
+
+        supervisor.dispose()
+    }
+
+    /** A crash after the process ran past the stable window resets the attempt counter, so backoff restarts at attempt 1. */
+    @Test
+    fun `a stable run resets the restart counter`() {
+        val processes = mutableListOf<FakeProcess>()
+        val scheduler = DeterministicScheduler()
+        val clock = MutableClock()
+        val supervisor =
+            ProcessSupervisor(
+                channel = RpcChannel { _, _, _ -> },
+                launcher = { FakeProcess().also { processes += it } },
+                notifier = failOnError,
+                onSpawned = {},
+                onRespawned = {},
+                scheduler = scheduler,
+                clock = clock,
+            )
+
+        supervisor.ensureStarted()
+        processes.last().kill()
+        scheduler.runPending()
+        processes.last().kill()
+        scheduler.runPending()
+        assertEquals(listOf(500L, 1000L), scheduler.recordedDelays)
+
+        // The process ran stably (well past the 15s window) before this crash.
+        clock.set(STABLE_WINDOW_EXCEEDED_MS)
+        processes.last().kill()
+        scheduler.runPending()
+
+        assertEquals(listOf(500L, 1000L, 500L), scheduler.recordedDelays, "the stable run reset the counter to attempt 1")
+        assertEquals(4, processes.size, "the post-stable crash still respawned")
+
+        supervisor.dispose()
+    }
+
+    /** A respawn scheduled before [ProcessSupervisor.dispose] must no-op when it fires — the disposed re-check guards it. */
+    @Test
+    fun `dispose prevents a scheduled respawn from firing`() {
+        val processes = mutableListOf<FakeProcess>()
+        val scheduler = DeterministicScheduler()
+        var respawnCount = 0
+        val supervisor =
+            ProcessSupervisor(
+                channel = RpcChannel { _, _, _ -> },
+                launcher = { FakeProcess().also { processes += it } },
+                notifier = failOnError,
+                onSpawned = {},
+                onRespawned = { respawnCount++ },
+                scheduler = scheduler,
+                clock = MutableClock(),
+            )
+
+        supervisor.ensureStarted()
+        processes.last().kill() // schedules a respawn
+        supervisor.dispose()
+        scheduler.runPending() // the scheduled task must observe `disposed` and bail
+
+        assertEquals(1, processes.size, "no respawn after dispose")
+        assertEquals(0, respawnCount, "onRespawned never ran")
+    }
+
+    /**
+     * The re-register contract: [onSpawned] runs on the first spawn *and* every
+     * crash respawn; [onRespawned] runs only after a crash respawn — never on the
+     * first spawn and never on dispose.
+     */
+    @Test
+    fun `onSpawned runs on every spawn while onRespawned runs only after a crash`() {
+        val processes = mutableListOf<FakeProcess>()
+        val scheduler = DeterministicScheduler()
+        var spawnCount = 0
+        var respawnCount = 0
+        val supervisor =
+            ProcessSupervisor(
+                channel = RpcChannel { _, _, _ -> },
+                launcher = { FakeProcess().also { processes += it } },
+                notifier = failOnError,
+                onSpawned = { spawnCount++ },
+                onRespawned = { respawnCount++ },
+                scheduler = scheduler,
+                clock = MutableClock(),
+            )
+
+        supervisor.ensureStarted()
+        assertEquals(1, spawnCount)
+        assertEquals(0, respawnCount, "onRespawned must not run on the first spawn")
+
+        processes.last().kill()
+        scheduler.runPending()
+        assertEquals(2, spawnCount, "onSpawned ran again on the crash respawn")
+        assertEquals(1, respawnCount, "onRespawned ran after the crash")
+
+        supervisor.dispose()
+        assertEquals(1, respawnCount, "dispose does not trigger a re-register")
+    }
+
+    private companion object {
+        // Comfortably past the supervisor's private 15s STABLE_RUN_MS.
+        const val STABLE_WINDOW_EXCEEDED_MS = 20_000L
+    }
+}

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannelTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannelTest.kt
@@ -1,0 +1,144 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+/**
+ * Exercises the transport's concurrency-critical guarantees against a scripted
+ * [FakeProcess] — coalescing, back-pressure, pump survival, and the reply
+ * leak-guard — without touching the supervisor. The channel needs no seams: its
+ * `attach(stdin, stdout)` already takes raw streams.
+ */
+@ExtendWith(TestLoggerSetup::class)
+class RpcChannelTest {
+    private val gson = Gson()
+
+    private fun parse(line: String): JsonObject = gson.fromJson(line, JsonObject::class.java)
+
+    /**
+     * Coalescing collapses to the *latest* keyed frame while non-coalesced frames
+     * survive in order. Enqueuing before [RpcChannel.attach] is deliberate: the
+     * writer thread only starts on attach, so the whole flood coalesces in the
+     * deque first, making the outcome deterministic.
+     */
+    @Test
+    fun `coalescing keeps only the latest keyed frame and preserves the rest in order`() {
+        val fake = FakeProcess()
+        val channel = RpcChannel { _, _, _ -> }
+
+        channel.notify("sync", mapOf("v" to 1), coalesceKey = "sync:x")
+        channel.notify("sync", mapOf("v" to 2), coalesceKey = "sync:x")
+        channel.notify("other", mapOf("v" to 99))
+        channel.notify("sync", mapOf("v" to 3), coalesceKey = "sync:x")
+
+        channel.attach(fake.outputStream, fake.inputStream)
+
+        val first = parse(fake.nextFrame())
+        val second = parse(fake.nextFrame())
+        assertEquals("other", first.get("method").asString)
+        assertEquals(99, first.getAsJsonObject("params").get("v").asInt)
+        assertEquals("sync", second.get("method").asString)
+        assertEquals(3, second.getAsJsonObject("params").get("v").asInt, "only the latest sync:x frame survives")
+        fake.expectNoFrame()
+    }
+
+    /**
+     * Past [OUTBOUND_CAPACITY] the oldest frame is dropped and the newest kept.
+     * The writer stays detached while we overflow, so the drop happens purely in
+     * the deque; attaching afterwards drains exactly the survivors.
+     */
+    @Test
+    fun `backpressure drops the oldest frame and retains the newest`() {
+        val capacity = 512
+        val fake = FakeProcess()
+        val channel = RpcChannel { _, _, _ -> }
+
+        for (i in 0..capacity) channel.notify("m", i) // capacity + 1 frames
+
+        channel.attach(fake.outputStream, fake.inputStream)
+
+        val params = (1..capacity).map { parse(fake.nextFrame()).get("params").asInt }
+        assertEquals(capacity, params.size)
+        assertEquals(1, params.first(), "frame 0 was dropped as the oldest")
+        assertEquals(capacity, params.last(), "the newest frame was retained")
+        fake.expectNoFrame()
+    }
+
+    /** A malformed inbound line is discarded without killing the reader pump — a later valid frame still dispatches. */
+    @Test
+    fun `malformed inbound frame does not kill the pump`() {
+        val dispatched = LinkedBlockingQueue<String>()
+        val channel = RpcChannel { method, _, _ -> dispatched.add(method) }
+        val fake = FakeProcess()
+        channel.attach(fake.outputStream, fake.inputStream)
+
+        fake.emit("this is not json {{{")
+        fake.emit("""{"method":"ping","params":{}}""")
+
+        assertEquals("ping", dispatched.poll(2, TimeUnit.SECONDS), "pump survived the malformed line")
+    }
+
+    /**
+     * Every inbound *request* (a frame with an `id`) is answered: a throwing
+     * handler still produces an `{id, error}` reply so the core's awaiting promise
+     * never leaks, and a normal handler's `{id, result}` reply is written too.
+     */
+    @Test
+    fun `inbound request is always answered even when the handler throws`() {
+        var channelRef: RpcChannel? = null
+        val channel = RpcChannel { method, _, id ->
+            when (method) {
+                "boom" -> throw RuntimeException("handler blew up")
+                "echo" -> channelRef!!.reply(id!!, "ok")
+            }
+        }
+        channelRef = channel
+        val fake = FakeProcess()
+        channel.attach(fake.outputStream, fake.inputStream)
+
+        fake.emit("""{"method":"boom","params":{},"id":7}""")
+        fake.emit("""{"method":"echo","params":{},"id":9}""")
+
+        val errorReply = parse(fake.nextFrame())
+        assertEquals(7, errorReply.get("id").asInt)
+        assertTrue(errorReply.has("error"), "a throwing handler must still settle the request")
+
+        val okReply = parse(fake.nextFrame())
+        assertEquals(9, okReply.get("id").asInt)
+        assertEquals("ok", okReply.get("result").asString)
+    }
+
+    /**
+     * [RpcChannel.detach] drops frames queued during the gap but leaves the writer
+     * thread alive, so frames enqueued after re-attach still flow. The
+     * `expectNoFrame` between detach and re-attach guarantees the dropped frame is
+     * consumed-and-discarded *before* the new writer is installed, removing the
+     * race where it could otherwise land on the second stream.
+     */
+    @Test
+    fun `detach drops frames but the writer survives and resumes`() {
+        val first = FakeProcess()
+        val channel = RpcChannel { _, _, _ -> }
+        channel.attach(first.outputStream, first.inputStream)
+
+        channel.notify("before", 1)
+        assertEquals("before", parse(first.nextFrame()).get("method").asString)
+
+        channel.detach()
+        channel.notify("dropped", 2)
+        first.expectNoFrame() // the writer wakes, sees no target, and drops the frame
+
+        val second = FakeProcess()
+        channel.attach(second.outputStream, second.inputStream)
+        channel.notify("after", 3)
+
+        val resumed = parse(second.nextFrame())
+        assertEquals("after", resumed.get("method").asString, "the surviving writer resumed on the new stream")
+    }
+}

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/TestLoggerSetup.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/TestLoggerSetup.kt
@@ -1,0 +1,44 @@
+package io.miragon.intellij.bpmn.bridge
+
+import com.intellij.openapi.diagnostic.Logger
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Installs a no-op [Logger] factory before any platform [Logger.getInstance]
+ * call fires. Without a real IDE, the default factory yields a `DefaultLogger`
+ * whose `error(...)` *throws* — which would abort the give-up and spawn-failure
+ * tests at the very line they mean to exercise. A no-op logger lets those paths
+ * run to their observable effect (or lack of one).
+ *
+ * Registered via `@ExtendWith(TestLoggerSetup::class)` on the suites that touch
+ * production code holding a `Logger`.
+ */
+class TestLoggerSetup : BeforeAllCallback {
+    override fun beforeAll(context: ExtensionContext) = install()
+
+    companion object {
+        private val installed = AtomicBoolean(false)
+
+        /** Idempotent: the factory is process-global, so install it at most once. */
+        fun install() {
+            if (installed.compareAndSet(false, true)) {
+                Logger.setFactory { NoopLogger() }
+            }
+        }
+    }
+}
+
+/** Swallows every level so production logging is inert under test. */
+private class NoopLogger : Logger() {
+    override fun isDebugEnabled(): Boolean = false
+
+    override fun debug(message: String?, t: Throwable?) = Unit
+
+    override fun info(message: String?, t: Throwable?) = Unit
+
+    override fun warn(message: String?, t: Throwable?) = Unit
+
+    override fun error(message: String?, t: Throwable?, vararg details: String) = Unit
+}


### PR DESCRIPTION
**Issue**

Closes #1105

**Description**

The IntelliJ plugin owned the system's hardest concurrency (bridge process supervision, the coalescing writer queue, reader-pump lifecycle) yet had zero tests. This adds a pure-JVM JUnit 5 harness that drives those paths against a scripted fake process, behind minimal behavior-preserving injection seams: `BridgeProcessLauncher` (extracts binary resolve + spawn out of the supervisor), `BridgeErrorNotifier` (a narrow port for fatal spawn/give-up errors, adapted from the lazy `HostNotifications` in `CoreProcess`), plus injected scheduler/clock — all with production defaults so wiring and runtime behavior are unchanged. Tests cover the transport (coalescing, backpressure, pump survival, reply leak-guard, detach/resume) and the supervisor (linear backoff, give-up threshold, stable-run reset, dispose safety, re-register contract). CI adds a jacoco XML report and a path-filtered `test-intellij-plugin` job that runs the suite and uploads coverage to Codecov on PRs touching the plugin.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created