### PR TITLE
chore(ci): pin github actions to exact version tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,8 @@ jobs:
       deployment-webview: ${{ steps.filter.outputs.deployment-webview }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@v7.0.0
+      - uses: dorny/paths-filter@v4.0.1
         id: filter
         with:
           # `every` makes the `!`-negation patterns in the `*-src` filters below
@@ -96,10 +96,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: Miragon/pin-npm-dependencies@v1
+      - uses: actions/checkout@v7.0.0
+      - uses: Miragon/pin-npm-dependencies@v1.2.1
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -117,10 +117,10 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: Miragon/pin-npm-dependencies@v1
+      - uses: actions/checkout@v7.0.0
+      - uses: Miragon/pin-npm-dependencies@v1.2.1
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -139,9 +139,9 @@ jobs:
     if: needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -153,9 +153,9 @@ jobs:
     if: needs.detect-changes.outputs.bpmn-i18n == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -167,9 +167,9 @@ jobs:
     if: needs.detect-changes.outputs.element-template-chooser == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -183,9 +183,9 @@ jobs:
       needs.detect-changes.outputs.element-template-chooser == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -197,9 +197,9 @@ jobs:
     if: needs.detect-changes.outputs.bpmn-clipboard == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -215,9 +215,9 @@ jobs:
       needs.detect-changes.outputs.bpmn-i18n == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -245,9 +245,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -272,7 +272,7 @@ jobs:
           always() && github.event_name == 'pull_request' &&
           needs.detect-changes.outputs.vscode-plugin-src == 'true'
         continue-on-error: true
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@v2.12.1
         with:
           # Paths resolve relative to working-directory; vitest writes the
           # reports to the repo-root coverage/ dir, two levels up.
@@ -282,7 +282,7 @@ jobs:
           name: vscode-plugin
       - name: Upload coverage to Codecov
         if: needs.detect-changes.outputs.vscode-plugin-src == 'true'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./coverage/apps/vscode-plugin"
@@ -306,9 +306,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -326,7 +326,7 @@ jobs:
           always() && github.event_name == 'pull_request' &&
           needs.detect-changes.outputs.modeler-core-src == 'true'
         continue-on-error: true
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@v2.12.1
         with:
           working-directory: libs/modeler-core
           json-summary-path: ../../coverage/libs/modeler-core/coverage-summary.json
@@ -334,7 +334,7 @@ jobs:
           name: modeler-core
       - name: Upload coverage to Codecov
         if: needs.detect-changes.outputs.modeler-core-src == 'true'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./coverage/libs/modeler-core"
@@ -359,9 +359,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -378,7 +378,7 @@ jobs:
           always() && github.event_name == 'pull_request' &&
           needs.detect-changes.outputs.modeler-bridge-src == 'true'
         continue-on-error: true
-        uses: davelosert/vitest-coverage-report-action@v2
+        uses: davelosert/vitest-coverage-report-action@v2.12.1
         with:
           working-directory: apps/modeler-bridge
           json-summary-path: ../../coverage/apps/modeler-bridge/coverage-summary.json
@@ -386,7 +386,7 @@ jobs:
           name: modeler-bridge
       - name: Upload coverage to Codecov
         if: needs.detect-changes.outputs.modeler-bridge-src == 'true'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./coverage/apps/modeler-bridge"
@@ -404,14 +404,14 @@ jobs:
     if: needs.detect-changes.outputs.intellij-plugin == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - name: Setup JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           distribution: temurin
           java-version: '21'
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.2.0
       # `jacocoTestReport` depends on `test`, so this runs the JUnit 5 suite and
       # then writes the coverage XML. Resources (bridge binary, webview bundles)
       # are absent on a clean checkout, so their Copy tasks are NO-SOURCE and the
@@ -420,7 +420,7 @@ jobs:
         working-directory: apps/intellij-plugin
         run: ./gradlew jacocoTestReport --no-daemon
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: apps/intellij-plugin/build/reports/jacoco/test/jacocoTestReport.xml
@@ -449,10 +449,10 @@ jobs:
        needs.detect-changes.outputs.shared == 'true')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: Miragon/pin-npm-dependencies@v1
+      - uses: actions/checkout@v7.0.0
+      - uses: Miragon/pin-npm-dependencies@v1.2.1
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -471,7 +471,7 @@ jobs:
         run: corepack yarn build
       # Cache the downloaded VS Code/Electron so reruns skip the ~150 MB fetch.
       - name: Cache VS Code download
-        uses: actions/cache@v5
+        uses: actions/cache@v5.0.5
         with:
           path: apps/vscode-plugin/.vscode-test
           key: vscode-test-${{ runner.os }}
@@ -489,9 +489,9 @@ jobs:
       needs.detect-changes.outputs.bpmn-clipboard == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -499,7 +499,7 @@ jobs:
         run: yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-webview @miragon/bpmn-modeler-shared @miragon/bpmn-modeler-i18n @miragon/bpmn-modeler-append-menu @miragon/bpmn-modeler-element-template-chooser @miragon/bpmn-modeler-clipboard
       - run: yarn workspace @miragon/bpmn-modeler-webview test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./coverage/apps/bpmn-webview"
@@ -513,9 +513,9 @@ jobs:
     if: needs.detect-changes.outputs.bpmn-i18n == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -523,7 +523,7 @@ jobs:
         run: yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-i18n
       - run: yarn workspace @miragon/bpmn-modeler-i18n test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: "./coverage/libs/bpmn-i18n"
@@ -543,9 +543,9 @@ jobs:
       needs.detect-changes.outputs.bpmn-clipboard == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -560,9 +560,9 @@ jobs:
       needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -577,9 +577,9 @@ jobs:
       needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -592,10 +592,10 @@ jobs:
     if: needs.detect-changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: Miragon/pin-npm-dependencies@v1
+      - uses: actions/checkout@v7.0.0
+      - uses: Miragon/pin-npm-dependencies@v1.2.1
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete old workflow runs
-        uses: Mattraks/delete-workflow-runs@v2
+        uses: Mattraks/delete-workflow-runs@v2.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,14 +27,14 @@ jobs:
       matrix:
         language: [ javascript-typescript, actions ]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v4.36.2
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v4.36.2
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,17 +21,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: Miragon/pin-npm-dependencies@v1
+      - uses: actions/checkout@v7.0.0
+      - uses: Miragon/pin-npm-dependencies@v1.2.1
       - run: corepack enable
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version: 22
           cache: yarn
       - run: corepack yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-docs
       - run: corepack yarn docs:test
       - run: corepack yarn docs:build
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: docs/.vitepress/dist
 
@@ -43,4 +43,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -22,7 +22,7 @@ jobs:
     name: Validate Conventional Commit title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Label PRs
-        uses: tinkurlab/monorepo-pr-labeler-action@master
+        uses: tinkurlab/monorepo-pr-labeler-action@4.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_DIRS: "apps|libs"

--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -49,36 +49,36 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check pinned dependencies
-        uses: Miragon/pin-npm-dependencies@v1
+        uses: Miragon/pin-npm-dependencies@v1.2.1
 
       - name: Corepack enable
         run: corepack enable
 
       - name: Setup Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
 
       - name: Setup JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.3.0
         with:
           distribution: temurin
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@v6.2.0
 
       # Bun is needed for cross-compiling the bridge to all 5 targets.
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version: latest
 
@@ -138,7 +138,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate App token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
@@ -227,7 +227,7 @@ jobs:
           exit 1
 
       - name: Record deployment
-        uses: actions/github-script@v9
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const version = "${{ steps.tag.outputs.version }}";

--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.ref }}
 
@@ -76,7 +76,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -94,7 +94,7 @@ jobs:
         run: npx @vscode/vsce package --out bpmn-modeler-plugin.vsix --yarn --no-dependencies
 
       - name: Upload .vsix artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: standalone-vsix
           path: dist/apps/vscode-plugin/bpmn-modeler-plugin.vsix
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.ref }}
 
@@ -124,7 +124,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -135,7 +135,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download .vsix from build-vsix job
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: standalone-vsix
           path: dist/apps/vscode-plugin
@@ -183,7 +183,7 @@ jobs:
 
       - name: Upload DMG artifact (dry-run)
         if: inputs.dry-run == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: standalone-dmg-dry-run
           path: |
@@ -219,12 +219,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
 
@@ -237,7 +237,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download .vsix from build-vsix job
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           name: standalone-vsix
           path: dist/apps/vscode-plugin
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload NSIS artifact (dry-run)
         if: inputs.dry-run == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: standalone-nsis-dry-run
           path: |
@@ -285,7 +285,7 @@ jobs:
     if: inputs.dry-run == false
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.ref }}
 
@@ -296,7 +296,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Record deployment
-        uses: actions/github-script@v9
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const version = "${{ steps.version.outputs.version }}";

--- a/.github/workflows/publish-vscode-modeler.yml
+++ b/.github/workflows/publish-vscode-modeler.yml
@@ -51,20 +51,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check pinned dependencies
-        uses: Miragon/pin-npm-dependencies@v1
+        uses: Miragon/pin-npm-dependencies@v1.2.1
 
       - name: Corepack enable
         run: corepack enable
 
       - name: Setup Node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: '22'
           cache: yarn
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload vsix artifact (dry-run)
         if: inputs.dry-run == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: bpmn-modeler-plugin-v${{ steps.version.outputs.version }}
           path: dist/apps/vscode-plugin/bpmn-modeler-plugin.vsix
@@ -108,7 +108,7 @@ jobs:
       # auto-creates on first deployment.
       - name: Record deployment
         if: inputs.dry-run == false
-        uses: actions/github-script@v9
+        uses: actions/github-script@v9.0.0
         with:
           script: |
             const version = "${{ steps.version.outputs.version }}";

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,13 +24,13 @@ jobs:
       tag: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@v5.0.0
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-engine-versions.yml
+++ b/.github/workflows/update-engine-versions.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.0
 
       - name: Setup NodeJS 20
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
## What

Pin all third-party GitHub Actions from floating major-version refs (`@vX`) to exact version tags (`@vX.Y.Z`), each resolved to the latest available release via the GitHub API.

## Why

Floating major tags (`@v7`) silently move when a maintainer re-publishes the major tag, so a build can change behaviour without any change in this repo. Exact version tags make CI reproducible and make every action bump an explicit, reviewable diff (and Dependabot-trackable).

Notably, `tinkurlab/monorepo-pr-labeler-action` was running off `@master` — an unpinned branch ref — now pinned to the latest release tag.

## Changes

| Action | before | after |
|---|---|---|
| actions/checkout | `@v7` | `@v7.0.0` |
| actions/setup-node | `@v6` | `@v6.4.0` |
| actions/setup-java | `@v5` | `@v5.3.0` |
| actions/cache | `@v5` | `@v5.0.5` |
| actions/upload-artifact | `@v7` | `@v7.0.1` |
| actions/download-artifact | `@v8` | `@v8.0.1` |
| actions/upload-pages-artifact | `@v5` | `@v5.0.0` |
| actions/deploy-pages | `@v5` | `@v5.0.0` |
| actions/create-github-app-token | `@v3` | `@v3.2.0` |
| actions/github-script | `@v9` | `@v9.0.0` |
| Miragon/pin-npm-dependencies | `@v1` | `@v1.2.1` |
| Mattraks/delete-workflow-runs | `@v2` | `@v2.1.0` |
| dorny/paths-filter | `@v4` | `@v4.0.1` |
| davelosert/vitest-coverage-report-action | `@v2` | `@v2.12.1` |
| codecov/codecov-action | `@v7` | `@v7.0.0` |
| gradle/actions/setup-gradle | `@v6` | `@v6.2.0` |
| github/codeql-action (init + analyze) | `@v4` | `@v4.36.2` |
| amannn/action-semantic-pull-request | `@v6` | `@v6.1.1` |
| oven-sh/setup-bun | `@v2` | `@v2.2.0` |
| googleapis/release-please-action | `@v5` | `@v5.0.0` |
| tinkurlab/monorepo-pr-labeler-action | `@master` | `@4.2.0` |

Local reusable-workflow refs (`./.github/workflows/...`) were left untouched.

## Notes

Tag pinning is stronger than major pinning but does not protect against tags being force-pushed. Full SHA pinning would be the next step if maximum supply-chain hardening is desired.