### PR TITLE
fix(bpmn-webview): keep side-by-side text editor focused while typing

### DIFF
--- a/libs/bpmn-clipboard/src/VsCodeClipboardModule.ts
+++ b/libs/bpmn-clipboard/src/VsCodeClipboardModule.ts
@@ -134,8 +134,19 @@ class VsCodeClipboard {
         // element.mousedown. After keyboard-triggered selection changes
         // (e.g. Cmd+A), the properties panel re-render can steal focus,
         // causing subsequent Cmd+C to silently fail.
+        //
+        // The `hasFocus()` guard prevents cross-pane focus theft: every
+        // external XML edit (e.g. typing in a side-by-side text editor)
+        // re-imports the diagram, and importXML fires `selection.changed`
+        // unconditionally. Without the guard, canvas.focus() would yank the
+        // caret out of that separate editor pane on every keystroke. A
+        // webview iframe's document.hasFocus() is false while another VS Code
+        // pane is focused, so this runs only when the webview truly has focus.
         eventBus.on("selection.changed", () => {
             requestAnimationFrame(() => {
+                if (!document.hasFocus()) {
+                    return;
+                }
                 const active = document.activeElement;
                 if (
                     active instanceof HTMLInputElement ||


### PR DESCRIPTION
**Issue**

Fixes #1171 — side-by-side text editor loses focus on every keystroke.

**Description**

When the raw XML is opened *beside* the BPMN modeler, every keystroke re-imports the diagram; `importXML` fires `selection.changed` unconditionally, and the clipboard module's re-focus handler then called `canvas.focus()`, yanking the caret out of the text editor pane. This guards the re-focus with `document.hasFocus()`, which is `false` while another VS Code pane is focused, so the canvas is only re-focused when the webview actually holds focus — preserving the original in-webview Cmd+A → Cmd+C fix.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
