### PR TITLE
chore: standardize portless dev scripts and pin portless dependency

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -30,7 +30,7 @@ corepack yarn test apps/vscode-plugin/src/shared/domain/BpmnDocument.spec.ts
 
 ### Webview scripts (bpmn-webview, dmn-webview, deployment-webview)
 
-Each webview workspace has three scripts, one per workflow:
+Each webview workspace has these scripts, one per workflow:
 
 - `build` — one-shot bundle to `dist/webview-staging/<name>/`.
 - `watch` — `vite build --watch`; rebuilds the bundle to disk. Used by the
@@ -38,6 +38,12 @@ Each webview workspace has three scripts, one per workflow:
   from disk via `webview.asWebviewUri`, so a dev HTTP server would not work
   here).
 - `serve` — Vite HTTP dev server via for standalone browser preview.
+- `dev` / `dev:app` — `dev` is only the [`portless`](https://portless.sh)
+  entrypoint; the real Vite command lives in `dev:app`
+  (`vite --port $PORT --host 127.0.0.1`). portless (a pinned dev dependency)
+  serves the app under a stable `<worktree>.<app>.localhost` URL, with
+  `portless.json` naming the app and pointing `dev` at `dev:app`. One-time
+  per machine: `npx portless service install`.
 
 At the root level: `yarn watch` runs the F5 orchestrator;
 `yarn workspace @miragon/bpmn-modeler-webview serve` / `yarn workspace @miragon/dmn-modeler-webview serve` / `yarn workspace @miragon/bpmn-modeler-deployment-webview serve`

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,8 +1,9 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [scripts]
-setup = "git -C \"$CONDUCTOR_ROOT_PATH\" fetch --prune origin && git -C \"$CONDUCTOR_ROOT_PATH\" pull --ff-only || true ; corepack yarn install"
-run = "corepack yarn workspace @miragon/bpmn-modeler-webview serve --port $CONDUCTOR_PORT"
+setup = "corepack yarn install"
+run = "corepack yarn workspace @miragon/bpmn-modeler-webview dev"
 archive = "rm -rf dist node_modules"
+
 run_mode = "concurrent"
 auto_run_after_setup = true

--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -6,7 +6,8 @@
     "description": "Webview frontend for the BPMN modeler.",
     "scripts": {
         "build": "vite build",
-        "dev": "portless run sh -c 'vite --port $PORT'",
+        "dev": "portless",
+        "dev:app": "vite --port $PORT --host 127.0.0.1",
         "watch": "vite build --watch",
         "serve": "vite",
         "test": "vitest run --coverage"

--- a/apps/bpmn-webview/portless.json
+++ b/apps/bpmn-webview/portless.json
@@ -1,0 +1,4 @@
+{
+    "name": "bpmn-modeler-webview",
+    "script": "dev:app"
+}

--- a/apps/bpmn-webview/vite.config.mts
+++ b/apps/bpmn-webview/vite.config.mts
@@ -69,4 +69,8 @@ export default defineConfig({
     define: {
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
+
+    server: {
+        allowedHosts: [".localhost"],
+    },
 });

--- a/apps/bpmn-webview/vite.config.mts
+++ b/apps/bpmn-webview/vite.config.mts
@@ -7,7 +7,6 @@ import { resolve } from "path";
 export default defineConfig({
     root: __dirname,
     cacheDir: "../../node_modules/.vite/bpmn-webview",
-
     plugins: [
         tsconfigPaths(),
         viteStaticCopy({
@@ -23,12 +22,10 @@ export default defineConfig({
             ],
         }),
     ],
-
     esbuild: {
         jsx: "automatic",
         jsxImportSource: "preact",
     },
-
     resolve: {
         dedupe: [
             "preact",
@@ -45,7 +42,6 @@ export default defineConfig({
             "@lezer/lr",
         ],
     },
-
     build: {
         target: "es2021",
         commonjsOptions: { transformMixedEsModules: true },
@@ -65,11 +61,9 @@ export default defineConfig({
             },
         },
     },
-
     define: {
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
-
     server: {
         allowedHosts: [".localhost"],
     },

--- a/apps/deployment-webview/package.json
+++ b/apps/deployment-webview/package.json
@@ -6,7 +6,8 @@
     "description": "Webview frontend for the deployment panel in BPMN Modeler.",
     "scripts": {
         "build": "vite build",
-        "dev": "portless run sh -c 'vite --port $PORT'",
+        "dev": "portless",
+        "dev:app": "vite --port $PORT --host 127.0.0.1",
         "watch": "vite build --watch",
         "serve": "vite"
     },

--- a/apps/deployment-webview/portless.json
+++ b/apps/deployment-webview/portless.json
@@ -1,0 +1,4 @@
+{
+    "name": "bpmn-modeler-deployment-webview",
+    "script": "dev:app"
+}

--- a/apps/deployment-webview/vite.config.mts
+++ b/apps/deployment-webview/vite.config.mts
@@ -6,9 +6,7 @@ import { resolve } from "path";
 export default defineConfig({
     root: __dirname,
     cacheDir: "../../node_modules/.vite/modeler-plugin-deployment-webview",
-
     plugins: [tsconfigPaths()],
-
     build: {
         target: "es2021",
         chunkSizeWarningLimit: 1200,
@@ -24,11 +22,9 @@ export default defineConfig({
             },
         },
     },
-
     define: {
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
-
     server: {
         // portless proxies the dev server behind a `<name>.localhost` host; Vite
         // rejects unknown Host headers unless the suffix is allow-listed.

--- a/apps/deployment-webview/vite.config.mts
+++ b/apps/deployment-webview/vite.config.mts
@@ -28,4 +28,10 @@ export default defineConfig({
     define: {
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
+
+    server: {
+        // portless proxies the dev server behind a `<name>.localhost` host; Vite
+        // rejects unknown Host headers unless the suffix is allow-listed.
+        allowedHosts: [".localhost"],
+    },
 });

--- a/apps/dmn-webview/package.json
+++ b/apps/dmn-webview/package.json
@@ -6,7 +6,8 @@
     "description": "Webview frontend for the DMN modeler in BPMN Modeler.",
     "scripts": {
         "build": "vite build",
-        "dev": "portless run sh -c 'vite --port $PORT'",
+        "dev": "portless",
+        "dev:app": "vite --port $PORT --host 127.0.0.1",
         "watch": "vite build --watch",
         "serve": "vite"
     },

--- a/apps/dmn-webview/portless.json
+++ b/apps/dmn-webview/portless.json
@@ -1,0 +1,4 @@
+{
+    "name": "dmn-modeler-webview",
+    "script": "dev:app"
+}

--- a/apps/dmn-webview/vite.config.mts
+++ b/apps/dmn-webview/vite.config.mts
@@ -54,4 +54,9 @@ export default defineConfig({
     define: {
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
     },
+    server: {
+        // portless proxies the dev server behind a `<name>.localhost` host; Vite
+        // rejects unknown Host headers unless the suffix is allow-listed.
+        allowedHosts: [".localhost"],
+    },
 });

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,13 @@ export default withMermaid(defineConfig({
     title: "Miragon BPMN Modeler",
     description: "Professional BPMN/DMN process modeling — as a VS Code extension or a standalone desktop app",
     base: "/bpmn-modeler/",
+    vite: {
+        server: {
+            // portless proxies the dev server behind a `<name>.localhost` host;
+            // Vite rejects unknown Host headers unless the suffix is allow-listed.
+            allowedHosts: [".localhost"],
+        },
+    },
     head: [
         [
             "link",

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,8 @@
     "name": "@miragon/bpmn-modeler-docs",
     "private": true,
     "scripts": {
-        "dev": "portless run sh -c '(open $PORTLESS_URL/bpmn-modeler/) & vitepress dev . --port $PORT --host 127.0.0.1'",
+        "dev": "portless",
+        "dev:app": "(open \"$PORTLESS_URL/bpmn-modeler/\" || true) & vitepress dev . --port $PORT --host 127.0.0.1",
         "build": "vitepress build .",
         "preview": "vitepress preview .",
         "test": "vitest run"

--- a/docs/portless.json
+++ b/docs/portless.json
@@ -1,0 +1,4 @@
+{
+    "name": "bpmn-modeler-docs",
+    "script": "dev:app"
+}

--- a/docs/vscode/contributing/development.md
+++ b/docs/vscode/contributing/development.md
@@ -25,10 +25,23 @@
   enough.
 - **VS Code**
 
-The webview `dev:*` scripts (standalone browser preview) use
-[`portless`](https://www.npmjs.com/package/portless), which is installed
-automatically as a dev dependency by `yarn install` — no global install
-required.
+The webview and docs `dev` scripts (standalone browser preview) use
+[`portless`](https://www.npmjs.com/package/portless) to serve each app under a
+stable, worktree-aware `https://<worktree>.<app>.localhost` URL — no port
+numbers to remember or collide. portless is a pinned dev dependency installed
+by `yarn install`, so no global install is required. The slug is derived by
+portless from the git worktree; never hand-build it.
+
+Its HTTPS proxy daemon is a one-time per-machine step (needs `sudo` once):
+
+```bash
+npx portless service install
+```
+
+Each app keeps the split `dev` / `dev:app` scripts: `dev` is just the portless
+entrypoint, and `dev:app` is the real Vite/VitePress command (which non-portless
+users can run directly). `portless.json` names the app and points `dev` at
+`dev:app` so it doesn't recurse.
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
         "jsdom": "29.1.1",
         "lint-staged": "17.0.7",
         "npm-run-all": "4.1.5",
+        "portless": "0.14.0",
         "prettier": "3.8.3",
         "typescript": "6.0.3",
         "typescript-eslint": "8.60.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8847,6 +8847,7 @@ __metadata:
     jsdom: "npm:29.1.1"
     lint-staged: "npm:17.0.7"
     npm-run-all: "npm:4.1.5"
+    portless: "npm:0.14.0"
     prettier: "npm:3.8.3"
     typescript: "npm:6.0.3"
     typescript-eslint: "npm:8.60.1"
@@ -17644,6 +17645,16 @@ __metadata:
     async: "npm:^3.2.6"
     debug: "npm:^4.3.6"
   checksum: 10c0/59b2f2aa0b620c90ce0d477241e62c277f38bfd4fb6074106c23560248dd5e5c2c629dd048ef721f32b19df4213d09b77234880e4f0ab04abf1ab70b6d8048fa
+  languageName: node
+  linkType: hard
+
+"portless@npm:0.14.0":
+  version: 0.14.0
+  resolution: "portless@npm:0.14.0"
+  bin:
+    portless: dist/cli.js
+  checksum: 10c0/c7483926d0ae73d3933a141f822b81b341b0aca2fcc5daba33dfc27e99e0e2d82f4b22814ccd18861b6bc2fcf4f98253484594092a15b6d53c345f380bd2a7b9
+  conditions: (os=darwin | os=linux | os=win32)
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Isolates the **portless dev-server tooling** so it can be reviewed and merged independently of the *embed-the-modeler-in-the-docs* work (which builds on top of this branch).

- Split each webview/docs `dev` script into `dev` (portless entrypoint) + `dev:app` (the real Vite/VitePress command), driven by a per-app `portless.json` (`bpmn-webview`, `dmn-webview`, `deployment-webview`, `docs`).
- Pin `portless@0.14.0` as a root dev dependency (no global install required).
- Allow-list the `.localhost` host suffix in each dev server so Vite/VitePress accept portless' `<worktree>.<app>.localhost` proxy host.
- Point the Conductor workspace `run` script at `… webview dev`.
- Document the `dev` / `dev:app` split and the one-time `npx portless service install` step (`.agent/AGENT.md`, `docs/vscode/contributing/development.md`).

## Why

These changes are pure local dev-server ergonomics and are orthogonal to the docs-embed feature. Splitting them out keeps both PRs small and focused.

## Notes

No runtime/build behavior changes — only `dev`-time scripting and tooling.