### PR TITLE
feat(scripting): add Camunda SPIN script completion

### DIFF
--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsConfigurable.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsConfigurable.kt
@@ -37,6 +37,7 @@ class ModelerSettingsConfigurable : Configurable {
         var colorTheme: String,
         var favouritesText: String,
         var language: String,
+        var scriptingSpin: Boolean,
     )
 
     private val state = loadState()
@@ -91,6 +92,15 @@ class ModelerSettingsConfigurable : Configurable {
                         LOCALE_CODES,
                         SimpleListCellRenderer.create("") { code -> LOCALE_LABELS[code] ?: code },
                     ).bindItem({ state.language }, { state.language = it ?: DEFAULT_LOCALE })
+                }
+                row {
+                    checkBox("Enable Camunda SPIN script completion")
+                        .bindSelected({ state.scriptingSpin }, { state.scriptingSpin = it })
+                        .comment(
+                            "Offer Camunda SPIN globals (<code>S(…)</code>, <code>JSON(…)</code>) and " +
+                                "SpinJsonNode member completion in inline Camunda 7 scripts. Disable if " +
+                                "your project does not have camunda-spin on the classpath.",
+                        )
                 }
                 group("Favourite Elements") {
                     row {
@@ -152,6 +162,7 @@ class ModelerSettingsConfigurable : Configurable {
             colorTheme = colorTheme,
             favouriteBpmnElements = parseFavourites(favouritesText),
             language = language,
+            scriptingSpin = scriptingSpin,
         )
 
     private fun UiState.copyFrom(other: UiState) {
@@ -163,6 +174,7 @@ class ModelerSettingsConfigurable : Configurable {
         colorTheme = other.colorTheme
         favouritesText = other.favouritesText
         language = other.language
+        scriptingSpin = other.scriptingSpin
     }
 
     private fun loadState(): UiState {
@@ -176,6 +188,7 @@ class ModelerSettingsConfigurable : Configurable {
             colorTheme = settings.colorTheme,
             favouritesText = settings.favouriteBpmnElements.joinToString("\n"),
             language = settings.language,
+            scriptingSpin = settings.scriptingSpin,
         )
     }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsStore.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsStore.kt
@@ -20,6 +20,7 @@ data class ModelerSettings(
     val colorTheme: String,
     val favouriteBpmnElements: List<String>,
     val language: String,
+    val scriptingSpin: Boolean,
 )
 
 /**
@@ -47,6 +48,7 @@ class ModelerSettingsStore {
             colorTheme = normalizeColorTheme(props.getValue(COLOR_THEME, DEFAULT_COLOR_THEME)),
             favouriteBpmnElements = props.getList(FAVOURITE_ELEMENTS) ?: DEFAULT_FAVOURITE_ELEMENTS,
             language = props.getValue(LANGUAGE, DEFAULT_LANGUAGE),
+            scriptingSpin = props.getBoolean(SCRIPTING_SPIN, DEFAULT_SCRIPTING_SPIN),
         )
 
     /** Persists the snapshot, normalising the two constrained fields so stored values stay valid. */
@@ -61,6 +63,7 @@ class ModelerSettingsStore {
         // Cap matches the webview append-menu palette (max 6 pinned elements).
         props.setList(FAVOURITE_ELEMENTS, settings.favouriteBpmnElements.take(MAX_FAVOURITES))
         props.setValue(LANGUAGE, settings.language, DEFAULT_LANGUAGE)
+        props.setValue(SCRIPTING_SPIN, settings.scriptingSpin, DEFAULT_SCRIPTING_SPIN)
     }
 
     /**
@@ -79,6 +82,10 @@ class ModelerSettingsStore {
             "colorTheme" to current.colorTheme,
             "favouriteBpmnElements" to current.favouriteBpmnElements,
             "language" to current.language,
+            // The RPC key is the camelCase field name matching the bridge's
+            // `SettingsSnapshot`, NOT the dotted persisted key — a mismatch here
+            // would make the gate a silent no-op.
+            "scriptingSpin" to current.scriptingSpin,
         )
     }
 
@@ -100,6 +107,7 @@ class ModelerSettingsStore {
         private const val COLOR_THEME = "miragon.bpmnModeler.colorTheme"
         private const val FAVOURITE_ELEMENTS = "miragon.bpmnModeler.favouriteBpmnElements"
         private const val LANGUAGE = "miragon.bpmnModeler.language"
+        private const val SCRIPTING_SPIN = "miragon.bpmnModeler.scripting.spin"
 
         // Defaults track apps/vscode-plugin/package.json.
         private const val DEFAULT_ALIGN_TO_ORIGIN = false
@@ -109,6 +117,7 @@ class ModelerSettingsStore {
         private const val DEFAULT_C8_API_VERSION = "v2"
         private const val DEFAULT_COLOR_THEME = "automatic"
         private const val DEFAULT_LANGUAGE = "en"
+        private const val DEFAULT_SCRIPTING_SPIN = true
         private val DEFAULT_FAVOURITE_ELEMENTS =
             listOf("bpmn:ServiceTask", "bpmn:UserTask", "bpmn:CallActivity", "bpmn:ExclusiveGateway")
     }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
@@ -18,14 +18,23 @@ import com.intellij.openapi.vfs.VirtualFile
  * Root of the `script/open.completion` payload: the beans in scope for this
  * script's kind, plus the process variables extracted from the model.
  *
- * [variables] **must** be nullable: Gson instantiates this class via Unsafe and
- * leaves a missing JSON member null even on a non-null Kotlin type, so an open
- * payload from an older bridge (no `variables` key) would otherwise carry a
- * deceptive non-null default. A nullable field makes the absence explicit.
+ * [variables], [globals], and [types] **must** be nullable: Gson instantiates
+ * this class via Unsafe and leaves a missing JSON member null even on a non-null
+ * Kotlin type, so an open payload from an older bridge (no `globals`/`types`
+ * keys) would otherwise carry a deceptive non-null default. A nullable field
+ * makes the absence explicit.
+ *
+ * [globals] are the Camunda SPIN root functions (`S`/`JSON`); [types] maps a Java
+ * type name to its callable methods, consulted when a variable carries a
+ * `typeHint` (e.g. `SpinJsonNode`). Both arrive empty when the bridge's SPIN
+ * setting is off — the gate lives in the bridge, so this host stays a pure
+ * renderer.
  */
 data class ScriptCompletionModel(
     val beans: List<BeanInfo>,
     val variables: List<VariableInfo>? = null,
+    val globals: List<MethodInfo>? = null,
+    val types: Map<String, List<MethodInfo>>? = null,
 )
 
 /**

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
@@ -59,19 +59,32 @@ class ScriptCompletionContributor : CompletionContributor() {
                 return
             }
 
-            val bean = matchMemberAccess(linePrefix)
-            if (bean != null) {
-                // Member mode: only the matched bean's methods. An unknown bean
-                // (e.g. a user's own variable) yields nothing, never the root beans.
-                model.beans.firstOrNull { it.name == bean }
-                    ?.methods
+            val qualifier = matchMemberAccess(linePrefix)
+            if (qualifier != null) {
+                // Member mode: the matched bean's methods win. Failing that, fall
+                // back to the typed-variable path — resolve the qualifier's
+                // `typeHint` against the shipped `types` table (e.g. a SPIN-typed
+                // variable's `node.` → SpinJsonNode methods). An unknown qualifier
+                // yields nothing, never the root beans.
+                val beanMethods = model.beans.firstOrNull { it.name == qualifier }?.methods
+                if (beanMethods != null) {
+                    beanMethods.forEach { result.addElement(methodLookup(it)) }
+                    return
+                }
+                val typeHint =
+                    model.variables.orEmpty().firstOrNull { it.name == qualifier }?.typeHint
+                typeHint?.let { model.types?.get(it) }
                     ?.forEach { result.addElement(methodLookup(it)) }
                 return
             }
 
-            // Root mode: in-scope bean names, then process variables (beans win
-            // any name clash, matching the VS Code provider).
+            // Root mode: in-scope bean names, then SPIN globals (`S`/`JSON`), then
+            // process variables. Globals render via `methodLookup` so accepting `S`
+            // inserts `S(…)` with the tab-through parameter template — the analogue
+            // of VS Code's snippet. Beans win any name clash with variables,
+            // matching the VS Code provider.
             model.beans.forEach { result.addElement(beanLookup(it)) }
+            model.globals.orEmpty().forEach { result.addElement(methodLookup(it)) }
             val beanNames = model.beans.map { it.name }.toSet()
             model.variables.orEmpty()
                 .filter { it.name !in beanNames }

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -198,6 +198,57 @@ describe("bridge script editor (real core over a fake transport)", () => {
         expect(update.params.message.content).toBe("console.log('hi')");
     });
 
+    it("ships SPIN globals and the SpinJsonNode type table when the setting is on", async () => {
+        const { rpc, frames, editorId } = await setup();
+
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+        });
+
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        const globalNames = open.params.completion.globals.map((g: { name: string }) => g.name);
+        expect(globalNames).toEqual(["S", "JSON"]);
+        // The full COMPLEX_TYPES map ships; the host only consults it on a
+        // `typeHint` lookup, and SpinJsonNode is the only hint 2b stamps.
+        expect(Object.keys(open.params.completion.types)).toContain("SpinJsonNode");
+        const methodNames = open.params.completion.types.SpinJsonNode.map(
+            (m: { name: string }) => m.name,
+        );
+        expect(methodNames).toContain("prop");
+        expect(methodNames).toContain("stringValue");
+    });
+
+    it("ships empty SPIN globals/types when the scripting.spin setting is off", async () => {
+        const { rpc, frames, editorId } = await setup();
+
+        // Host pushes the SPIN gate off; the bridge is the single source of the
+        // gate, so the payload must carry nothing rather than the host filtering.
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "settings/didChange",
+                params: { settings: { scriptingSpin: false } },
+            }),
+        );
+
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+        });
+
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        expect(open.params.completion.globals).toEqual([]);
+        expect(open.params.completion.types).toEqual({});
+    });
+
     it("carries the seeded variables in the script/open completion payload", async () => {
         const { rpc, frames, editorId } = await setup();
         const variables = [{ name: "amount", origin: "form field", confidence: "declared" }];

--- a/apps/modeler-bridge/src/composition/scriptFeature.ts
+++ b/apps/modeler-bridge/src/composition/scriptFeature.ts
@@ -23,7 +23,13 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
     // in-core service — the VS Code original was never extracted (its guts are
     // VS Code-specific accidental complexity) — so the portable slice lives here
     // and the Kotlin host is a dumb editor surface keyed by an opaque scriptId.
-    const scriptEditor = new BridgeScriptEditor(deps.store, deps.picker, deps.rpc, deps.notifier);
+    const scriptEditor = new BridgeScriptEditor(
+        deps.store,
+        deps.picker,
+        deps.rpc,
+        deps.notifier,
+        deps.settings,
+    );
 
     deps.router
         .on("OpenScriptEditorCommand", (message: Command, editorId: string) => {

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -388,6 +388,7 @@ export interface SettingsSnapshot {
     colorTheme: "automatic" | "light";
     favouriteBpmnElements: string[];
     language: string;
+    scriptingSpin: boolean;
 }
 
 /** Mirrors the VS Code config prefix so `affectsConfiguration` keys line up across hosts. */
@@ -413,6 +414,7 @@ const DEFAULT_SETTINGS: SettingsSnapshot = {
         "bpmn:ExclusiveGateway",
     ],
     language: "en",
+    scriptingSpin: true,
 };
 
 /**
@@ -492,13 +494,14 @@ export class BridgeSettings implements SettingsPort {
         return this.snapshot.language;
     }
     /**
-     * The host frame does not carry a SPIN toggle yet — globals and typed-member
-     * resolution only reach IntelliJ in sub-phase 2d, where the bridge gains a
-     * dedicated config. Until then the bridge mirrors the core's unconditional
-     * default so no caller observes globals being silently suppressed.
+     * Whether to ship the Camunda SPIN globals (`S`/`JSON`) and the
+     * `SpinJsonNode` member table to the host. The gate lives here in the bridge
+     * (single source) so the thin Kotlin completion contributor needs no toggle
+     * of its own — an off setting simply makes the `script/open` payload carry
+     * empty `globals`/`types`.
      */
     getScriptingSpin(): boolean {
-        return true;
+        return this.snapshot.scriptingSpin;
     }
 }
 

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -491,6 +491,15 @@ export class BridgeSettings implements SettingsPort {
     getLanguage(): string {
         return this.snapshot.language;
     }
+    /**
+     * The host frame does not carry a SPIN toggle yet — globals and typed-member
+     * resolution only reach IntelliJ in sub-phase 2d, where the bridge gains a
+     * dedicated config. Until then the bridge mirrors the core's unconditional
+     * default so no caller observes globals being silently suppressed.
+     */
+    getScriptingSpin(): boolean {
+        return true;
+    }
 }
 
 /** Order-sensitive equality covering the snapshot's primitives and the string-array field. */

--- a/apps/modeler-bridge/src/protocol/descriptor.ts
+++ b/apps/modeler-bridge/src/protocol/descriptor.ts
@@ -459,7 +459,7 @@ export const PROTOCOL = [
             fileName: "script.js",
             languageId: "javascript",
             content: "x",
-            completion: { beans: [], variables: [] },
+            completion: { beans: [], variables: [], globals: [], types: {} },
         } satisfies ScriptOpenParams,
     },
     {

--- a/apps/modeler-bridge/src/protocol/types.ts
+++ b/apps/modeler-bridge/src/protocol/types.ts
@@ -10,6 +10,7 @@
  * the `Rpc.request` call-sites used to carry.
  */
 
+import { GlobalFunctionDef, MethodDef } from "@miragon/bpmn-modeler-core";
 import {
     AuthTypePayload,
     Command,
@@ -267,6 +268,14 @@ export interface ScriptOpenParams {
     completion: {
         beans: readonly ScriptCompletionBean[];
         variables: VariableDef[];
+        /** Camunda SPIN globals (`S`/`JSON`) offered at script root; empty when the SPIN setting is off. */
+        globals: readonly GlobalFunctionDef[];
+        /**
+         * Type name → callable methods, for resolving a typed variable's members
+         * (e.g. a `typeHint: "SpinJsonNode"` variable's `node.` completion).
+         * Empty when the SPIN setting is off.
+         */
+        types: Record<string, readonly MethodDef[]>;
     };
 }
 

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -18,7 +18,9 @@
 
 import {
     beansFor,
+    COMPLEX_TYPES,
     EditorSessionStore,
+    globalFunctionsFor,
     methodsForBean,
     NotifierPort,
     PickerPort,
@@ -33,6 +35,7 @@ import {
     VariableDef,
 } from "@miragon/bpmn-modeler-shared";
 
+import { BridgeSettings } from "./nodeAdapters";
 import { Rpc } from "./rpc";
 import { METHODS } from "./protocol/descriptor";
 
@@ -63,6 +66,7 @@ export class BridgeScriptEditor {
         private readonly picker: PickerPort,
         private readonly rpc: Rpc,
         private readonly notifier: NotifierPort,
+        private readonly settings: BridgeSettings,
     ) {}
 
     /**
@@ -107,6 +111,14 @@ export class BridgeScriptEditor {
         // variable completion before the first live update arrives.
         this.variablesByEditor.set(editorId, cmd.variables ?? []);
 
+        // The SPIN globals (`S`/`JSON`) and the type→methods table are gated here
+        // in the bridge (single source): off → empty, so the Kotlin contributor
+        // renders nothing and needs no gate of its own. Shipping the full
+        // `COMPLEX_TYPES` map when on is harmless — the host only consults `types`
+        // on a variable's `typeHint` lookup, and `SpinJsonNode` is the only hint
+        // the producer heuristic currently stamps.
+        const spinOn = this.settings.getScriptingSpin();
+
         // `fileName` carries the extension so the host infers the FileType for
         // highlighting; `content` is honoured only on first open (see above).
         // `completion` ships the kind-scoped bean/method catalog resolved *here*
@@ -130,6 +142,10 @@ export class BridgeScriptEditor {
                     methods: methodsForBean(bean),
                 })),
                 variables: this.variablesByEditor.get(editorId) ?? [],
+                globals: spinOn ? globalFunctionsFor(cmd.kind) : [],
+                types: spinOn
+                    ? Object.fromEntries(COMPLEX_TYPES.map((type) => [type.name, type.methods]))
+                    : {},
             },
         });
     }

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -285,6 +285,11 @@
                     "default": false,
                     "markdownDescription": "Align the diagram to the origin when opening a new diagram. Click [here](https://github.com/bpmn-io/align-to-origin) to see the behaviour when enabled."
                 },
+                "miragon.bpmnModeler.scripting.spin": {
+                    "type": "boolean",
+                    "default": true,
+                    "markdownDescription": "Offer Camunda SPIN globals (`S(…)`, `JSON(…)`) and SpinJsonNode member completion in inline Camunda 7 scripts. Disable if your project does not have camunda-spin on the classpath."
+                },
                 "miragon.bpmnModeler.configFolder": {
                     "type": "string",
                     "default": ".camunda",

--- a/apps/vscode-plugin/src/composition/scriptFeature.ts
+++ b/apps/vscode-plugin/src/composition/scriptFeature.ts
@@ -34,7 +34,7 @@ export function register(
     scriptTaskSvc.register(context);
 
     const scriptVariableStore = new ScriptVariableStore();
-    new ScriptCompletionProvider(scriptVariableStore).register(context);
+    new ScriptCompletionProvider(scriptVariableStore, deps.vsSettings).register(context);
 
     return { scriptTaskSvc, scriptVariableStore };
 }

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
@@ -29,7 +29,7 @@ vi.mock("vscode", () => {
     };
 });
 
-import { ScriptUri, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
+import { ScriptUri, ScriptVariableStore, SettingsPort } from "@miragon/bpmn-modeler-core";
 import { VariableDef } from "@miragon/bpmn-modeler-shared";
 
 import { ScriptCompletionProvider } from "./ScriptCompletionProvider";
@@ -44,6 +44,13 @@ function storeWith(...variables: VariableDef[]): ScriptVariableStore {
     const store = new ScriptVariableStore();
     store.set(EDITOR, variables);
     return store;
+}
+
+// Only `getScriptingSpin` is exercised by the provider; a partial stub keeps the
+// test focused on the SPIN gate without standing up the full settings surface.
+function buildProvider(store: ScriptVariableStore, spinEnabled = true): ScriptCompletionProvider {
+    const settings = { getScriptingSpin: () => spinEnabled } as SettingsPort;
+    return new ScriptCompletionProvider(store, settings);
 }
 
 function complete(
@@ -67,26 +74,38 @@ const variable = (name: string, typeHint?: string): VariableDef => ({
 });
 
 describe("ScriptCompletionProvider modes", () => {
-    it("root mode offers beans and process variables", () => {
-        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+    it("root mode offers SPIN globals, beans and process variables", () => {
+        const provider = buildProvider(storeWith(variable("amount")));
         const labels = complete(provider, "am");
+        expect(labels).toContain("S");
+        expect(labels).toContain("JSON");
+        expect(labels).toContain("execution");
+        expect(labels).toContain("amount");
+    });
+
+    it("root mode omits SPIN globals when the setting is off", () => {
+        const provider = buildProvider(storeWith(variable("amount")), false);
+        const labels = complete(provider, "am");
+        expect(labels).not.toContain("S");
+        expect(labels).not.toContain("JSON");
+        // Beans and variables are unaffected by the SPIN gate.
         expect(labels).toContain("execution");
         expect(labels).toContain("amount");
     });
 
     it("variable-string-arg mode offers only process variables", () => {
-        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const provider = buildProvider(storeWith(variable("amount")));
         const labels = complete(provider, `execution.getVariable("am`);
         expect(labels).toEqual(["amount"]);
     });
 
     it("a quote trigger outside a variable argument returns nothing", () => {
-        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const provider = buildProvider(storeWith(variable("amount")));
         expect(complete(provider, `def label = "am`, { triggerCharacter: '"' })).toEqual([]);
     });
 
     it("an unknown editor hash yields beans only, no variables", () => {
-        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const provider = buildProvider(storeWith(variable("amount")));
         const labels = complete(provider, "am", {
             path: "/unknownhash/Task_1/script-task/Task_1.groovy",
         });
@@ -95,14 +114,14 @@ describe("ScriptCompletionProvider modes", () => {
     });
 
     it("member access on a known bean returns its methods, not variables", () => {
-        const provider = new ScriptCompletionProvider(storeWith(variable("amount")));
+        const provider = buildProvider(storeWith(variable("amount")));
         const labels = complete(provider, "execution.");
         expect(labels).toContain("getVariable");
         expect(labels).not.toContain("amount");
     });
 
     it("carries the typeHint as the completion detail", () => {
-        const provider = new ScriptCompletionProvider(storeWith(variable("amount", "long")));
+        const provider = buildProvider(storeWith(variable("amount", "long")));
         const document = {
             uri: { path: SCRIPT_PATH },
             lineAt: () => ({ text: `execution.getVariable("` }),

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
@@ -120,6 +120,32 @@ describe("ScriptCompletionProvider modes", () => {
         expect(labels).not.toContain("amount");
     });
 
+    it("member access on a SPIN-typed variable returns SpinJsonNode methods", () => {
+        const provider = buildProvider(storeWith(variable("node", "SpinJsonNode")));
+        const labels = complete(provider, "node.");
+        expect(labels).toContain("prop");
+        expect(labels).toContain("stringValue");
+        expect(labels).toContain("mapTo");
+        // Neither bean methods nor variable names leak into a typed-member list.
+        expect(labels).not.toContain("amount");
+        expect(labels).not.toContain("execution");
+    });
+
+    it("member access on a typed variable returns nothing when SPIN is off", () => {
+        const provider = buildProvider(storeWith(variable("node", "SpinJsonNode")), false);
+        expect(complete(provider, "node.")).toEqual([]);
+    });
+
+    it("member access on a variable without a typeHint returns nothing", () => {
+        const provider = buildProvider(storeWith(variable("node")));
+        expect(complete(provider, "node.")).toEqual([]);
+    });
+
+    it("member access on a primitive-typed variable returns nothing", () => {
+        const provider = buildProvider(storeWith(variable("node", "long")));
+        expect(complete(provider, "node.")).toEqual([]);
+    });
+
     it("carries the typeHint as the completion detail", () => {
         const provider = buildProvider(storeWith(variable("amount", "long")));
         const document = {

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -12,13 +12,21 @@ import {
     TextDocument,
 } from "vscode";
 
-import { BeanDef, beansFor, MethodDef, methodsForBean } from "@miragon/bpmn-modeler-core";
+import {
+    BeanDef,
+    beansFor,
+    GlobalFunctionDef,
+    globalFunctionsFor,
+    MethodDef,
+    methodsForBean,
+} from "@miragon/bpmn-modeler-core";
 import {
     matchMemberAccess,
     matchVariableStringArg,
     parseEditorHashFromUri,
     parseKindFromUri,
     ScriptVariableStore,
+    SettingsPort,
 } from "@miragon/bpmn-modeler-core";
 import { VariableDef } from "@miragon/bpmn-modeler-shared";
 
@@ -49,8 +57,9 @@ import { VariableDef } from "@miragon/bpmn-modeler-shared";
  * 2. **Member completion**: triggered after a `.` following a known bean.
  *    Returns the bean's methods rendered as snippets so the cursor lands
  *    inside the parentheses with parameter placeholders.
- * 3. **Root completion**: returns the bean names plus the process variables
- *    whenever a word is being typed at root scope.
+ * 3. **Root completion**: returns the SPIN global functions (`S`/`JSON`, when
+ *    the `scripting.spin` setting is on), the bean names, and the process
+ *    variables whenever a word is being typed at root scope.
  *
  * The provider depends on a {@link ScriptVariableStore} (populated by the
  * webview's live variable extraction) so suggestions reflect the current model
@@ -60,7 +69,10 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
     // Languages this provider participates in.
     private static readonly LANGUAGES = ["javascript", "groovy", "python", "ruby"] as const;
 
-    constructor(private readonly store: ScriptVariableStore) {}
+    constructor(
+        private readonly store: ScriptVariableStore,
+        private readonly settings: SettingsPort,
+    ) {}
 
     /**
      * Registers the completion provider for every supported language scoped
@@ -112,13 +124,20 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
             return bean ? methodsForBean(bean).map(methodToCompletion) : [];
         }
 
-        // Mode 3: root — beans first, then process variables, beans winning any
-        // name clash (a variable named `execution` would be shadowed anyway).
+        // Mode 3: root — globals first, then beans, then process variables, with
+        // beans winning any name clash (a variable named `execution` would be
+        // shadowed anyway). The setting is read live on every invocation, so a
+        // toggle takes effect on the next completion request with no reload.
+        const globals = this.settings.getScriptingSpin() ? globalFunctionsFor(kind) : [];
         const beanNames = new Set(beans.map((b) => b.name));
         const variableItems = this.variableItems(document).filter(
             (item) => !beanNames.has(item.label as string),
         );
-        return [...beans.map(beanToCompletion), ...variableItems];
+        return [
+            ...globals.map(globalToCompletion),
+            ...beans.map(beanToCompletion),
+            ...variableItems,
+        ];
     }
 
     /** Process-variable completions for the editor the script URI belongs to. */
@@ -139,6 +158,23 @@ function beanToCompletion(bean: BeanDef): CompletionItem {
     const item = new CompletionItem(bean.name, CompletionItemKind.Variable);
     item.detail = `${bean.name}: ${bean.type}`;
     item.documentation = new MarkdownString(bean.description);
+    return item;
+}
+
+function globalToCompletion(fn: GlobalFunctionDef): CompletionItem {
+    const item = new CompletionItem(fn.name, CompletionItemKind.Function);
+    item.detail = `${fn.name}(${fn.params
+        .map((p) => `${p.name}: ${p.type}`)
+        .join(", ")}): ${fn.returnType}`;
+
+    // Same snippet convention as methods: drop the cursor on the first
+    // parameter, or inside empty parens for zero-arg calls.
+    const placeholders = fn.params.map((p, i) => `\${${i + 1}:${p.name}}`).join(", ");
+    item.insertText = new SnippetString(`${fn.name}(${placeholders})`);
+
+    const paramLines = fn.params.map((p) => `- \`${p.name}\` — \`${p.type}\``);
+    const docs = [fn.description, "", ...paramLines].join("\n");
+    item.documentation = new MarkdownString(docs);
     return item;
 }
 

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -19,6 +19,7 @@ import {
     globalFunctionsFor,
     MethodDef,
     methodsForBean,
+    methodsForType,
 } from "@miragon/bpmn-modeler-core";
 import {
     matchMemberAccess,
@@ -54,9 +55,11 @@ import { VariableDef } from "@miragon/bpmn-modeler-shared";
  * 1. **Variable-name completion**: triggered inside the string argument of a
  *    `getVariable`/`setVariable`/… call. Returns the editor's process
  *    variables (from {@link ScriptVariableStore}).
- * 2. **Member completion**: triggered after a `.` following a known bean.
- *    Returns the bean's methods rendered as snippets so the cursor lands
- *    inside the parentheses with parameter placeholders.
+ * 2. **Member completion**: triggered after a `.` following a known bean, or
+ *    a process variable carrying a `typeHint` whose catalog type exposes
+ *    methods (e.g. a SPIN-typed `var node = S(…)`, gated by `scripting.spin`).
+ *    Returns the methods rendered as snippets so the cursor lands inside the
+ *    parentheses with parameter placeholders.
  * 3. **Root completion**: returns the SPIN global functions (`S`/`JSON`, when
  *    the `scripting.spin` setting is on), the bean names, and the process
  *    variables whenever a word is being typed at root scope.
@@ -115,13 +118,26 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
             return [];
         }
 
-        // Mode 2: member access on a known bean. An unknown qualifier (e.g. a
-        // user's own variable `myVar.`) stays empty — no type info until later
-        // phases; never fall back to root items here.
+        // Mode 2: member access on a known bean, or on a typed process variable.
+        // An unknown qualifier with no resolvable type stays empty; never fall
+        // back to root items here.
         const memberAccess = matchMemberAccess(linePrefix);
         if (memberAccess) {
             const bean = beans.find((b) => b.name === memberAccess);
-            return bean ? methodsForBean(bean).map(methodToCompletion) : [];
+            if (bean) {
+                return methodsForBean(bean).map(methodToCompletion);
+            }
+            // Not a bean: a producer-heuristic typeHint (e.g. SpinJsonNode) may
+            // resolve. Gated by the same setting as the SPIN globals —
+            // SpinJsonNode is the only type-method surface today, so the flag
+            // governs it end to end.
+            if (this.settings.getScriptingSpin()) {
+                const variable = this.variablesFor(document).find((v) => v.name === memberAccess);
+                if (variable?.typeHint) {
+                    return methodsForType(variable.typeHint).map(methodToCompletion);
+                }
+            }
+            return [];
         }
 
         // Mode 3: root — globals first, then beans, then process variables, with
@@ -142,8 +158,17 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
 
     /** Process-variable completions for the editor the script URI belongs to. */
     private variableItems(document: TextDocument): CompletionItem[] {
+        return this.variablesFor(document).map(variableToCompletion);
+    }
+
+    /**
+     * Raw process variables for the editor the script URI belongs to. The
+     * member path needs the `typeHint` carried on {@link VariableDef}, which the
+     * pre-mapped {@link variableItems} completions discard.
+     */
+    private variablesFor(document: TextDocument): VariableDef[] {
         const editorHash = parseEditorHashFromUri(document.uri.path) ?? "";
-        return this.store.getByEditorHash(editorHash).map(variableToCompletion);
+        return this.store.getByEditorHash(editorHash);
     }
 }
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeSettings.ts
@@ -104,4 +104,18 @@ export class VsCodeSettings implements SettingsPort {
             false
         );
     }
+
+    /**
+     * Whether to offer Camunda SPIN globals (`S(…)`, `JSON(…)`) and SpinJsonNode
+     * member completion in inline Camunda 7 scripts.
+     *
+     * Defaults to `true`: SPIN ships with Camunda 7 and JSON variables are
+     * common, so the globals are useful out of the box. Disable when the
+     * project does not have camunda-spin on the classpath.
+     */
+    getScriptingSpin(): boolean {
+        return (
+            workspace.getConfiguration("miragon.bpmnModeler").get<boolean>("scripting.spin") ?? true
+        );
+    }
 }

--- a/libs/modeler-core/src/scriptTask/domain/scriptApi.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptApi.spec.ts
@@ -1,0 +1,41 @@
+import { ScriptKind } from "@miragon/bpmn-modeler-shared";
+import { describe, expect, it } from "vitest";
+
+import { BeanDef, COMPLEX_TYPES, globalFunctionsFor, methodsForBean } from "./scriptApi";
+
+const ALL_KINDS: readonly ScriptKind[] = ["script-task", "execution-listener", "task-listener"];
+
+describe("globalFunctionsFor", () => {
+    it("offers the SPIN globals S and JSON for every script kind", () => {
+        for (const kind of ALL_KINDS) {
+            const names = globalFunctionsFor(kind).map((fn) => fn.name);
+            expect(names).toContain("S");
+            expect(names).toContain("JSON");
+        }
+    });
+
+    it("types each SPIN global's return as SpinJsonNode", () => {
+        const globals = globalFunctionsFor("script-task");
+        expect(globals.every((fn) => fn.returnType === "SpinJsonNode")).toBe(true);
+    });
+});
+
+describe("SpinJsonNode catalog entry", () => {
+    it("is registered in COMPLEX_TYPES so 2c can resolve a typeHint", () => {
+        expect(COMPLEX_TYPES.some((type) => type.name === "SpinJsonNode")).toBe(true);
+    });
+
+    it("resolves its methods through methodsForBean for a SpinJsonNode-typed bean", () => {
+        // No bean ships with this type in 2a; a synthetic one proves the
+        // type-name lookup (the path 2c reuses for typed variables) works.
+        const bean: BeanDef = {
+            name: "node",
+            type: "SpinJsonNode",
+            description: "synthetic",
+        };
+        const methodNames = methodsForBean(bean).map((m) => m.name);
+        expect(methodNames).toContain("prop");
+        expect(methodNames).toContain("elements");
+        expect(methodNames).toContain("mapTo");
+    });
+});

--- a/libs/modeler-core/src/scriptTask/domain/scriptApi.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptApi.spec.ts
@@ -1,7 +1,13 @@
 import { ScriptKind } from "@miragon/bpmn-modeler-shared";
 import { describe, expect, it } from "vitest";
 
-import { BeanDef, COMPLEX_TYPES, globalFunctionsFor, methodsForBean } from "./scriptApi";
+import {
+    BeanDef,
+    COMPLEX_TYPES,
+    globalFunctionsFor,
+    methodsForBean,
+    methodsForType,
+} from "./scriptApi";
 
 const ALL_KINDS: readonly ScriptKind[] = ["script-task", "execution-listener", "task-listener"];
 
@@ -37,5 +43,19 @@ describe("SpinJsonNode catalog entry", () => {
         expect(methodNames).toContain("prop");
         expect(methodNames).toContain("elements");
         expect(methodNames).toContain("mapTo");
+    });
+});
+
+describe("methodsForType", () => {
+    it("resolves the SpinJsonNode methods by type name", () => {
+        const methodNames = methodsForType("SpinJsonNode").map((m) => m.name);
+        expect(methodNames).toContain("prop");
+        expect(methodNames).toContain("stringValue");
+        expect(methodNames).toContain("mapTo");
+    });
+
+    it("returns no methods for a primitive or unknown type name", () => {
+        expect(methodsForType("long")).toEqual([]);
+        expect(methodsForType("Nonexistent")).toEqual([]);
     });
 });

--- a/libs/modeler-core/src/scriptTask/domain/scriptApi.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptApi.ts
@@ -36,6 +36,15 @@ export interface MethodDef {
 }
 
 /**
+ * A global function callable at script root with no receiver (e.g. Camunda
+ * SPIN's `S(…)` / `JSON(…)`). Structurally identical to {@link MethodDef} —
+ * the distinction is purely positional: a {@link MethodDef} is reached through
+ * `<receiver>.method(…)`, a `GlobalFunctionDef` is reached bare. Sharing the
+ * shape keeps a single renderer and one snippet convention.
+ */
+export type GlobalFunctionDef = MethodDef;
+
+/**
  * Describes a complex Camunda type (e.g. `DelegateExecution`) — the bag
  * of methods we look up to populate `<bean>.<member>` completions.
  */
@@ -214,6 +223,118 @@ const DELEGATE_TASK_METHODS: readonly MethodDef[] = [
     },
 ];
 
+/**
+ * Camunda SPIN's JSON node — the wrapper returned by `S(json)` / `JSON(json)`
+ * for reading and writing JSON process variables. Read-focused subset of the
+ * official Javadoc (7.22/7.23): overloaded setters are collapsed to their
+ * getter form (`prop(name)`) so completion shows one label per concept rather
+ * than duplicate `prop` entries.
+ */
+const SPIN_JSON_NODE_METHODS: readonly MethodDef[] = [
+    {
+        name: "prop",
+        params: [{ name: "name", type: "String" }],
+        returnType: "SpinJsonNode",
+        description: "Returns the child node stored under the given property name.",
+    },
+    {
+        name: "hasProp",
+        params: [{ name: "name", type: "String" }],
+        returnType: "Boolean",
+        description: "Returns whether a property with the given name exists.",
+    },
+    {
+        name: "elements",
+        params: [],
+        returnType: "SpinList<SpinJsonNode>",
+        description: "Returns the elements of this array node.",
+    },
+    {
+        name: "fieldNames",
+        params: [],
+        returnType: "List<String>",
+        description: "Returns the property names of this object node.",
+    },
+    {
+        name: "stringValue",
+        params: [],
+        returnType: "String",
+        description: "Returns this node's value as a string.",
+    },
+    {
+        name: "numberValue",
+        params: [],
+        returnType: "Number",
+        description: "Returns this node's value as a number.",
+    },
+    {
+        name: "boolValue",
+        params: [],
+        returnType: "Boolean",
+        description: "Returns this node's value as a boolean.",
+    },
+    {
+        name: "isObject",
+        params: [],
+        returnType: "Boolean",
+        description: "Returns whether this node is a JSON object.",
+    },
+    {
+        name: "isArray",
+        params: [],
+        returnType: "Boolean",
+        description: "Returns whether this node is a JSON array.",
+    },
+    {
+        name: "isValue",
+        params: [],
+        returnType: "Boolean",
+        description: "Returns whether this node is a scalar value.",
+    },
+    {
+        name: "isNull",
+        params: [],
+        returnType: "Boolean",
+        description: "Returns whether this node is JSON null.",
+    },
+    {
+        name: "value",
+        params: [],
+        returnType: "Object",
+        description: "Returns this node's value as a plain Java object.",
+    },
+    {
+        name: "mapTo",
+        params: [{ name: "type", type: "String" }],
+        returnType: "Object",
+        description: "Deserialises this node into an instance of the given Java type.",
+    },
+    {
+        name: "append",
+        params: [{ name: "property", type: "Object" }],
+        returnType: "SpinJsonNode",
+        description: "Appends a value to this array node.",
+    },
+    {
+        name: "deleteProp",
+        params: [{ name: "name", type: "String" }],
+        returnType: "SpinJsonNode",
+        description: "Removes the property with the given name from this object node.",
+    },
+    {
+        name: "toString",
+        params: [],
+        returnType: "String",
+        description: "Serialises this node back to its JSON string representation.",
+    },
+];
+
+const SPIN_JSON_NODE_TYPE: TypeDef = {
+    name: "SpinJsonNode",
+    description: "Camunda SPIN wrapper for reading and writing JSON variables.",
+    methods: SPIN_JSON_NODE_METHODS,
+};
+
 const DELEGATE_EXECUTION_TYPE: TypeDef = {
     name: "DelegateExecution",
     description: "Provides access to process variables and execution metadata.",
@@ -226,8 +347,15 @@ const DELEGATE_TASK_TYPE: TypeDef = {
     methods: DELEGATE_TASK_METHODS,
 };
 
-// All complex (interface-typed) types referenced by any bean.
-export const COMPLEX_TYPES: readonly TypeDef[] = [DELEGATE_EXECUTION_TYPE, DELEGATE_TASK_TYPE];
+// All complex (interface-typed) types referenced by any bean, global function
+// return type, or (from 2c) variable `typeHint`. `SpinJsonNode` has no bean of
+// its type in 2a — it is registered here so `TYPES_BY_NAME` can resolve it once
+// the producer heuristic stamps `typeHint: "SpinJsonNode"` on variables.
+export const COMPLEX_TYPES: readonly TypeDef[] = [
+    DELEGATE_EXECUTION_TYPE,
+    DELEGATE_TASK_TYPE,
+    SPIN_JSON_NODE_TYPE,
+];
 
 const TYPES_BY_NAME: ReadonlyMap<string, TypeDef> = new Map(
     COMPLEX_TYPES.map((type) => [type.name, type]),
@@ -278,4 +406,37 @@ const BEANS_BY_KIND: Record<ScriptKind, readonly BeanDef[]> = {
  */
 export function beansFor(kind: ScriptKind): readonly BeanDef[] {
     return BEANS_BY_KIND[kind];
+}
+
+/**
+ * Camunda SPIN global functions available at script root. `S(input)` really
+ * returns `Spin<T>` and auto-detects JSON vs. XML; we type it as
+ * {@link SPIN_JSON_NODE_TYPE} because JSON is the dominant use and the only one
+ * in scope here. `JSON(input)` is the JSON-only constructor.
+ */
+const SPIN_GLOBAL_FUNCTIONS: readonly GlobalFunctionDef[] = [
+    {
+        name: "S",
+        params: [{ name: "input", type: "Object" }],
+        returnType: "SpinJsonNode",
+        description: "Camunda SPIN: wraps a JSON string or value as a SpinJsonNode.",
+    },
+    {
+        name: "JSON",
+        params: [{ name: "input", type: "Object" }],
+        returnType: "SpinJsonNode",
+        description: "Camunda SPIN: parses a JSON string or value into a SpinJsonNode.",
+    },
+];
+
+/**
+ * Returns the global functions in scope for a script kind. The SPIN globals are
+ * available in all three Camunda 7 kinds, so this currently ignores `kind` —
+ * the parameter parallels {@link beansFor} and gives a single seam for future
+ * per-kind differences. Kept unconditional: whether to *offer* the globals is
+ * the host's decision (VS Code gates them behind `miragon.bpmnModeler.scripting.spin`),
+ * so the core stays pure and IntelliJ can apply its own setting in 2d.
+ */
+export function globalFunctionsFor(_kind: ScriptKind): readonly GlobalFunctionDef[] {
+    return SPIN_GLOBAL_FUNCTIONS;
 }

--- a/libs/modeler-core/src/scriptTask/domain/scriptApi.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptApi.ts
@@ -362,12 +362,23 @@ const TYPES_BY_NAME: ReadonlyMap<string, TypeDef> = new Map(
 );
 
 /**
+ * Returns the methods callable on a value of the given catalog type. Empty for a
+ * primitive/unknown type name (e.g. a form-field `typeHint: "long"`), which keeps
+ * member completion silent rather than wrong. Drives typed-variable member
+ * resolution (a variable's `typeHint`) the same way {@link methodsForBean} drives
+ * beans.
+ */
+export function methodsForType(typeName: string): readonly MethodDef[] {
+    return TYPES_BY_NAME.get(typeName)?.methods ?? [];
+}
+
+/**
  * Returns the methods callable on a bean. Empty when the bean's type is a
  * primitive Java label not registered in {@link COMPLEX_TYPES} (e.g.
  * `eventName: String`).
  */
 export function methodsForBean(bean: BeanDef): readonly MethodDef[] {
-    return TYPES_BY_NAME.get(bean.type)?.methods ?? [];
+    return methodsForType(bean.type);
 }
 
 const EXECUTION_BEAN: BeanDef = {

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -87,6 +87,8 @@ export interface SettingsPort {
     getLanguage(): string;
     /** Whether the activity→code map is persisted under `<configFolder>/code-link/`. */
     getPersistCodeLinkMap(): boolean;
+    /** Whether Camunda SPIN globals (`S`/`JSON`) and SpinJsonNode members are offered in C7 scripts. */
+    getScriptingSpin(): boolean;
 }
 
 /**

--- a/libs/shared/src/lib/processVariables.spec.ts
+++ b/libs/shared/src/lib/processVariables.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
     collectExpressionRefs,
     collectSetVariableNames,
+    collectSpinTypedNames,
     dedupeVariables,
     extractProcessVariables,
     VariableDef,
@@ -38,6 +39,26 @@ describe("collectSetVariableNames", () => {
 
     it("ignores method calls that are not setVariable", () => {
         expect(collectSetVariableNames(`execution.getVariable("a")`)).toEqual([]);
+    });
+});
+
+describe("collectSpinTypedNames", () => {
+    it("captures setVariable/setVariableLocal whose value is a SPIN call", () => {
+        expect(collectSpinTypedNames(`execution.setVariable("a", S(x))`)).toEqual(["a"]);
+        expect(collectSpinTypedNames(`execution.setVariableLocal('a', JSON(x))`)).toEqual(["a"]);
+    });
+
+    it("captures bare/var/def assignments whose value is a SPIN call", () => {
+        expect(collectSpinTypedNames(`b = JSON(x)`)).toEqual(["b"]);
+        expect(collectSpinTypedNames(`var c = S(x)`)).toEqual(["c"]);
+        expect(collectSpinTypedNames(`def c = S(x)`)).toEqual(["c"]);
+    });
+
+    it("ignores a field write, comparison, or non-SPIN call", () => {
+        expect(collectSpinTypedNames(`obj.d = S(x)`)).toEqual([]);
+        expect(collectSpinTypedNames(`e == S(x)`)).toEqual([]);
+        expect(collectSpinTypedNames(`e = myParse(x)`)).toEqual([]);
+        expect(collectSpinTypedNames(`e = foo.S(x)`)).toEqual([]);
     });
 });
 
@@ -144,6 +165,71 @@ describe("extractProcessVariables", () => {
         );
         expect(names(vars)).toEqual(["listened", "scripted"]);
         expect(byName(vars, "scripted")?.confidence).toBe("declared");
+    });
+
+    it("types a setVariable SPIN value as SpinJsonNode", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ScriptTask",
+                id: "Task_1",
+                script: `execution.setVariable("out", S(execution.getVariable("p")))`,
+            }),
+        );
+        expect(byName(vars, "out")?.typeHint).toBe("SpinJsonNode");
+        expect(byName(vars, "out")?.confidence).toBe("declared");
+    });
+
+    it("types a var-assigned SPIN value as SpinJsonNode", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ScriptTask",
+                id: "Task_1",
+                script: `var node = JSON(execution.getVariable("p"))`,
+            }),
+        );
+        expect(byName(vars, "node")?.typeHint).toBe("SpinJsonNode");
+    });
+
+    it("types a SPIN value assigned in a listener script", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ScriptTask",
+                id: "Task_1",
+                extensionElements: {
+                    values: [
+                        {
+                            $type: "camunda:ExecutionListener",
+                            script: { value: `var node = S(execution.getVariable("p"))` },
+                        },
+                    ],
+                },
+            }),
+        );
+        expect(byName(vars, "node")?.typeHint).toBe("SpinJsonNode");
+    });
+
+    it("keeps the typed entry when a name is seen as plain setVariable and SPIN value", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ScriptTask",
+                id: "Task_1",
+                script: `execution.setVariable("x", S(execution.getVariable("p")))`,
+            }),
+        );
+        const x = vars.filter((v) => v.name === "x");
+        expect(x).toHaveLength(1);
+        expect(x[0].typeHint).toBe("SpinJsonNode");
+    });
+
+    it("leaves an ordinary setVariable value untyped", () => {
+        const vars = extractProcessVariables(
+            definitionsOf({
+                $type: "bpmn:ScriptTask",
+                id: "Task_1",
+                script: `execution.setVariable("plain", 1)`,
+            }),
+        );
+        expect(byName(vars, "plain")?.typeHint).toBeUndefined();
     });
 
     it("reads ${var} from sequence-flow condition expressions as referenced", () => {

--- a/libs/shared/src/lib/processVariables.ts
+++ b/libs/shared/src/lib/processVariables.ts
@@ -58,6 +58,28 @@ const SET_VARIABLE_RE = /setVariable(?:Local)?\s*\(\s*(["'])([^"'\\]+)\1/g;
 // the first identifier is captured: `${a.b}` yields `a`, the variable in scope.
 const EXPRESSION_REF_RE = /[$#]\{\s*([A-Za-z_$][A-Za-z0-9_$]*)/g;
 
+// `setVariable("x", S(...))` / `setVariableLocal('x', JSON(...))` — same shape
+// as SET_VARIABLE_RE but the trailing `(?:S|JSON)\s*\(` guard requires the value
+// arg to be a SPIN call, marking the variable as a `SpinJsonNode`. Group 2 is
+// the name.
+const SPIN_SET_VARIABLE_RE =
+    /setVariable(?:Local)?\s*\(\s*(["'])([^"'\\]+)\1\s*,\s*(?:S|JSON)\s*\(/g;
+
+// `x = S(...)` / `var x = JSON(...)` / `def x = S(...)` — a free identifier
+// assigned a SPIN call. Group 1 is the name.
+//
+// The `(?<![.\w$])` lookbehind rejects `obj.x = S(...)` (field write) and
+// keyword glue, capturing only a free identifier. `\s*=\s*(?:S|JSON)\s*\(`
+// rejects `==`/`!=`/`>=` (a second operator char is neither whitespace nor the
+// SPIN call) and `x = myParse(` / `x = foo.S(` (the SPIN call must immediately
+// follow `=`).
+//
+// Known accepted over-approximation: `x = S(j).stringValue()` types `x` as
+// `SpinJsonNode` though the terminal call returns `String`. Completion offers
+// generously — a false positive costs only a glance — so we don't chase chain
+// return-types here.
+const SPIN_ASSIGNMENT_RE = /(?<![.\w$])([A-Za-z_$][\w$]*)\s*=\s*(?:S|JSON)\s*\(/g;
+
 /**
  * Returns the variable names written by `setVariable`/`setVariableLocal` string
  * literals in a script body. Exported for unit testing the regex in isolation.
@@ -66,6 +88,22 @@ export function collectSetVariableNames(script: string): string[] {
     const names: string[] = [];
     for (const match of script.matchAll(SET_VARIABLE_RE)) {
         names.push(match[2]);
+    }
+    return names;
+}
+
+/**
+ * Returns variable names whose value is a SPIN call (`S(...)`/`JSON(...)`), from
+ * either `setVariable("x", S(...))` or `x = S(...)`. These resolve to the
+ * `SpinJsonNode` TypeDef. Exported for unit testing the regexes in isolation.
+ */
+export function collectSpinTypedNames(script: string): string[] {
+    const names: string[] = [];
+    for (const match of script.matchAll(SPIN_SET_VARIABLE_RE)) {
+        names.push(match[2]);
+    }
+    for (const match of script.matchAll(SPIN_ASSIGNMENT_RE)) {
+        names.push(match[1]);
     }
     return names;
 }
@@ -163,6 +201,17 @@ function collectFromElement(element: any, out: VariableDef[]): void {
         for (const name of collectSetVariableNames(element.script)) {
             out.push({ name, origin: `script of ${label}`, confidence: "declared" });
         }
+        // A SPIN-valued name yields a second, typed entry; `dedupeVariables`
+        // keeps it over the untyped one at equal confidence, so each collector
+        // stays single-purpose rather than threading type state through names.
+        for (const name of collectSpinTypedNames(element.script)) {
+            out.push({
+                name,
+                origin: `SPIN value in script of ${label}`,
+                typeHint: "SpinJsonNode",
+                confidence: "declared",
+            });
+        }
     }
 
     // Sequence-flow condition expression: `${var}` reads.
@@ -239,6 +288,14 @@ function collectFromExtension(extension: any, label: string, out: VariableDef[])
                     out.push({
                         name,
                         origin: `listener script of ${label}`,
+                        confidence: "declared",
+                    });
+                }
+                for (const name of collectSpinTypedNames(extension.script.value)) {
+                    out.push({
+                        name,
+                        origin: `SPIN value in listener script of ${label}`,
+                        typeHint: "SpinJsonNode",
                         confidence: "declared",
                     });
                 }


### PR DESCRIPTION
**Issue**

Closes: #1116

**Description**

Camunda 7 scripts read and write JSON process variables through the SPIN API, but the script-completion catalog had no knowledge of it. This adds end-to-end SPIN support across the script-completion stack, gated by a new `miragon.bpmnModeler.scripting.spin` setting (default `true`, mirrored in the IntelliJ host settings).

- **Catalog (`libs/modeler-core` — single source of truth):** a static `SpinJsonNode` `TypeDef` (read-focused subset of the 7.22/7.23 Javadoc) plus the `S()` / `JSON()` global functions, exposed via `globalFunctionsFor()` and `methodsForType()`. `SpinJsonNode` is registered in `COMPLEX_TYPES` so a typed `typeHint` resolves the same way a bean's type does.
- **Static extraction (`libs/shared`):** SPIN-valued variables are stamped with `typeHint: "SpinJsonNode"`. A `setVariable("x", S(...))` write is a genuine process variable; a bare `var node = S(...)` binding is a *script-local* (flagged `local`) — typed for member completion but never retrievable via `getVariable`.
- **VS Code provider:** renders `S`/`JSON` at script root as parameter snippets, and resolves typed-member access (`node.` → `SpinJsonNode` methods). The setting is read live, so toggling it takes effect on the next completion request.
- **Bridge → IntelliJ host:** the bridge ships the resolved `globals`/`types` in the `script/open` payload, gated in one place (off → empty payload) so the Kotlin contributor stays a pure renderer. The IntelliJ `ModelerSettings` carries the matching `scriptingSpin` toggle.
- **Script-local correctness:** `local` bindings are excluded from `getVariable("…")`-argument completion on both hosts (they resolve to `null` at runtime and the extraction is process-wide), while remaining available for member and root completion. Scope-merge in `dedupeVariables` keeps a name that is *both* a `setVariable` write and a SPIN local retrievable via `getVariable`.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
