### PR TITLE
fix(bpmn-webview): keep side-by-side text editor focused while typing

### DIFF
--- a/libs/bpmn-clipboard/src/VsCodeClipboardModule.ts
+++ b/libs/bpmn-clipboard/src/VsCodeClipboardModule.ts
@@ -134,8 +134,19 @@ class VsCodeClipboard {
         // element.mousedown. After keyboard-triggered selection changes
         // (e.g. Cmd+A), the properties panel re-render can steal focus,
         // causing subsequent Cmd+C to silently fail.
+        //
+        // The `hasFocus()` guard prevents cross-pane focus theft: every
+        // external XML edit (e.g. typing in a side-by-side text editor)
+        // re-imports the diagram, and importXML fires `selection.changed`
+        // unconditionally. Without the guard, canvas.focus() would yank the
+        // caret out of that separate editor pane on every keystroke. A
+        // webview iframe's document.hasFocus() is false while another VS Code
+        // pane is focused, so this runs only when the webview truly has focus.
         eventBus.on("selection.changed", () => {
             requestAnimationFrame(() => {
+                if (!document.hasFocus()) {
+                    return;
+                }
                 const active = document.activeElement;
                 if (
                     active instanceof HTMLInputElement ||


### PR DESCRIPTION
**Issue**

Closes: #1171 

**Description**

The clipboard module re-focuses the canvas on every selection.changed. External XML edits re-import the diagram, and importXML fires selection.changed unconditionally, so typing in a side-by-side text editor pulled the caret back into the webview on every keystroke. Guard the re-focus with document.hasFocus() so it only runs when the webview actually holds focus, preserving the in-webview Cmd+A then Cmd+C fix.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
