### PR TITLE
chore(release): move intellij plugin version out of build.gradle.kts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
       vscode-plugin: ${{ steps.filter.outputs.vscode-plugin }}
       vscode-plugin-src: ${{ steps.filter.outputs.vscode-plugin-src }}
       intellij-plugin: ${{ steps.filter.outputs.intellij-plugin }}
+      intellij-plugin-src: ${{ steps.filter.outputs.intellij-plugin-src }}
       modeler-core-src: ${{ steps.filter.outputs.modeler-core-src }}
       modeler-bridge-src: ${{ steps.filter.outputs.modeler-bridge-src }}
       bpmn-webview: ${{ steps.filter.outputs.bpmn-webview }}
@@ -65,19 +66,19 @@ jobs:
               - 'apps/modeler-bridge/**'
             vscode-plugin:
               - 'apps/vscode-plugin/**'
-            # No `*-src` split: release-please bumps the version inside
-            # build.gradle.kts (not a dedicated file), so there is no clean way to
-            # exclude a version-only change — a redundant coverage upload on a
-            # version-bump PR is harmless (Codecov dedups by commit).
             intellij-plugin:
               - 'apps/intellij-plugin/**'
-            # `*-src` mirror the package filters above but drop package.json, so a
-            # version-bump-only PR (release-please) skips the Codecov coverage
-            # report while build+test still run via the broad filters. Relies on
-            # `predicate-quantifier: every` to honour the negation.
+            # `*-src` mirror the package filters above but drop the file
+            # release-please bumps (package.json, or gradle.properties for the
+            # IntelliJ plugin), so a version-bump-only PR skips the Codecov
+            # coverage report while build+test still run via the broad filters.
+            # Relies on `predicate-quantifier: every` to honour the negation.
             vscode-plugin-src:
               - 'apps/vscode-plugin/**'
               - '!apps/vscode-plugin/package.json'
+            intellij-plugin-src:
+              - 'apps/intellij-plugin/**'
+              - '!apps/intellij-plugin/gradle.properties'
             modeler-core-src:
               - 'libs/modeler-core/**'
               - '!libs/modeler-core/package.json'
@@ -419,7 +420,11 @@ jobs:
       - name: Run unit tests with coverage
         working-directory: apps/intellij-plugin
         run: ./gradlew jacocoTestReport --no-daemon
+      # Gate the upload on the plugin's own sources so a release-please
+      # version-bump PR (gradle.properties only) skips the redundant report
+      # while the build+test step above still runs via the broad filter.
       - name: Upload coverage to Codecov
+        if: needs.detect-changes.outputs.intellij-plugin-src == 'true'
         uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "io.miragon"
-version = "1.1.2" // x-release-please-version
+version = providers.gradleProperty("pluginVersion").get()
 
 repositories {
     mavenCentral()

--- a/apps/intellij-plugin/gradle.properties
+++ b/apps/intellij-plugin/gradle.properties
@@ -1,3 +1,8 @@
+# Plugin version. Managed by release-please — do not edit by hand.
+# x-release-please-start-version
+pluginVersion=1.1.2
+# x-release-please-end
+
 # IntelliJ IDEA Community version the plugin builds and runs against. 2024.2+
 # bundles JCEF (embedded Chromium), which the BPMN editor relies on.
 ideaVersion=2024.2.5

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,7 +29,7 @@
         },
         {
           "type": "generic",
-          "path": "apps/intellij-plugin/build.gradle.kts"
+          "path": "apps/intellij-plugin/gradle.properties"
         }
       ]
     }


### PR DESCRIPTION
**Issue**

The release PR's `test-intellij-plugin` job failed with `Task 'jacocoTestReport' not found`. release-please managed the \`version\` line inside `build.gradle.kts`, which also holds the hand-maintained jacoco/JUnit harness — a stale release-PR rebase reverted that harness while CI still invoked `jacocoTestReport`.

**Description**

Moves the release-managed version into `apps/intellij-plugin/gradle.properties` (`pluginVersion`, wrapped in release-please block markers) and reads it in `build.gradle.kts` via `providers.gradleProperty("pluginVersion").get()`, mirroring the existing `ideaVersion` pattern. `release-please-config.json`'s generic updater is repointed to `gradle.properties` so release-please never rewrites `build.gradle.kts` again, making this class of failure structurally impossible. Verified locally: \`:properties\` reads `1.1.2`, `jacocoTestReport` builds successfully, and `patchPluginXml` emits `<version>1.1.2</version>`.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created