### PR TITLE
feat(scripting): add *.bpmn.vars.json process-variable manifest override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,6 +433,16 @@ jobs:
           flags: intellij-plugin
           name: intellij-plugin
           verbose: true
+      # Binary-compatibility gate. We build against the 242 floor but claim
+      # compatibility up to the latest (untilBuild = null), so the verifier checks
+      # the plugin against both the floor and a current release (2026.1), failing
+      # only on real breakage (removed/changed APIs) — see the `failureLevel` in
+      # build.gradle.kts. Runs last so the unit-test signal and coverage land
+      # first; it downloads the verified IDEs (~1 GB), which setup-gradle caches
+      # under ~/.gradle across runs.
+      - name: Verify plugin binary compatibility
+        working-directory: apps/intellij-plugin
+        run: ./gradlew verifyPlugin --no-daemon
 
   # Extension-Host smoke test: the only job that runs the composition root
   # (`activate()` + custom-editor registration) end-to-end in a real VS Code.

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -36,6 +36,10 @@ dependencies {
         // (no version-catalog entry) and the jars download on the first test run.
         testFramework(TestFrameworkType.JUnit5)
         testFramework(TestFrameworkType.Platform)
+        // Java code-insight test fixtures: ship LightJavaCodeInsightFixtureTestCase5,
+        // the JUnit5 base class the script-completion test extends to drive the real
+        // completion pipeline with a properly leak-tracked light project.
+        testFramework(TestFrameworkType.Plugin.Java)
     }
     // Gson does the JSON encode/decode for the host ↔ bridge ↔ webview messages.
     // Hand-built strings are unsafe here: SyncDocumentCommand carries the full
@@ -58,6 +62,12 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+    // A new JVM per test class. The light-project code-insight test
+    // (ScriptCompletionContributorTest) and the @TestApplication router tests can't
+    // share a JVM: the router tests install a strict app-level project-leak tracker
+    // that catches the code-insight test's light project (held by project services
+    // after disposal). Isolating each class sidesteps the cross-contamination.
+    setForkEvery(1)
     // Always refresh the coverage data so `jacocoTestReport` reflects the latest run.
     finalizedBy(tasks.jacocoTestReport)
 }

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -1,5 +1,7 @@
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.PrepareSandboxTask
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -78,6 +80,32 @@ intellijPlatform {
             // rejects every IDE newer than 2024.2 at install time. Null removes
             // the upper bound entirely (the documented opt-out).
             untilBuild = provider { null }
+        }
+    }
+
+    // Binary-compatibility verification. We build against the 242 floor but claim
+    // compatibility up to the latest (untilBuild = null), so the verifier guards
+    // the open upper bound: the floor catches accidental use of a post-242 API,
+    // and a current release (the top of the range users actually run) catches a
+    // removed/changed API the 242 build would crash on at runtime.
+    pluginVerification {
+        // Gate on real breakage only. Deprecated/experimental/internal usages are
+        // reported but don't fail: across a 242→latest range the replacement API
+        // often doesn't exist on the floor, so failing on a deprecation would make
+        // every upstream deprecation an un-fixable build break. COMPATIBILITY and
+        // SCHEDULED_FOR_REMOVAL are the categories that mean "will not run".
+        failureLevel = listOf(
+            FailureLevel.COMPATIBILITY_PROBLEMS,
+            FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            FailureLevel.MISSING_DEPENDENCIES,
+            FailureLevel.INVALID_PLUGIN,
+        )
+        ides {
+            // The 242 floor still ships as the standalone Community artifact.
+            create(IntelliJPlatformType.IntellijIdeaCommunity, "2024.2.5")
+            // Community stopped being published as a separate artifact in 2025.3;
+            // newer releases resolve through the unified IntelliJ IDEA type.
+            create(IntelliJPlatformType.IntellijIdea, "2026.1.3")
         }
     }
 }

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -133,6 +133,11 @@ val bridgeBinary = layout.projectDirectory.file("../../apps/modeler-bridge/dist/
 val bridgeDistRoot = layout.projectDirectory.dir("../../apps/modeler-bridge/dist")
 val stagedResourcesRoot = layout.buildDirectory.dir("modeler-resources")
 
+// Single source of truth: the `*.bpmn.vars.json` JSON Schema lives in libs/shared
+// next to the type it mirrors. Staged into resources so the JsonSchemaProviderFactory
+// loads it from the classpath at `/schemas/bpmn-vars.schema.json`.
+val varsSchema = layout.projectDirectory.file("../../libs/shared/src/lib/variableManifest.schema.json")
+
 /**
  * Release distribution mode: when set, stage every per-platform bridge binary
  * under `bin/<os>-<arch>/` so the published ZIP runs on any host. Default
@@ -250,17 +255,32 @@ val copyBridge =
         }
     }
 
+val copySchema =
+    tasks.register<Copy>("copySchema") {
+        description = "Stages the shared *.bpmn.vars.json JSON Schema into plugin resources (loaded from the classpath by the JsonSchemaProviderFactory)."
+        doFirst {
+            if (!varsSchema.asFile.exists()) {
+                throw GradleException("Vars manifest schema not found at ${varsSchema.asFile}.")
+            }
+        }
+        from(varsSchema) {
+            rename { "bpmn-vars.schema.json" }
+        }
+        // Lands at `/schemas/bpmn-vars.schema.json` on the classpath.
+        into(stagedResourcesRoot.map { it.dir("schemas") })
+    }
+
 sourceSets.named("main") {
     resources.srcDir(stagedResourcesRoot)
 }
 
 tasks.named<ProcessResources>("processResources") {
-    dependsOn(copyWebview, copyDeploymentWebview, copyBridge)
+    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema)
 }
 
 // The sandbox for `runIde` is assembled from the jar, which already contains the
 // staged resources, so no extra sandbox wiring is needed — but make the
 // dependency explicit so a clean `runIde` always stages the bundles first.
 tasks.withType<PrepareSandboxTask>().configureEach {
-    dependsOn(copyWebview, copyDeploymentWebview, copyBridge)
+    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema)
 }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreProcess.kt
@@ -129,6 +129,14 @@ class CoreProcess(private val project: Project) : Disposable {
     /** Pushes the current settings snapshot to the running core so an open editor reacts live. */
     fun pushSettings() = editorRouter.pushSettings()
 
+    /**
+     * Asks the core to scaffold a `*.bpmn.vars.json` entry for an unknown script
+     * variable and reveal the manifest — backs the "Declare in variable manifest"
+     * intention, which has the `scriptId` but not the bridge channel.
+     */
+    fun appendScriptVariableToManifest(scriptId: String, name: String) =
+        scriptRouter.appendToManifest(scriptId, name)
+
     // ── deployment tool window ─────────────────────────────────────────────────
 
     fun registerDeploymentWindow(sink: (String) -> Unit) = deploymentRouter.registerDeploymentWindow(sink)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DeclareVariableIntention.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DeclareVariableIntention.kt
@@ -1,0 +1,87 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.plugins.groovy.lang.psi.api.statements.expressions.GrReferenceExpression
+
+/**
+ * 💡 "Declare '<name>' in variable manifest" — the IntelliJ counterpart of VS
+ * Code's `ScriptDeclareVariableCodeAction`. When the caret sits on a genuinely
+ * *unresolved* bare reference in one of our inline Groovy script tabs, this
+ * offers to scaffold a `*.bpmn.vars.json` entry for it; the core writes the
+ * file, reveals it (via `notifier/openDocument`), and the manifest watcher
+ * re-pushes completion so the variable appears live as an `authored` entry.
+ *
+ * Unlike VS Code's lexical heuristic this uses real Groovy PSI, so detection is
+ * precise: [ScriptBindingMembersContributor] resolves every in-scope bean *and*
+ * known process variable as a synthetic binding, so a reference that resolves to
+ * `null` is exactly one the model doesn't know. Scoped to Groovy via the
+ * `<language>` of its `<intentionAction>` registration and to our own tabs via
+ * [SCRIPT_COMPLETION_KEY].
+ */
+class DeclareVariableIntention : IntentionAction {
+    // Computed in isAvailable and read by getText on the same EDT pass — the
+    // conventional way an IntentionAction surfaces the concrete name in its label.
+    private var variableName: String? = null
+
+    override fun getFamilyName(): String = "Declare variable in manifest"
+
+    override fun getText(): String =
+        variableName?.let { "Declare '$it' in variable manifest" } ?: familyName
+
+    // No PSI mutation — the change is an out-of-process RPC, so no write action.
+    override fun startInWriteAction(): Boolean = false
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        variableName = null
+        if (editor == null || file == null) return false
+        val model = file.scriptCompletionModel() ?: return false
+
+        val name = unresolvedReferenceAt(file, editor.caretModel.offset)?.referenceName ?: return false
+        // A resolved reference was already excluded; this also guards the case
+        // where the synthetic binding didn't materialise for a known variable.
+        if (model.variables.orEmpty().any { it.name == name }) return false
+
+        variableName = name
+        return true
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        if (editor == null || file == null) return
+        val scriptId = file.scriptVirtualFile()?.getUserData(SCRIPT_ID_KEY) ?: return
+        val name = unresolvedReferenceAt(file, editor.caretModel.offset)?.referenceName ?: return
+        project.service<CoreProcess>().appendScriptVariableToManifest(scriptId, name)
+    }
+
+    /**
+     * The bare, unresolved Groovy reference at [offset] (or immediately before it,
+     * so a caret resting at the end of the identifier still matches), or null.
+     * Only *unqualified* references qualify: a process variable is a top-level
+     * name, not `obj.member`, and an in-scope bean/variable would resolve and be
+     * skipped.
+     */
+    private fun unresolvedReferenceAt(file: PsiFile, offset: Int): GrReferenceExpression? {
+        val reference = referenceAt(file, offset) ?: referenceAt(file, (offset - 1).coerceAtLeast(0))
+        if (reference == null || reference.qualifierExpression != null) return null
+        return if (reference.resolve() == null) reference else null
+    }
+
+    private fun referenceAt(file: PsiFile, offset: Int): GrReferenceExpression? =
+        PsiTreeUtil.getParentOfType(
+            file.findElementAt(offset),
+            GrReferenceExpression::class.java,
+            false,
+        )
+
+    /** The completion catalog for this tab, or null if it isn't one of our script tabs. */
+    private fun PsiFile.scriptCompletionModel(): ScriptCompletionModel? =
+        scriptVirtualFile()?.getUserData(SCRIPT_COMPLETION_KEY)
+
+    // The in-memory copy IntelliJ resolves against has no virtualFile; fall back
+    // to the original so the UserData lookup still finds our tab.
+    private fun PsiFile.scriptVirtualFile() = virtualFile ?: originalFile.virtualFile
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
@@ -38,14 +38,17 @@ data class ScriptCompletionModel(
 )
 
 /**
- * A process variable surfaced by the model's static extraction. [origin] and
- * [typeHint] are nullable for the same Gson reason as above and because the
- * core only sets `typeHint` when it knows one (e.g. a form field's type).
+ * A process variable surfaced by the model's static extraction or declared in a
+ * `*.bpmn.vars.json` manifest. [origin], [typeHint], and [description] are
+ * nullable for the same Gson reason as above and because the core only sets each
+ * when it knows one — [description] rides along only for manifest (`authored`)
+ * entries.
  */
 data class VariableInfo(
     val name: String,
     val origin: String?,
     val typeHint: String?,
+    val description: String?,
 )
 
 /**

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletion.kt
@@ -82,6 +82,15 @@ data class ParamInfo(val name: String, val type: String)
  */
 val SCRIPT_COMPLETION_KEY: Key<ScriptCompletionModel> = Key.create("modeler.script.completion")
 
+/**
+ * The opaque `scriptId` the bridge assigned this tab, stashed on its
+ * [VirtualFile] so [DeclareVariableIntention] can address the
+ * `script/appendToManifest` RPC for an unknown variable. Separate from
+ * [SCRIPT_COMPLETION_KEY] because the completion catalog is swapped wholesale on
+ * every `updateVariables`, whereas the id is stable for the tab's lifetime.
+ */
+val SCRIPT_ID_KEY: Key<String> = Key.create("modeler.script.id")
+
 private val MEMBER_ACCESS = Regex("([A-Za-z_][A-Za-z0-9_]*)\\.\\s*$")
 
 /**

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
@@ -3,6 +3,7 @@ package io.miragon.intellij.bpmn
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResult
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.codeInsight.lookup.LookupElementBuilder
@@ -11,6 +12,7 @@ import com.intellij.codeInsight.template.impl.ConstantNode
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.util.TextRange
 import com.intellij.patterns.PlatformPatterns
+import com.intellij.util.Consumer
 import com.intellij.util.ProcessingContext
 
 /**
@@ -69,6 +71,11 @@ class ScriptCompletionContributor : CompletionContributor() {
                 val beanMethods = model.beans.firstOrNull { it.name == qualifier }?.methods
                 if (beanMethods != null) {
                     beanMethods.forEach { result.addElement(methodLookup(it)) }
+                    // ScriptBindingMembersContributor injects these same methods as
+                    // synthetic GrLightMethodBuilders so they *resolve*; Groovy's
+                    // native completion would then re-emit each as a bare duplicate.
+                    // Filter those by name while letting unrelated members through.
+                    passThroughExcept(parameters, result, beanMethods.mapTo(HashSet()) { it.name })
                     return
                 }
                 val typeHint =
@@ -89,11 +96,52 @@ class ScriptCompletionContributor : CompletionContributor() {
             model.variables.orEmpty()
                 .filter { it.name !in beanNames }
                 .forEach { result.addElement(variableLookup(it)) }
+
+            // Every bean/global/variable name above is also a synthetic
+            // GrLightVariable/GrLightMethod injected by
+            // ScriptBindingMembersContributor so the bare name *resolves*; Groovy's
+            // native contributor then re-emits each as a second, untyped, doc-less
+            // lookup (the duplicate row). Run the remaining contributors ourselves
+            // and drop only the names we already rendered — keywords, `println`,
+            // and stdlib still pass through, which is the point of `language="any"`.
+            val ourNames = HashSet<String>(beanNames)
+            model.globals.orEmpty().mapTo(ourNames) { it.name }
+            model.variables.orEmpty().mapTo(ourNames) { it.name }
+            passThroughExcept(parameters, result, ourNames)
         }
 
-        /** Bean as a variable-icon lookup: `name`, type on the right, description greyed. */
+        /**
+         * Hands the remaining (lower-priority) completion contributors a chance to
+         * run, forwarding only the lookups whose string we did **not** already
+         * contribute. Replaces the default "run remaining automatically" so we can
+         * suppress the native Groovy duplicate of every bean/variable/method that
+         * [ScriptBindingMembersContributor] injects for resolution — see the call
+         * sites. Requires `order="first"` in plugin.xml so Groovy counts as
+         * "remaining" relative to us.
+         */
+        private fun passThroughExcept(
+            parameters: CompletionParameters,
+            result: CompletionResultSet,
+            ourNames: Set<String>,
+        ) {
+            result.runRemainingContributors(
+                parameters,
+                Consumer { completionResult: CompletionResult ->
+                    if (completionResult.lookupElement.lookupString !in ourNames) {
+                        result.passResult(completionResult)
+                    }
+                },
+            )
+        }
+
+        /**
+         * Bean as a variable-icon lookup: `name`, type on the right, description
+         * greyed. Seeded via `create(bean, bean.name)` so `LookupElement.getObject()`
+         * returns the [BeanInfo] — [ScriptDocumentationProvider] reads it to fill the
+         * quick-doc pane.
+         */
         private fun beanLookup(bean: BeanInfo) =
-            LookupElementBuilder.create(bean.name)
+            LookupElementBuilder.create(bean, bean.name)
                 .withIcon(AllIcons.Nodes.Variable)
                 .withTypeText(bean.type)
                 .appendTailText("  ${bean.description}", true)
@@ -102,10 +150,12 @@ class ScriptCompletionContributor : CompletionContributor() {
          * Process variable as a variable-icon lookup: typeHint (or a generic
          * label) right, doc greyed. An authored manifest variable leads with its
          * [VariableInfo.description]; otherwise the heuristic [VariableInfo.origin]
-         * is shown.
+         * is shown. Seeded via `create(variable, variable.name)` so
+         * `LookupElement.getObject()` returns the [VariableInfo] for
+         * [ScriptDocumentationProvider]'s quick-doc pane.
          */
         private fun variableLookup(variable: VariableInfo) =
-            LookupElementBuilder.create(variable.name)
+            LookupElementBuilder.create(variable, variable.name)
                 .withIcon(AllIcons.Nodes.Variable)
                 .withTypeText(variable.typeHint ?: "process variable")
                 .appendTailText(
@@ -118,10 +168,12 @@ class ScriptCompletionContributor : CompletionContributor() {
          * the right, description greyed. Accepting it inserts `name(…)` and starts
          * a live [com.intellij.codeInsight.template.Template] so the parameters are
          * tab-through editable — the IntelliJ analogue of VS Code's `SnippetString`
-         * `${1:param}` placeholders.
+         * `${1:param}` placeholders. Seeded via `create(method, method.name)` so
+         * `LookupElement.getObject()` returns the [MethodInfo] for
+         * [ScriptDocumentationProvider]'s quick-doc pane.
          */
         private fun methodLookup(method: MethodInfo) =
-            LookupElementBuilder.create(method.name)
+            LookupElementBuilder.create(method, method.name)
                 .withIcon(AllIcons.Nodes.Method)
                 .withTailText(signatureOf(method), true)
                 .withTypeText(method.returnType)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributor.kt
@@ -98,12 +98,20 @@ class ScriptCompletionContributor : CompletionContributor() {
                 .withTypeText(bean.type)
                 .appendTailText("  ${bean.description}", true)
 
-        /** Process variable as a variable-icon lookup: typeHint (or a generic label) right, origin greyed. */
+        /**
+         * Process variable as a variable-icon lookup: typeHint (or a generic
+         * label) right, doc greyed. An authored manifest variable leads with its
+         * [VariableInfo.description]; otherwise the heuristic [VariableInfo.origin]
+         * is shown.
+         */
         private fun variableLookup(variable: VariableInfo) =
             LookupElementBuilder.create(variable.name)
                 .withIcon(AllIcons.Nodes.Variable)
                 .withTypeText(variable.typeHint ?: "process variable")
-                .appendTailText(variable.origin?.let { "  $it" }.orEmpty(), true)
+                .appendTailText(
+                    (variable.description ?: variable.origin)?.let { "  $it" }.orEmpty(),
+                    true,
+                )
 
         /**
          * Method as a method-icon lookup: `name`, `(params)` tail, return type on

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptDocumentationProvider.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptDocumentationProvider.kt
@@ -1,0 +1,107 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.lang.Language
+import com.intellij.lang.documentation.AbstractDocumentationProvider
+import com.intellij.lang.documentation.DocumentationMarkup
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.impl.FakePsiElement
+
+/**
+ * Populates the quick-doc (Ctrl-Q) / documentation pane for the inline
+ * "Edit Script" completions [ScriptCompletionContributor] contributes.
+ *
+ * The contributor's lookups are plain [com.intellij.codeInsight.lookup.LookupElementBuilder]s,
+ * so without a [com.intellij.lang.documentation.DocumentationProvider] the side
+ * pane shows "No documentation found" even though the catalog carries a rich
+ * description. We bridge that gap here: the lookups now seed `getObject()` with
+ * the originating [VariableInfo]/[BeanInfo]/[MethodInfo], and this provider reads
+ * it back to render the description.
+ *
+ * Registered as the **application-level, language-agnostic** `documentationProvider`
+ * EP (not `lang.documentationProvider`): a modeler script tab is frequently
+ * PLAIN_TEXT (no JS/Groovy plugin), and a per-language provider would never fire
+ * for it. The render is pure — it touches no index, bridge, or network — so it is
+ * safe on the read-action/background thread the platform calls it from.
+ */
+class ScriptDocumentationProvider : AbstractDocumentationProvider() {
+
+    /**
+     * Wraps the catalog entry the user is completing into a throwaway PSI element
+     * the platform can hand back to [generateDoc]. Returns null for any lookup
+     * that isn't ours, so unrelated completions fall through to other providers.
+     */
+    override fun getDocumentationElementForLookupItem(
+        psiManager: PsiManager,
+        obj: Any?,
+        element: PsiElement?,
+    ): PsiElement? =
+        when (obj) {
+            is VariableInfo, is BeanInfo, is MethodInfo -> ScriptInfoElement(psiManager, obj)
+            else -> null
+        }
+
+    /** Renders the catalog entry carried by our [ScriptInfoElement] as quick-doc HTML. */
+    override fun generateDoc(element: PsiElement?, originalElement: PsiElement?): String? =
+        when (val info = (element as? ScriptInfoElement)?.info) {
+            is VariableInfo -> renderVariable(info)
+            is BeanInfo -> renderBean(info)
+            is MethodInfo -> renderMethod(info)
+            else -> null
+        }
+
+    private fun renderVariable(variable: VariableInfo): String =
+        buildDoc(
+            definition = "${variable.name}: ${variable.typeHint ?: "process variable"}",
+            // An authored manifest entry leads with its description; a heuristic
+            // entry has only its origin, which is still the most useful thing to show.
+            content = variable.description ?: variable.origin,
+        )
+
+    private fun renderBean(bean: BeanInfo): String =
+        buildDoc(definition = "${bean.name}: ${bean.type}", content = bean.description)
+
+    private fun renderMethod(method: MethodInfo): String =
+        buildDoc(
+            definition = "${method.name}${signatureOf(method)}: ${method.returnType}",
+            content = method.description,
+        )
+
+    private fun signatureOf(method: MethodInfo): String =
+        method.params.joinToString(", ", "(", ")") { "${it.name}: ${it.type}" }
+
+    /**
+     * Assembles the standard quick-doc layout: a code-styled definition header and
+     * an optional description body, both HTML-escaped since the catalog text is
+     * arbitrary user-authored content.
+     */
+    private fun buildDoc(definition: String, content: String?): String =
+        buildString {
+            append(DocumentationMarkup.DEFINITION_START)
+            append(StringUtil.escapeXmlEntities(definition))
+            append(DocumentationMarkup.DEFINITION_END)
+            if (!content.isNullOrBlank()) {
+                append(DocumentationMarkup.CONTENT_START)
+                append(StringUtil.escapeXmlEntities(content))
+                append(DocumentationMarkup.CONTENT_END)
+            }
+        }
+
+    /**
+     * A non-physical PSI element that exists only to ferry a catalog entry from
+     * [getDocumentationElementForLookupItem] to [generateDoc]. It has no real
+     * declaration site, so [getParent] is null; [getManager] returns the manager
+     * the platform handed us so any incidental platform call stays valid.
+     */
+    private class ScriptInfoElement(
+        private val psiManager: PsiManager,
+        val info: Any,
+    ) : FakePsiElement() {
+        override fun getParent(): PsiElement? = null
+
+        override fun getManager(): PsiManager = psiManager
+
+        override fun getLanguage(): Language = Language.ANY
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptEditorManager.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ScriptEditorManager.kt
@@ -94,6 +94,9 @@ class ScriptEditorManager(
             val file = LightVirtualFile(fileName, content)
             // Attach before opening so the contributor sees it on the first keystroke.
             file.putUserData(SCRIPT_COMPLETION_KEY, completion)
+            // Stable for the tab's lifetime (updateVariables swaps only the catalog),
+            // so the "Declare in variable manifest" intention can address this script.
+            file.putUserData(SCRIPT_ID_KEY, scriptId)
             manager.openFile(file, true)
 
             val document = FileDocumentManager.getInstance().getDocument(file)

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/VarsManifestJsonSchemaProviderFactory.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/VarsManifestJsonSchemaProviderFactory.kt
@@ -1,0 +1,39 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.jsonSchema.extension.JsonSchemaFileProvider
+import com.jetbrains.jsonSchema.extension.JsonSchemaProviderFactory
+import com.jetbrains.jsonSchema.extension.SchemaType
+
+/**
+ * Associates the bundled `*.bpmn.vars.json` JSON Schema with process-variable
+ * manifest files, giving authors validation, completion, and hover docs as they
+ * edit — the IntelliJ counterpart of VS Code's `contributes.jsonValidation`.
+ *
+ * The schema is the same file shipped to VS Code (single source of truth in
+ * `libs/shared`, staged into resources by the Gradle `copySchema` task), so both
+ * hosts validate against an identical contract. Scoped by the `.bpmn.vars.json`
+ * suffix rather than a path glob because the manifest's location under
+ * `<configFolder>/vars/` is user-configurable.
+ */
+class VarsManifestJsonSchemaProviderFactory : JsonSchemaProviderFactory {
+    override fun getProviders(project: Project): List<JsonSchemaFileProvider> =
+        listOf(VarsManifestSchemaProvider())
+
+    private class VarsManifestSchemaProvider : JsonSchemaFileProvider {
+        override fun getName(): String = "BPMN Variable Manifest"
+
+        override fun isAvailable(file: VirtualFile): Boolean =
+            file.name.endsWith(".bpmn.vars.json")
+
+        // Loaded from the plugin classpath; the Gradle build stages the shared
+        // schema here. Returns null if absent so the JSON plugin degrades to no
+        // validation rather than throwing.
+        override fun getSchemaFile(): VirtualFile? =
+            JsonSchemaProviderFactory.getResourceFile(javaClass, "/schemas/bpmn-vars.schema.json")
+
+        // Bundled in the plugin (not a user mapping or a remote URL).
+        override fun getSchemaType(): SchemaType = SchemaType.embeddedSchema
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ScriptRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/ScriptRouter.kt
@@ -52,4 +52,17 @@ internal class ScriptRouter(private val deps: BridgeDeps) {
                 )
             }
     }
+
+    /**
+     * Host→Core: the "Declare in variable manifest" intention asks the core to
+     * scaffold a manifest entry for an unknown variable. Fire-and-forget — the
+     * core writes the file, reveals it via `notifier/openDocument`, and the
+     * manifest watcher re-pushes `script/updateVariables`.
+     */
+    fun appendToManifest(scriptId: String, name: String) {
+        deps.channel.notify(
+            "script/appendToManifest",
+            linkedMapOf("scriptId" to scriptId, "name" to name),
+        )
+    }
 }

--- a/apps/intellij-plugin/src/main/resources/META-INF/modeler-groovy.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/modeler-groovy.xml
@@ -20,5 +20,15 @@
         <annotator
             language="Groovy"
             implementationClass="io.miragon.intellij.bpmn.ScriptSemanticHighlighter"/>
+
+        <!-- 💡 "Declare '<name>' in variable manifest" for an unresolved variable
+             in our Groovy script tabs. <language> scopes it to Groovy (it needs
+             Groovy PSI); the action self-scopes to our tabs via the UserData.
+             See DeclareVariableIntention. -->
+        <intentionAction>
+            <language>Groovy</language>
+            <className>io.miragon.intellij.bpmn.DeclareVariableIntention</className>
+            <category>BPMN Modeler</category>
+        </intentionAction>
     </extensions>
 </idea-plugin>

--- a/apps/intellij-plugin/src/main/resources/META-INF/modeler-json.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/modeler-json.xml
@@ -1,0 +1,9 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="JavaScript.JsonSchema">
+        <!-- Associates the bundled JSON Schema with *.bpmn.vars.json manifests
+             (validation + completion + hover docs). Same schema as the VS Code
+             jsonValidation contribution. See VarsManifestJsonSchemaProviderFactory. -->
+        <ProviderFactory
+            implementation="io.miragon.intellij.bpmn.VarsManifestJsonSchemaProviderFactory"/>
+    </extensions>
+</idea-plugin>

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -35,10 +35,18 @@
 
     <depends>com.intellij.modules.platform</depends>
     <!--
+        The Groovy binding resolver (ScriptBindingMembersContributor, loaded via
+        modeler-groovy.xml) builds synthetic Java PSI — JavaPsiFacade, PsiClass,
+        PsiElementFactory — so the Java plugin must be present. Groovy already
+        pulls Java transitively, but the plugin verifier only honours an explicit
+        declaration, and it documents the real requirement. Java also brings the
+        XML module, so the explicit modules.xml below is belt-and-braces.
+    -->
+    <depends>com.intellij.modules.java</depends>
+    <!--
         XMLLanguage (BpmnFileType's base language) lives in the bundled XML
-        module. The plugin already depends on com.intellij.java, which pulls
-        XML transitively, but declaring it explicitly documents the intent
-        and protects against a future drop of the java dependency.
+        module. Declared explicitly so a future drop of the Java dependency
+        above wouldn't silently take XML highlighting with it.
     -->
     <depends>com.intellij.modules.xml</depends>
 

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -124,10 +124,22 @@
         <!-- Camunda IntelliSense for the inline "Edit Script" editor. `language="any"`
              fires the contributor for every file type (the script tab may be
              PLAIN_TEXT when no JS/Python plugin is installed); it scopes itself to
-             modeler script tabs via the SCRIPT_COMPLETION_KEY UserData. -->
+             modeler script tabs via the SCRIPT_COMPLETION_KEY UserData.
+             `order="first"`: the Groovy binding resolver injects each catalog
+             symbol as synthetic PSI so it resolves, which makes Groovy's native
+             completion re-emit it as a duplicate. Running first lets the
+             contributor treat Groovy as a "remaining" contributor and filter those
+             duplicates while keeping its keywords/stdlib. -->
         <completion.contributor
             language="any"
+            order="first"
             implementationClass="io.miragon.intellij.bpmn.ScriptCompletionContributor"/>
+
+        <!-- Quick-doc (Ctrl-Q) for the script completions above. Application-level
+             and language-agnostic (NOT lang.documentationProvider) so it also fires
+             on PLAIN_TEXT script tabs where no per-language provider would. -->
+        <documentationProvider
+            implementation="io.miragon.intellij.bpmn.ScriptDocumentationProvider"/>
 
         <!-- Drops the Groovy annotator's "Cannot resolve symbol" greying on our
              inline script tabs for anything still unresolved. The bindings/script

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,14 @@
     -->
     <depends optional="true" config-file="modeler-groovy.xml">org.intellij.groovy</depends>
 
+    <!--
+        Optional: when the JSON module is present (it is in every IntelliJ-based
+        IDE), register the JSON Schema for `*.bpmn.vars.json` manifests so authors
+        get validation + completion (modeler-json.xml). Optional so a hypothetical
+        JSON-less host still loads the rest of the plugin.
+    -->
+    <depends optional="true" config-file="modeler-json.xml">com.intellij.modules.json</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <!--
             Registers `.bpmn` as a real file type so (a) JetBrains Marketplace's

--- a/apps/intellij-plugin/src/main/resources/intentionDescriptions/DeclareVariableIntention/after.groovy.template
+++ b/apps/intellij-plugin/src/main/resources/intentionDescriptions/DeclareVariableIntention/after.groovy.template
@@ -1,0 +1,1 @@
+execution.setVariable("total", orderId * amount)

--- a/apps/intellij-plugin/src/main/resources/intentionDescriptions/DeclareVariableIntention/before.groovy.template
+++ b/apps/intellij-plugin/src/main/resources/intentionDescriptions/DeclareVariableIntention/before.groovy.template
@@ -1,0 +1,1 @@
+execution.setVariable("total", <spot>orderId</spot> * amount)

--- a/apps/intellij-plugin/src/main/resources/intentionDescriptions/DeclareVariableIntention/description.html
+++ b/apps/intellij-plugin/src/main/resources/intentionDescriptions/DeclareVariableIntention/description.html
@@ -1,0 +1,13 @@
+<html>
+<body>
+Offers to declare an unknown process variable referenced in an inline BPMN
+script. When the caret sits on a variable the diagram model doesn't know,
+this appends a name-only entry to the diagram's
+<code>*.bpmn.vars.json</code> manifest and opens it so you can fill in the
+type and description. The variable then appears in script completion as an
+authored entry.
+<!-- tooltip end -->
+<p>Available only in the modeler's inline Groovy script tabs, on a reference
+that doesn't resolve to a known process variable or Camunda binding.</p>
+</body>
+</html>

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributorTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/ScriptCompletionContributorTest.kt
@@ -1,0 +1,108 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the de-duplication contract of [ScriptCompletionContributor] against the
+ * live completion pipeline. The contributor renders our catalog, while
+ * [ScriptBindingMembersContributor] separately injects every catalog symbol as
+ * synthetic Groovy PSI so the bare name *resolves* — which makes Groovy's native
+ * completion re-emit each as a second, untyped lookup. The regression these tests
+ * lock down is that exact double: a manifest-declared variable must surface
+ * **once**, while genuine Groovy completions (keywords) still pass through.
+ *
+ * Uses [LightJavaCodeInsightFixtureTestCase5] — the JUnit5 code-insight base class
+ * — because it manages the light-project lifecycle the suite's leak tracker
+ * expects (a hand-rolled `createCodeInsightFixture` leaks the project into the
+ * application disposer tree). The Groovy plugin is on the test classpath, so a
+ * `.groovy` tab resolves through the real binding contributor.
+ */
+class ScriptCompletionContributorTest : LightJavaCodeInsightFixtureTestCase5() {
+
+    // The base class defaults to a COMMUNITY-relative test-data path that doesn't
+    // exist in the gradle-downloaded SDK; resolving it throws. These tests build
+    // their PSI with configureByText (no data files), so any real directory works.
+    override fun getTestDataPath(): String = System.getProperty("java.io.tmpdir")
+
+    @Test
+    fun `manifest-declared variable surfaces exactly once`() {
+        // Two variables share the `ten` prefix so the popup stays open (a single
+        // match would auto-insert and hide the list), letting us count duplicates.
+        val result =
+            completeScript(
+                "ten",
+                variable("tenantId", typeHint = "String", description = "The tenant"),
+                variable("tenantName", typeHint = "String"),
+            )
+
+        assertEquals(
+            1,
+            result.lookups.count { it == "tenantId" },
+            "tenantId should appear once, not duplicated; got: ${result.lookups}",
+        )
+        assertEquals(
+            1,
+            result.lookups.count { it == "tenantName" },
+            "tenantName should appear once, not duplicated; got: ${result.lookups}",
+        )
+    }
+
+    @Test
+    fun `groovy keywords still complete past the filter`() {
+        // `def` is a genuine Groovy keyword the native contributor supplies; our
+        // name filter must let it through (the point of `language="any"`). It is
+        // the sole `de` match, so completion auto-inserts it — assert on the
+        // resulting text as well as any open popup.
+        val result = completeScript("de", variable("tenantId", typeHint = "String"))
+
+        val keywordCompleted = "def" in result.lookups || result.resultText.trim() == "def"
+        assertTrue(keywordCompleted, "Groovy keyword `def` should still complete; got: $result")
+    }
+
+    /** The lookups offered (empty when a single match auto-inserts) plus the resulting document text. */
+    private data class CompletionOutcome(val lookups: List<String>, val resultText: String)
+
+    /**
+     * Configures a Groovy script tab carrying [variables] as its catalog and runs
+     * basic completion with the caret right after [prefix]. Attaching the
+     * [SCRIPT_COMPLETION_KEY] UserData is what scopes both contributors to this
+     * file — exactly as `ScriptEditorManager` does for real "Edit Script" tabs.
+     */
+    private fun completeScript(prefix: String, vararg variables: VariableInfo): CompletionOutcome {
+        val model =
+            ScriptCompletionModel(
+                beans = emptyList(),
+                variables = variables.toList(),
+                globals = emptyList(),
+                types = emptyMap(),
+            )
+        val psiFile = fixture.configureByText("script.groovy", "$prefix<caret>")
+        psiFile.virtualFile.putUserData(SCRIPT_COMPLETION_KEY, model)
+        fixture.completeBasic()
+        return CompletionOutcome(
+            lookups = fixture.lookupElementStrings.orEmpty(),
+            resultText = fixture.editor.document.text,
+        )
+    }
+
+    private fun variable(
+        name: String,
+        typeHint: String? = null,
+        description: String? = null,
+    ): VariableInfo = VariableInfo(name = name, origin = null, typeHint = typeHint, description = description)
+
+    companion object {
+        @JvmStatic
+        @BeforeAll
+        fun disableJcef() {
+            // Opening the light project runs BridgeWarmupActivity, which spins up a
+            // JCEF browser and leaks a Swing timer the leak tracker rejects. Disable
+            // JCEF for this suite (irrelevant to completion) before the project opens.
+            System.setProperty("ide.browser.jcef.enabled", "false")
+        }
+    }
+}

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -81,9 +81,12 @@ describe("bridge script editor (real core over a fake transport)", () => {
         const sourcePath = join(root, "source.bpmn");
         await fs.writeFile(sourcePath, C7_XML, "utf8");
         // Written before session/register so the script feature's onSessionRegistered
-        // hook reads it into the editor's manifest source.
+        // hook reads it into the editor's manifest source. The manifest now lives
+        // under `<configFolder>/vars/<relBpmn>.vars.json`, not beside the diagram.
         if (options?.manifest !== undefined) {
-            await fs.writeFile(`${sourcePath}.vars.json`, options.manifest, "utf8");
+            const varsDir = join(root, ".camunda", "vars");
+            await fs.mkdir(varsDir, { recursive: true });
+            await fs.writeFile(join(varsDir, "source.bpmn.vars.json"), options.manifest, "utf8");
         }
 
         const frames: any[] = [];
@@ -312,11 +315,11 @@ describe("bridge script editor (real core over a fake transport)", () => {
         expect(open.params.completion.variables).toHaveLength(2);
     });
 
-    it("opens a diagram without a sibling manifest without logging an error", async () => {
+    it("opens a diagram without a manifest without logging an error", async () => {
         // Exercises the real NodeWorkspace.readFile ENOENT path: a missing
         // manifest must read as "absent" (FileNotFound), not rethrow and get
         // logged at error level on every editor open. `setup()` writes no
-        // `.vars.json`, so session/register hits the absent-manifest branch.
+        // `.camunda/vars/*.vars.json`, so session/register hits the absent-manifest branch.
         const { rpc, frames, editorId } = await setup();
         await settle();
 

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -74,10 +74,17 @@ describe("bridge script editor (real core over a fake transport)", () => {
         }
     });
 
-    async function setup(): Promise<{ rpc: Rpc; frames: any[]; editorId: string }> {
+    async function setup(options?: {
+        manifest?: string;
+    }): Promise<{ rpc: Rpc; frames: any[]; editorId: string }> {
         const root = await fs.mkdtemp(join(tmpdir(), "modeler-bridge-script-"));
         const sourcePath = join(root, "source.bpmn");
         await fs.writeFile(sourcePath, C7_XML, "utf8");
+        // Written before session/register so the script feature's onSessionRegistered
+        // hook reads it into the editor's manifest source.
+        if (options?.manifest !== undefined) {
+            await fs.writeFile(`${sourcePath}.vars.json`, options.manifest, "utf8");
+        }
 
         const frames: any[] = [];
         const { rpc } = createBridge((line) => frames.push(JSON.parse(line)));
@@ -265,6 +272,44 @@ describe("bridge script editor (real core over a fake transport)", () => {
 
         const open = await waitForFrame(frames, (f) => f.method === "script/open");
         expect(open.params.completion.variables).toEqual(variables);
+    });
+
+    it("merges the *.bpmn.vars.json manifest into the script/open payload, manifest winning a clash", async () => {
+        const { rpc, frames, editorId } = await setup({
+            manifest: JSON.stringify({
+                variables: [
+                    { name: "orderId", type: "String", description: "Set by REST start" },
+                    { name: "amount", type: "Long" },
+                ],
+            }),
+        });
+
+        // `amount` also arrives as an extracted (heuristic) variable — the
+        // manifest's authored entry must win the clash.
+        const variables = [{ name: "amount", origin: "form field", confidence: "declared" }];
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+            variables,
+        });
+
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        const byName: Record<string, any> = Object.fromEntries(
+            open.params.completion.variables.map((v: { name: string }) => [v.name, v]),
+        );
+
+        expect(byName.orderId).toMatchObject({
+            typeHint: "String",
+            description: "Set by REST start",
+            confidence: "authored",
+        });
+        // The authored `amount` (type Long) wins over the extracted form field.
+        expect(byName.amount).toMatchObject({ typeHint: "Long", confidence: "authored" });
+        expect(open.params.completion.variables).toHaveLength(2);
     });
 
     it("pushes script/updateVariables for that editor's open scripts only", async () => {

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -312,6 +312,36 @@ describe("bridge script editor (real core over a fake transport)", () => {
         expect(open.params.completion.variables).toHaveLength(2);
     });
 
+    it("opens a diagram without a sibling manifest without logging an error", async () => {
+        // Exercises the real NodeWorkspace.readFile ENOENT path: a missing
+        // manifest must read as "absent" (FileNotFound), not rethrow and get
+        // logged at error level on every editor open. `setup()` writes no
+        // `.vars.json`, so session/register hits the absent-manifest branch.
+        const { rpc, frames, editorId } = await setup();
+        await settle();
+
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+            variables: [{ name: "amount", origin: "form field", confidence: "declared" }],
+        });
+
+        const errorLog = frames.find(
+            (f) => f.method === "notifier/log" && f.params?.level === "error",
+        );
+        expect(errorLog).toBeUndefined();
+
+        // With no manifest the payload carries only the extracted variables.
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        expect(open.params.completion.variables).toEqual([
+            { name: "amount", origin: "form field", confidence: "declared" },
+        ]);
+    });
+
     it("pushes script/updateVariables for that editor's open scripts only", async () => {
         const { rpc, frames, editorId } = await setup();
         await feedOpen(rpc, editorId, {

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -12,7 +12,7 @@
 
 import { promises as fs } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -313,6 +313,52 @@ describe("bridge script editor (real core over a fake transport)", () => {
         // The authored `amount` (type Long) wins over the extracted form field.
         expect(byName.amount).toMatchObject({ typeHint: "Long", confidence: "authored" });
         expect(open.params.completion.variables).toHaveLength(2);
+    });
+
+    it("appends to the manifest, reveals it, and re-pushes updateVariables on script/appendToManifest", async () => {
+        const { rpc, frames, editorId } = await setup({
+            manifest: JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
+        });
+
+        await feedOpen(rpc, editorId, {
+            elementId: "Task_1",
+            kind: "script-task",
+            listenerIndex: undefined,
+            eventName: undefined,
+            scriptFormat: "groovy",
+            content: "",
+        });
+        const open = await waitForFrame(frames, (f) => f.method === "script/open");
+        const scriptId = open.params.scriptId;
+
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "script/appendToManifest",
+                params: { scriptId, name: "amount" },
+            }),
+        );
+
+        // (a) the reveal frame carries the resolved manifest path …
+        const reveal = await waitForFrame(frames, (f) => f.method === "notifier/openDocument");
+        const sourcePath = editorId.replace(/^file:\/\//, "");
+        const manifestPath = join(dirname(sourcePath), ".camunda", "vars", "source.bpmn.vars.json");
+        expect(reveal.params.path).toBe(manifestPath);
+
+        // (b) … the entry was appended on disk (the existing entry preserved) …
+        const onDisk = JSON.parse(await fs.readFile(manifestPath, "utf8"));
+        expect(onDisk.variables).toEqual([{ name: "orderId", type: "String" }, { name: "amount" }]);
+
+        // (c) … and the watcher-driven reload re-pushes the merged var to the tab.
+        const update = await waitForFrame(
+            frames,
+            (f) =>
+                f.method === "script/updateVariables" &&
+                f.params.scriptId === scriptId &&
+                f.params.variables.some((v: { name: string }) => v.name === "amount"),
+        );
+        expect(update.params.variables.map((v: { name: string }) => v.name)).toEqual(
+            expect.arrayContaining(["orderId", "amount"]),
+        );
     });
 
     it("opens a diagram without a manifest without logging an error", async () => {

--- a/apps/modeler-bridge/src/bridge.script.spec.ts
+++ b/apps/modeler-bridge/src/bridge.script.spec.ts
@@ -348,7 +348,8 @@ describe("bridge script editor (real core over a fake transport)", () => {
         const onDisk = JSON.parse(await fs.readFile(manifestPath, "utf8"));
         expect(onDisk.variables).toEqual([{ name: "orderId", type: "String" }, { name: "amount" }]);
 
-        // (c) … and the watcher-driven reload re-pushes the merged var to the tab.
+        // (c) … and the append re-pushes the merged var to the tab (done eagerly,
+        // not via the fs watcher, so it is deterministic and does not race a write).
         const update = await waitForFrame(
             frames,
             (f) =>

--- a/apps/modeler-bridge/src/composition/scriptFeature.ts
+++ b/apps/modeler-bridge/src/composition/scriptFeature.ts
@@ -3,12 +3,13 @@ import {
     OpenScriptEditorCommand,
     UpdateScriptVariablesCommand,
 } from "@miragon/bpmn-modeler-shared";
+import { ScriptVariableManifestService } from "@miragon/bpmn-modeler-core";
 
 import { BridgeScriptEditor } from "../scriptAdapters";
 import { METHODS } from "../protocol/descriptor";
 import { ScriptCloseParams, ScriptDidChangeParams } from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
-import { SessionHooks } from "./sessionHooks";
+import { RegisterParams, SessionHooks } from "./sessionHooks";
 
 /**
  * The inline-script-editor feature owns the {@link BridgeScriptEditor}
@@ -23,13 +24,19 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
     // in-core service — the VS Code original was never extracted (its guts are
     // VS Code-specific accidental complexity) — so the portable slice lives here
     // and the Kotlin host is a dumb editor surface keyed by an opaque scriptId.
+    const manifestSvc = new ScriptVariableManifestService(deps.nodeWorkspace);
     const scriptEditor = new BridgeScriptEditor(
         deps.store,
         deps.picker,
         deps.rpc,
         deps.notifier,
         deps.settings,
+        manifestSvc,
     );
+
+    // Manifest watchers are armed per session and disposed when that editor
+    // closes, mirroring the template-watcher lifecycle in templatesSettingsFeature.
+    const manifestWatchers = new Map<string, { dispose(): void }>();
 
     deps.router
         .on("OpenScriptEditorCommand", (message: Command, editorId: string) => {
@@ -58,8 +65,27 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
 
     return {
         sessionHooks: {
-            // Close any script tabs this editor opened before its handle is dropped.
-            onSessionDisposed: (editorId) => scriptEditor.disposeEditor(editorId),
+            // Load the sibling manifest and arm its watcher so authored variables
+            // merge into completion and refresh live. Guard non-file editors
+            // (a diff pane has no manifest on disk); the manifest service speaks
+            // fs paths, so pass the host-provided `fsPath`.
+            onSessionRegistered: async (params: RegisterParams) => {
+                if (params.scheme !== "file") {
+                    return;
+                }
+                await scriptEditor.loadManifest(params.editorId, params.fsPath);
+                manifestWatchers.set(
+                    params.editorId,
+                    scriptEditor.watchManifest(params.editorId, params.fsPath),
+                );
+            },
+            // Close any script tabs this editor opened before its handle is
+            // dropped, and stop watching its manifest.
+            onSessionDisposed: (editorId) => {
+                manifestWatchers.get(editorId)?.dispose();
+                manifestWatchers.delete(editorId);
+                scriptEditor.disposeEditor(editorId);
+            },
         },
     };
 }

--- a/apps/modeler-bridge/src/composition/scriptFeature.ts
+++ b/apps/modeler-bridge/src/composition/scriptFeature.ts
@@ -7,7 +7,11 @@ import { ScriptVariableManifestService } from "@miragon/bpmn-modeler-core";
 
 import { BridgeScriptEditor } from "../scriptAdapters";
 import { METHODS } from "../protocol/descriptor";
-import { ScriptCloseParams, ScriptDidChangeParams } from "../protocol/types";
+import {
+    ScriptAppendToManifestParams,
+    ScriptCloseParams,
+    ScriptDidChangeParams,
+} from "../protocol/types";
 import { BridgeSharedDeps } from "./sharedDeps";
 import { RegisterParams, SessionHooks } from "./sessionHooks";
 
@@ -65,6 +69,17 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
     // re-reads the current BPMN content rather than revealing a stale tab.
     deps.rpc.on(METHODS.scriptDidClose, (params: ScriptCloseParams) => {
         scriptEditor.didClose(params.scriptId);
+    });
+
+    // The host's "Declare in variable manifest" intention → scaffold the entry in
+    // the diagram's manifest and reveal it. Fire-and-forget; the manifest watcher
+    // re-pushes completion on the resulting write.
+    deps.rpc.on(METHODS.scriptAppendToManifest, (params: ScriptAppendToManifestParams) => {
+        void scriptEditor.appendToManifest(params.scriptId, {
+            name: params.name,
+            type: params.type,
+            description: params.description,
+        });
     });
 
     return {

--- a/apps/modeler-bridge/src/composition/scriptFeature.ts
+++ b/apps/modeler-bridge/src/composition/scriptFeature.ts
@@ -24,7 +24,11 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
     // in-core service — the VS Code original was never extracted (its guts are
     // VS Code-specific accidental complexity) — so the portable slice lives here
     // and the Kotlin host is a dumb editor surface keyed by an opaque scriptId.
-    const manifestSvc = new ScriptVariableManifestService(deps.nodeWorkspace);
+    const manifestSvc = new ScriptVariableManifestService(
+        deps.nodeWorkspace,
+        deps.settings,
+        deps.artifactSvc,
+    );
     const scriptEditor = new BridgeScriptEditor(
         deps.store,
         deps.picker,
@@ -65,10 +69,10 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
 
     return {
         sessionHooks: {
-            // Load the sibling manifest and arm its watcher so authored variables
-            // merge into completion and refresh live. Guard non-file editors
-            // (a diff pane has no manifest on disk); the manifest service speaks
-            // fs paths, so pass the host-provided `fsPath`.
+            // Load the manifest and arm its watcher so authored variables merge
+            // into completion and refresh live. Guard non-file editors (a diff
+            // pane has no manifest on disk); the manifest service speaks fs paths,
+            // so pass the host-provided `fsPath`.
             onSessionRegistered: async (params: RegisterParams) => {
                 if (params.scheme !== "file") {
                     return;
@@ -76,7 +80,7 @@ export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks }
                 await scriptEditor.loadManifest(params.editorId, params.fsPath);
                 manifestWatchers.set(
                     params.editorId,
-                    scriptEditor.watchManifest(params.editorId, params.fsPath),
+                    await scriptEditor.watchManifest(params.editorId, params.fsPath),
                 );
             },
             // Close any script tabs this editor opened before its handle is

--- a/apps/modeler-bridge/src/nodeAdapters.ts
+++ b/apps/modeler-bridge/src/nodeAdapters.ts
@@ -35,6 +35,7 @@ import { posix, sep } from "node:path";
 import {
     DirectoryNotFound,
     EditorSubscription,
+    FileNotFound,
     NoWorkspaceFolderFoundError,
     SettingChange,
     SettingsPort,
@@ -201,8 +202,23 @@ export class NodeWorkspace implements WorkspacePort {
         });
     }
 
+    /**
+     * @throws {FileNotFound} on `ENOENT`. The {@link WorkspacePort.readFile}
+     *   contract is "throw FileNotFound when absent" (VsCodeWorkspace already
+     *   does, via `Uri.file`), and callers like `ScriptVariableManifestService`
+     *   catch it (via `instanceof`) to mean "no manifest, use defaults". A raw
+     *   ENOENT would slip that guard and rethrow — mirror the `readDirectory`
+     *   precedent above so the class identity survives bundling.
+     */
     async readFile(path: string): Promise<string> {
-        return fs.readFile(toFsPath(path), "utf8");
+        try {
+            return await fs.readFile(toFsPath(path), "utf8");
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+                throw new FileNotFound(path);
+            }
+            throw error;
+        }
     }
 
     /**

--- a/apps/modeler-bridge/src/protocol/descriptor.ts
+++ b/apps/modeler-bridge/src/protocol/descriptor.ts
@@ -48,6 +48,7 @@ import {
     PickerShowParams,
     PickerShowResult,
     RegisterParams,
+    ScriptAppendToManifestParams,
     ScriptCloseNotifyParams,
     ScriptCloseParams,
     ScriptDidChangeParams,
@@ -86,6 +87,7 @@ export const METHODS = {
     deploymentOpen: "deployment/open",
     scriptDidChange: "script/didChange",
     scriptDidClose: "script/didClose",
+    scriptAppendToManifest: "script/appendToManifest",
 
     // Core → Host requests
     documentWrite: "document/write",
@@ -243,6 +245,15 @@ export const PROTOCOL = [
         direction: "hostToCore",
         kind: "notification",
         paramsFixture: { scriptId: "s1" } satisfies ScriptCloseParams,
+    },
+    {
+        method: METHODS.scriptAppendToManifest,
+        direction: "hostToCore",
+        kind: "notification",
+        paramsFixture: {
+            scriptId: "s1",
+            name: "orderId",
+        } satisfies ScriptAppendToManifestParams,
     },
 
     // ── Core → Host requests ─────────────────────────────────────────────────

--- a/apps/modeler-bridge/src/protocol/protocol.json
+++ b/apps/modeler-bridge/src/protocol/protocol.json
@@ -127,6 +127,15 @@
         ]
     },
     {
+        "method": "script/appendToManifest",
+        "direction": "hostToCore",
+        "kind": "notification",
+        "paramKeys": [
+            "name",
+            "scriptId"
+        ]
+    },
+    {
         "method": "document/write",
         "direction": "coreToHost",
         "kind": "request",

--- a/apps/modeler-bridge/src/protocol/protocol.spec.ts
+++ b/apps/modeler-bridge/src/protocol/protocol.spec.ts
@@ -108,6 +108,7 @@ describe("RPC protocol descriptor", () => {
                     "  deployment/open",
                     "  script/didChange",
                     "  script/didClose",
+                    "  script/appendToManifest",
                     "",
                     "Core → Host (requests):",
                     "  document/write",

--- a/apps/modeler-bridge/src/protocol/types.ts
+++ b/apps/modeler-bridge/src/protocol/types.ts
@@ -114,6 +114,19 @@ export interface ScriptCloseParams {
     scriptId: string;
 }
 
+/**
+ * `script/appendToManifest` — the host's "Declare in variable manifest" intention
+ * asks the core to scaffold a `*.bpmn.vars.json` entry for an unknown variable.
+ * `type`/`description` are optional so the host can append a name-only entry and
+ * let the author fill the rest in the opened manifest.
+ */
+export interface ScriptAppendToManifestParams {
+    scriptId: string;
+    name: string;
+    type?: string;
+    description?: string;
+}
+
 // ── Core → Host requests (params + results) ──────────────────────────────────
 
 /** `document/write` — push core-originated text; result reports whether it changed. */

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -188,9 +188,10 @@ export class BridgeScriptEditor {
     /**
      * Watches the manifest file and reloads + re-pushes on any change. The
      * returned handle is owned by the session feature, which disposes it when the
-     * editor closes.
+     * editor closes. Async because resolving the manifest path needs the
+     * workspace root.
      */
-    watchManifest(editorId: string, documentPath: string): { dispose(): void } {
+    async watchManifest(editorId: string, documentPath: string): Promise<{ dispose(): void }> {
         return this.manifestSvc.createWatcher(documentPath, () => {
             void this.loadManifest(editorId, documentPath);
         });

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -26,8 +26,10 @@ import {
     PickerPort,
     ScriptLanguage,
     ScriptUri,
+    ScriptVariableManifestService,
 } from "@miragon/bpmn-modeler-core";
 import {
+    dedupeVariables,
     OpenScriptEditorCommand,
     ScriptKind,
     UpdateScriptContentQuery,
@@ -56,10 +58,15 @@ interface TrackedScript {
 export class BridgeScriptEditor {
     private readonly scripts = new Map<string, TrackedScript>();
 
-    // Latest process-variable model per editor. Seeded on open and replaced on
-    // every `UpdateScriptVariablesCommand`; read both into the `script/open`
-    // payload and the per-script `script/updateVariables` push.
-    private readonly variablesByEditor = new Map<string, VariableDef[]>();
+    // Two process-variable sources per editor, kept apart and merged on read
+    // (mirrors the VS Code `ScriptVariableStore`): the webview-extracted model
+    // (seeded on open, replaced on every `UpdateScriptVariablesCommand`) and the
+    // `*.bpmn.vars.json` manifest model (loaded on session register, refreshed by
+    // the file watcher). `mergedFor` deduplicates them so the manifest's
+    // `authored` tier wins clashes; the merge feeds both the `script/open`
+    // payload and the `script/updateVariables` push.
+    private readonly extractedByEditor = new Map<string, VariableDef[]>();
+    private readonly manifestByEditor = new Map<string, VariableDef[]>();
 
     constructor(
         private readonly store: EditorSessionStore,
@@ -67,6 +74,7 @@ export class BridgeScriptEditor {
         private readonly rpc: Rpc,
         private readonly notifier: NotifierPort,
         private readonly settings: BridgeSettings,
+        private readonly manifestSvc: ScriptVariableManifestService,
     ) {}
 
     /**
@@ -107,9 +115,9 @@ export class BridgeScriptEditor {
             listenerIndex: cmd.listenerIndex,
         });
 
-        // Seed the editor's variable model from the open command so the host has
+        // Seed the editor's extracted model from the open command so the host has
         // variable completion before the first live update arrives.
-        this.variablesByEditor.set(editorId, cmd.variables ?? []);
+        this.extractedByEditor.set(editorId, cmd.variables ?? []);
 
         // The SPIN globals (`S`/`JSON`) and the type→methods table are gated here
         // in the bridge (single source): off → empty, so the Kotlin contributor
@@ -141,7 +149,7 @@ export class BridgeScriptEditor {
                     // they have no member completion.
                     methods: methodsForBean(bean),
                 })),
-                variables: this.variablesByEditor.get(editorId) ?? [],
+                variables: this.mergedFor(editorId),
                 globals: spinOn ? globalFunctionsFor(cmd.kind) : [],
                 types: spinOn
                     ? Object.fromEntries(COMPLEX_TYPES.map((type) => [type.name, type.methods]))
@@ -151,12 +159,53 @@ export class BridgeScriptEditor {
     }
 
     /**
-     * Replaces an editor's process-variable model and pushes it to every open
-     * script tab of that editor via `script/updateVariables`, so completion goes
-     * live without reopening. Scoped to the originating editor's scripts only.
+     * Replaces an editor's webview-extracted model and re-pushes the merged
+     * model to every open script tab of that editor via `script/updateVariables`,
+     * so completion goes live without reopening. Scoped to the originating
+     * editor's scripts only.
      */
     updateVariables(editorId: string, variables: VariableDef[]): void {
-        this.variablesByEditor.set(editorId, variables);
+        this.extractedByEditor.set(editorId, variables);
+        this.pushVariables(editorId);
+    }
+
+    /**
+     * Loads the `*.bpmn.vars.json` manifest for an editor and re-pushes the merged
+     * model. Called on session register (no tabs open yet, so the push is a no-op
+     * that just seeds the manifest source) and on every manifest file change.
+     * A read error is logged and leaves the previous manifest model in place.
+     */
+    async loadManifest(editorId: string, documentPath: string): Promise<void> {
+        try {
+            this.manifestByEditor.set(editorId, await this.manifestSvc.load(documentPath));
+        } catch (error) {
+            this.notifier.logError(error as Error);
+            return;
+        }
+        this.pushVariables(editorId);
+    }
+
+    /**
+     * Watches the manifest file and reloads + re-pushes on any change. The
+     * returned handle is owned by the session feature, which disposes it when the
+     * editor closes.
+     */
+    watchManifest(editorId: string, documentPath: string): { dispose(): void } {
+        return this.manifestSvc.createWatcher(documentPath, () => {
+            void this.loadManifest(editorId, documentPath);
+        });
+    }
+
+    /** Deduplicated manifest-over-extracted model; manifest's `authored` tier wins. */
+    private mergedFor(editorId: string): VariableDef[] {
+        const manifest = this.manifestByEditor.get(editorId) ?? [];
+        const extracted = this.extractedByEditor.get(editorId) ?? [];
+        return dedupeVariables([...manifest, ...extracted]);
+    }
+
+    /** Pushes the merged model to every open script tab of `editorId`. */
+    private pushVariables(editorId: string): void {
+        const variables = this.mergedFor(editorId);
         for (const [scriptId, entry] of this.scripts) {
             if (entry.editorId === editorId) {
                 this.rpc.notify(METHODS.scriptUpdateVariables, { scriptId, variables });
@@ -202,7 +251,8 @@ export class BridgeScriptEditor {
                 this.scripts.delete(scriptId);
             }
         }
-        this.variablesByEditor.delete(editorId);
+        this.extractedByEditor.delete(editorId);
+        this.manifestByEditor.delete(editorId);
     }
 
     /**

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -35,6 +35,7 @@ import {
     UpdateScriptContentQuery,
     UpdateScriptFormatQuery,
     VariableDef,
+    VariableManifestEntry,
 } from "@miragon/bpmn-modeler-shared";
 
 import { BridgeSettings } from "./nodeAdapters";
@@ -67,6 +68,12 @@ export class BridgeScriptEditor {
     // payload and the `script/updateVariables` push.
     private readonly extractedByEditor = new Map<string, VariableDef[]>();
     private readonly manifestByEditor = new Map<string, VariableDef[]>();
+
+    // The editor's diagram fs path, retained so `appendToManifest` can resolve
+    // which manifest to write — a script tab is addressed only by an opaque
+    // `scriptId`, which carries no path. Seeded when `loadManifest` runs at
+    // session register.
+    private readonly documentPathByEditor = new Map<string, string>();
 
     constructor(
         private readonly store: EditorSessionStore,
@@ -176,6 +183,7 @@ export class BridgeScriptEditor {
      * A read error is logged and leaves the previous manifest model in place.
      */
     async loadManifest(editorId: string, documentPath: string): Promise<void> {
+        this.documentPathByEditor.set(editorId, documentPath);
         try {
             this.manifestByEditor.set(editorId, await this.manifestSvc.load(documentPath));
         } catch (error) {
@@ -241,6 +249,31 @@ export class BridgeScriptEditor {
     }
 
     /**
+     * The host's "Declare in variable manifest" intention fired: scaffold the
+     * entry in the script's diagram manifest, then reveal the file so the author
+     * fills in `type`/`description`. Reveal reuses the existing `notifier/openDocument`
+     * capability (already implemented on the host). The append does **not** re-push
+     * variables manually — the per-session manifest watcher fires on the write and
+     * re-pushes `script/updateVariables`, so the new authored entry appears live.
+     */
+    async appendToManifest(scriptId: string, entry: VariableManifestEntry): Promise<void> {
+        const tracked = this.scripts.get(scriptId);
+        if (!tracked) {
+            return;
+        }
+        const documentPath = this.documentPathByEditor.get(tracked.editorId);
+        if (!documentPath) {
+            return;
+        }
+        try {
+            const manifestPath = await this.manifestSvc.upsert(documentPath, entry);
+            await this.notifier.openDocument(manifestPath);
+        } catch (error) {
+            this.notifier.logError(error as Error);
+        }
+    }
+
+    /**
      * The BPMN editor was disposed: tell the host to close every script tab it
      * opened for that editor and drop their tracking. Iterating while deleting is
      * safe for a `Map` — only already-visited or current entries are removed.
@@ -254,6 +287,7 @@ export class BridgeScriptEditor {
         }
         this.extractedByEditor.delete(editorId);
         this.manifestByEditor.delete(editorId);
+        this.documentPathByEditor.delete(editorId);
     }
 
     /**

--- a/apps/modeler-bridge/src/scriptAdapters.ts
+++ b/apps/modeler-bridge/src/scriptAdapters.ts
@@ -252,9 +252,14 @@ export class BridgeScriptEditor {
      * The host's "Declare in variable manifest" intention fired: scaffold the
      * entry in the script's diagram manifest, then reveal the file so the author
      * fills in `type`/`description`. Reveal reuses the existing `notifier/openDocument`
-     * capability (already implemented on the host). The append does **not** re-push
-     * variables manually — the per-session manifest watcher fires on the write and
-     * re-pushes `script/updateVariables`, so the new authored entry appears live.
+     * capability (already implemented on the host).
+     *
+     * The re-push is done explicitly via `loadManifest` rather than left to the
+     * per-session manifest watcher: `fs.watch` latency is unbounded (and flaky in
+     * CI), so waiting for the watcher to observe *our own* write would make the new
+     * authored entry appear only after an indeterminate delay. The watcher still
+     * covers external edits; a redundant watcher-driven re-push afterwards is
+     * idempotent.
      */
     async appendToManifest(scriptId: string, entry: VariableManifestEntry): Promise<void> {
         const tracked = this.scripts.get(scriptId);
@@ -268,6 +273,7 @@ export class BridgeScriptEditor {
         try {
             const manifestPath = await this.manifestSvc.upsert(documentPath, entry);
             await this.notifier.openDocument(manifestPath);
+            await this.loadManifest(tracked.editorId, documentPath);
         } catch (error) {
             this.notifier.logError(error as Error);
         }

--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -87,6 +87,12 @@
     ],
     "main": "main.js",
     "contributes": {
+        "jsonValidation": [
+            {
+                "fileMatch": "*.bpmn.vars.json",
+                "url": "./schemas/bpmn-vars.schema.json"
+            }
+        ],
         "themes": [
             {
                 "id": "miragon-light",

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -17,6 +17,7 @@ import { ElementTemplatesParticipant } from "../modeler/bpmn/controller/editor-p
 import { SettingsParticipant } from "../modeler/bpmn/controller/editor-participants/SettingsParticipant";
 import { EngineVersionStatusBarParticipant } from "../modeler/bpmn/controller/editor-participants/EngineVersionStatusBarParticipant";
 import { ScriptTaskTeardownParticipant } from "../modeler/bpmn/controller/editor-participants/ScriptTaskTeardownParticipant";
+import { ScriptManifestParticipant } from "../modeler/bpmn/controller/editor-participants/ScriptManifestParticipant";
 import { DmnRenderParticipant } from "../modeler/dmn/controller/editor-participants/DmnRenderParticipant";
 import { DmnSettingsParticipant } from "../modeler/dmn/controller/editor-participants/DmnSettingsParticipant";
 import {
@@ -60,6 +61,7 @@ interface EditorHandles {
     diffController: BpmnDiffController;
     scriptTaskSvc: ScriptTaskService;
     scriptVariableStore: ScriptVariableStore;
+    scriptManifestParticipant: ScriptManifestParticipant;
     codeLink: CodeLinkHandles;
 }
 
@@ -77,7 +79,13 @@ export function register(
     deps: SharedDeps,
     handles: EditorHandles,
 ): { bpmnService: BpmnModelerService } {
-    const { diffController, scriptTaskSvc, scriptVariableStore, codeLink } = handles;
+    const {
+        diffController,
+        scriptTaskSvc,
+        scriptVariableStore,
+        scriptManifestParticipant,
+        codeLink,
+    } = handles;
 
     const panelStateRepo = new PropertiesPanelStateRepository(context);
     const bpmnService = new BpmnModelerService(
@@ -184,6 +192,7 @@ export function register(
             new SettingsParticipant(settingsBroadcaster),
             new EngineVersionStatusBarParticipant(deps.statusBar, deps.vsDocument),
             new ScriptTaskTeardownParticipant(scriptTaskSvc, scriptVariableStore),
+            scriptManifestParticipant,
             codeLink.codeLinkParticipant,
         ],
         // Diff routing: when the URI resolves as a diff pane the diff controller

--- a/apps/vscode-plugin/src/composition/scriptFeature.ts
+++ b/apps/vscode-plugin/src/composition/scriptFeature.ts
@@ -43,7 +43,7 @@ export function register(
     new ScriptCompletionProvider(scriptVariableStore, deps.vsSettings).register(context);
 
     const scriptManifestParticipant = new ScriptManifestParticipant(
-        new ScriptVariableManifestService(deps.vsWorkspace),
+        new ScriptVariableManifestService(deps.vsWorkspace, deps.vsSettings, deps.artifactSvc),
         scriptVariableStore,
         deps.notifier,
     );

--- a/apps/vscode-plugin/src/composition/scriptFeature.ts
+++ b/apps/vscode-plugin/src/composition/scriptFeature.ts
@@ -3,6 +3,7 @@ import { ExtensionContext, workspace } from "vscode";
 import { ScriptVariableManifestService, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { BpmnScriptFileSystem } from "../scriptTask/infrastructure/BpmnScriptFileSystem";
 import { ScriptCompletionProvider } from "../scriptTask/controller/ScriptCompletionProvider";
+import { ScriptDeclareVariableCodeAction } from "../scriptTask/controller/ScriptDeclareVariableCodeAction";
 import { ScriptManifestParticipant } from "../modeler/bpmn/controller/editor-participants/ScriptManifestParticipant";
 import { ScriptTaskService } from "../scriptTask/controller/ScriptTaskService";
 import { SharedDeps } from "./sharedDeps";
@@ -42,8 +43,23 @@ export function register(
     const scriptVariableStore = new ScriptVariableStore();
     new ScriptCompletionProvider(scriptVariableStore, deps.vsSettings).register(context);
 
+    // One manifest service feeds both the read path (the participant loads/watches
+    // it into the store) and the write path (the code action scaffolds entries).
+    const manifestSvc = new ScriptVariableManifestService(
+        deps.vsWorkspace,
+        deps.vsSettings,
+        deps.artifactSvc,
+    );
+
+    new ScriptDeclareVariableCodeAction(
+        scriptTaskSvc,
+        scriptVariableStore,
+        manifestSvc,
+        deps.notifier,
+    ).register(context);
+
     const scriptManifestParticipant = new ScriptManifestParticipant(
-        new ScriptVariableManifestService(deps.vsWorkspace, deps.vsSettings, deps.artifactSvc),
+        manifestSvc,
         scriptVariableStore,
         deps.notifier,
     );

--- a/apps/vscode-plugin/src/composition/scriptFeature.ts
+++ b/apps/vscode-plugin/src/composition/scriptFeature.ts
@@ -1,8 +1,9 @@
 import { ExtensionContext, workspace } from "vscode";
 
-import { ScriptVariableStore } from "@miragon/bpmn-modeler-core";
+import { ScriptVariableManifestService, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
 import { BpmnScriptFileSystem } from "../scriptTask/infrastructure/BpmnScriptFileSystem";
 import { ScriptCompletionProvider } from "../scriptTask/controller/ScriptCompletionProvider";
+import { ScriptManifestParticipant } from "../modeler/bpmn/controller/editor-participants/ScriptManifestParticipant";
 import { ScriptTaskService } from "../scriptTask/controller/ScriptTaskService";
 import { SharedDeps } from "./sharedDeps";
 
@@ -10,14 +11,19 @@ import { SharedDeps } from "./sharedDeps";
  * The inline-script-editor feature owns the virtual `bpmn-script:` filesystem,
  * the task service, the completion provider, and the process-variable store.
  * Registering the FS provider here (rather than in `activate`) is safe because
- * no `bpmn-script:` URI is resolved during activation. `scriptTaskSvc` and
- * `scriptVariableStore` are returned because the editor feature wires them into
- * the BPMN router and the teardown participant.
+ * no `bpmn-script:` URI is resolved during activation. `scriptTaskSvc`,
+ * `scriptVariableStore`, and `scriptManifestParticipant` are returned because
+ * the editor feature wires them into the BPMN router, the teardown participant,
+ * and the session participant list.
  */
 export function register(
     context: ExtensionContext,
     deps: SharedDeps,
-): { scriptTaskSvc: ScriptTaskService; scriptVariableStore: ScriptVariableStore } {
+): {
+    scriptTaskSvc: ScriptTaskService;
+    scriptVariableStore: ScriptVariableStore;
+    scriptManifestParticipant: ScriptManifestParticipant;
+} {
     const bpmnScriptFs = new BpmnScriptFileSystem();
     context.subscriptions.push(
         workspace.registerFileSystemProvider("bpmn-script", bpmnScriptFs, {
@@ -36,5 +42,11 @@ export function register(
     const scriptVariableStore = new ScriptVariableStore();
     new ScriptCompletionProvider(scriptVariableStore, deps.vsSettings).register(context);
 
-    return { scriptTaskSvc, scriptVariableStore };
+    const scriptManifestParticipant = new ScriptManifestParticipant(
+        new ScriptVariableManifestService(deps.vsWorkspace),
+        scriptVariableStore,
+        deps.notifier,
+    );
+
+    return { scriptTaskSvc, scriptVariableStore, scriptManifestParticipant };
 }

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -29,12 +29,14 @@ export function activate(context: ExtensionContext): void {
 
     const deps = buildSharedDeps(context);
     const { diffController } = diffFeature.register(context, deps);
-    const { scriptTaskSvc, scriptVariableStore } = scriptFeature.register(context, deps);
+    const { scriptTaskSvc, scriptVariableStore, scriptManifestParticipant } =
+        scriptFeature.register(context, deps);
     const codeLink = codeLinkFeature.register(context, deps);
     const { bpmnService } = editorFeature.register(context, deps, {
         diffController,
         scriptTaskSvc,
         scriptVariableStore,
+        scriptManifestParticipant,
         codeLink,
     });
     compareFeature.register(context, deps, { diffController });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.ts
@@ -1,0 +1,53 @@
+import { Uri } from "vscode";
+
+import { ScriptVariableManifestService, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
+import { VsCodeNotifier } from "../../../../shared/infrastructure/VsCodeNotifier";
+import {
+    EditorSessionContext,
+    EditorSessionParticipant,
+} from "../../../editor-session/EditorSessionParticipant";
+
+/**
+ * Feeds the `*.bpmn.vars.json` manifest model into the {@link ScriptVariableStore}
+ * for a BPMN session and keeps it live: loads the manifest on resolve and
+ * re-reads it whenever the file is created, edited, or deleted. The store merges
+ * it with the webview-extracted model, so script completion reflects authored
+ * variables (with their types and docs) on top of the heuristic ones.
+ *
+ * The `editorId` is a document URI; the manifest service speaks fs paths, so the
+ * conversion and the `file:`-scheme guard live here — a `git:`/`untitled:` diff
+ * editor has no sibling manifest on disk.
+ */
+export class ScriptManifestParticipant implements EditorSessionParticipant {
+    constructor(
+        private readonly manifestSvc: ScriptVariableManifestService,
+        private readonly store: ScriptVariableStore,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    async onResolve(session: EditorSessionContext): Promise<void> {
+        const uri = Uri.parse(session.editorId);
+        if (uri.scheme !== "file") {
+            return;
+        }
+        const documentPath = uri.fsPath;
+        const { editorId } = session;
+
+        await this.reload(editorId, documentPath);
+
+        session.addDisposable(
+            this.manifestSvc.createWatcher(documentPath, () => {
+                void this.reload(editorId, documentPath);
+            }),
+        );
+    }
+
+    /** Re-reads the manifest into the store; a read error leaves the store untouched. */
+    private async reload(editorId: string, documentPath: string): Promise<void> {
+        try {
+            this.store.setManifest(editorId, await this.manifestSvc.load(documentPath));
+        } catch (error) {
+            this.notifier.notifyError("Failed to read process-variable manifest", error as Error);
+        }
+    }
+}

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.ts
@@ -16,7 +16,7 @@ import {
  *
  * The `editorId` is a document URI; the manifest service speaks fs paths, so the
  * conversion and the `file:`-scheme guard live here — a `git:`/`untitled:` diff
- * editor has no sibling manifest on disk.
+ * editor has no manifest on disk.
  */
 export class ScriptManifestParticipant implements EditorSessionParticipant {
     constructor(
@@ -36,7 +36,7 @@ export class ScriptManifestParticipant implements EditorSessionParticipant {
         await this.reload(editorId, documentPath);
 
         session.addDisposable(
-            this.manifestSvc.createWatcher(documentPath, () => {
+            await this.manifestSvc.createWatcher(documentPath, () => {
                 void this.reload(editorId, documentPath);
             }),
         );

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -139,7 +139,7 @@ describe("set-style handlers forward the command payload", () => {
 describe("openScriptEditorHandler", () => {
     it("maps every command field to the script-task service, in order", async () => {
         const scriptTaskSvc = { openScriptEditor: vi.fn().mockResolvedValue(undefined) };
-        const variableStore = { set: vi.fn() };
+        const variableStore = { setExtracted: vi.fn() };
 
         await openScriptEditorHandler(scriptTaskSvc as never, variableStore as never)(
             new OpenScriptEditorCommand(
@@ -166,7 +166,7 @@ describe("openScriptEditorHandler", () => {
 
     it("seeds the variable store from the command before opening", async () => {
         const scriptTaskSvc = { openScriptEditor: vi.fn().mockResolvedValue(undefined) };
-        const variableStore = { set: vi.fn() };
+        const variableStore = { setExtracted: vi.fn() };
         const variables = [{ name: "amount", origin: "form field", confidence: "declared" }];
 
         await openScriptEditorHandler(scriptTaskSvc as never, variableStore as never)(
@@ -182,13 +182,13 @@ describe("openScriptEditorHandler", () => {
             EDITOR,
         );
 
-        expect(variableStore.set).toHaveBeenCalledWith(EDITOR, variables);
+        expect(variableStore.setExtracted).toHaveBeenCalledWith(EDITOR, variables);
     });
 });
 
 describe("updateScriptVariablesHandler", () => {
     it("replaces the editor's variable model in the store", () => {
-        const variableStore = { set: vi.fn() };
+        const variableStore = { setExtracted: vi.fn() };
         const variables = [{ name: "total", origin: "output mapping", confidence: "declared" }];
 
         updateScriptVariablesHandler(variableStore as never)(
@@ -196,6 +196,6 @@ describe("updateScriptVariablesHandler", () => {
             EDITOR,
         );
 
-        expect(variableStore.set).toHaveBeenCalledWith(EDITOR, variables);
+        expect(variableStore.setExtracted).toHaveBeenCalledWith(EDITOR, variables);
     });
 });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -142,7 +142,7 @@ export function openScriptEditorHandler(
 ): MessageHandler {
     return async (message: Command, editorId: string) => {
         const cmd = message as OpenScriptEditorCommand;
-        variableStore.set(editorId, cmd.variables ?? []);
+        variableStore.setExtracted(editorId, cmd.variables ?? []);
         await scriptTaskSvc.openScriptEditor(
             editorId,
             cmd.elementId,
@@ -158,7 +158,7 @@ export function openScriptEditorHandler(
 /** `UpdateScriptVariablesCommand` → replace the editor's variable model for live completion. */
 export function updateScriptVariablesHandler(variableStore: ScriptVariableStore): MessageHandler {
     return (message: Command, editorId: string) => {
-        variableStore.set(editorId, (message as UpdateScriptVariablesCommand).variables);
+        variableStore.setExtracted(editorId, (message as UpdateScriptVariablesCommand).variables);
     };
 }
 

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
@@ -42,7 +42,7 @@ const SCRIPT_PATH = `/${HASH}/Task_1/script-task/Task_1.groovy`;
 
 function storeWith(...variables: VariableDef[]): ScriptVariableStore {
     const store = new ScriptVariableStore();
-    store.set(EDITOR, variables);
+    store.setExtracted(EDITOR, variables);
     return store;
 }
 

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -175,7 +175,12 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
 function variableToCompletion(variable: VariableDef): CompletionItem {
     const item = new CompletionItem(variable.name, CompletionItemKind.Variable);
     item.detail = variable.typeHint ?? "process variable";
-    item.documentation = new MarkdownString(variable.origin);
+    // Author-supplied description leads; the heuristic `origin` follows as a
+    // muted line so a manifest variable reads as documentation, not provenance.
+    const docs = variable.description
+        ? `${variable.description}\n\n_${variable.origin}_`
+        : variable.origin;
+    item.documentation = new MarkdownString(docs);
     return item;
 }
 

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -69,8 +69,9 @@ import { VariableDef } from "@miragon/bpmn-modeler-shared";
  * without reopening the script.
  */
 export class ScriptCompletionProvider implements CompletionItemProvider {
-    // Languages this provider participates in.
-    private static readonly LANGUAGES = ["javascript", "groovy", "python", "ruby"] as const;
+    // Languages this provider participates in. Public so the sibling
+    // `ScriptDeclareVariableCodeAction` registers for exactly the same set.
+    static readonly LANGUAGES = ["javascript", "groovy", "python", "ruby"] as const;
 
     constructor(
         private readonly store: ScriptVariableStore,

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptDeclareVariableCodeAction.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptDeclareVariableCodeAction.ts
@@ -1,0 +1,144 @@
+import {
+    CodeAction,
+    CodeActionKind,
+    CodeActionProvider,
+    commands,
+    ExtensionContext,
+    languages,
+    Range,
+    TextDocument,
+    Uri,
+    window,
+} from "vscode";
+
+import {
+    beansFor,
+    parseEditorHashFromUri,
+    parseKindFromUri,
+    ScriptVariableManifestService,
+    ScriptVariableStore,
+} from "@miragon/bpmn-modeler-core";
+import { VsCodeNotifier } from "../../shared/infrastructure/VsCodeNotifier";
+import { ScriptCompletionProvider } from "./ScriptCompletionProvider";
+import { ScriptTaskService } from "./ScriptTaskService";
+
+/**
+ * 💡 quick-fix that scaffolds a `*.bpmn.vars.json` entry for an unknown variable
+ * referenced in an inline script, then opens the manifest so the author can fill
+ * in `type`/`description`. It closes the "dead-metadata trap": a hand-authored
+ * sidecar nobody discovers. The affordance appears exactly where the gap is felt
+ * — editing a script and naming a variable the model doesn't know.
+ *
+ * VS Code has no Groovy/JS parser for these virtual `bpmn-script:` documents, so
+ * "unknown" is a lexical heuristic: the word under the caret looks like an
+ * identifier and is absent from the merged completion set (process variables +
+ * the kind's Camunda beans). Gating to unknown-only — and only as a user-invoked
+ * action — keeps the rare false positive (a script-local variable) acceptable;
+ * the IntelliJ counterpart uses real PSI resolution for precision instead.
+ */
+export class ScriptDeclareVariableCodeAction implements CodeActionProvider {
+    static readonly providedCodeActionKinds = [CodeActionKind.QuickFix];
+
+    // Programmatic command backing the quick-fix. The action can't carry a
+    // WorkspaceEdit because the work is async file IO plus opening the manifest,
+    // which an edit can't express — so it dispatches this command instead.
+    private static readonly COMMAND = "miragon.bpmnModeler.declareScriptVariable";
+
+    // A bare identifier word, so the action never offers on an operator, number,
+    // or string fragment the word-range happens to capture.
+    private static readonly IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+    constructor(
+        private readonly scriptTaskSvc: ScriptTaskService,
+        private readonly store: ScriptVariableStore,
+        private readonly manifestSvc: ScriptVariableManifestService,
+        private readonly notifier: VsCodeNotifier,
+    ) {}
+
+    /**
+     * Registers the provider for every supported script language scoped to the
+     * `bpmn-script` scheme (mirroring {@link ScriptCompletionProvider}) plus the
+     * single command the quick-fix dispatches.
+     */
+    register(context: ExtensionContext): void {
+        for (const language of ScriptCompletionProvider.LANGUAGES) {
+            context.subscriptions.push(
+                languages.registerCodeActionsProvider({ scheme: "bpmn-script", language }, this, {
+                    providedCodeActionKinds:
+                        ScriptDeclareVariableCodeAction.providedCodeActionKinds,
+                }),
+            );
+        }
+        context.subscriptions.push(
+            commands.registerCommand(
+                ScriptDeclareVariableCodeAction.COMMAND,
+                (scriptUri: Uri, name: string) => this.declare(scriptUri, name),
+            ),
+        );
+    }
+
+    provideCodeActions(document: TextDocument, range: Range): CodeAction[] {
+        const wordRange = document.getWordRangeAtPosition(range.start);
+        if (!wordRange) {
+            return [];
+        }
+        const word = document.getText(wordRange);
+        if (
+            !ScriptDeclareVariableCodeAction.IDENTIFIER.test(word) ||
+            this.isKnown(document, word)
+        ) {
+            return [];
+        }
+
+        const action = new CodeAction(
+            `Declare '${word}' in variable manifest`,
+            CodeActionKind.QuickFix,
+        );
+        action.command = {
+            command: ScriptDeclareVariableCodeAction.COMMAND,
+            title: action.title,
+            arguments: [document.uri, word],
+        };
+        return [action];
+    }
+
+    /**
+     * Whether `word` is already a known symbol for this script's editor — a merged
+     * process variable or one of the kind's Camunda beans (`execution`, `task`,
+     * …). Beans are folded in so referencing an in-scope bean never offers a
+     * spurious "declare" action, matching what the author sees in completion.
+     */
+    private isKnown(document: TextDocument, word: string): boolean {
+        const editorHash = parseEditorHashFromUri(document.uri.path) ?? "";
+        if (this.store.getByEditorHash(editorHash).some((variable) => variable.name === word)) {
+            return true;
+        }
+        const kind = parseKindFromUri(document.uri.path);
+        return kind ? beansFor(kind).some((bean) => bean.name === word) : false;
+    }
+
+    /**
+     * Appends `{ name }` to the diagram's manifest and opens it. The editorId is
+     * recovered from the script URI, then converted to an fs path at this host
+     * boundary (the manifest service speaks fs paths); a non-`file:` editor (a
+     * diff pane) has no manifest on disk, so the action is silently skipped. The
+     * session's manifest watcher re-pushes completion on the write — no manual
+     * refresh here.
+     */
+    private async declare(scriptUri: Uri, name: string): Promise<void> {
+        const editorId = this.scriptTaskSvc.getEditorIdForScriptUri(scriptUri.path);
+        if (!editorId) {
+            return;
+        }
+        const editorUri = Uri.parse(editorId);
+        if (editorUri.scheme !== "file") {
+            return;
+        }
+        try {
+            const manifestPath = await this.manifestSvc.upsert(editorUri.fsPath, { name });
+            await window.showTextDocument(Uri.file(manifestPath));
+        } catch (error) {
+            this.notifier.notifyError("Failed to update process-variable manifest", error as Error);
+        }
+    }
+}

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts
@@ -175,6 +175,17 @@ export class ScriptTaskService {
     }
 
     /**
+     * Maps an open script URI path back to its owning BPMN editor id, or
+     * `undefined` if no script is tracked at that path. The "Declare in variable
+     * manifest" code action needs this to resolve which diagram's manifest the
+     * unknown variable belongs to — the script URI itself carries only a one-way
+     * hash of the editor id, not the original document path.
+     */
+    getEditorIdForScriptUri(uriPath: string): string | undefined {
+        return this.openDocuments.get(uriPath)?.editorId;
+    }
+
+    /**
      * Re-sends the current content of every open virtual document for the
      * given editor as `UpdateScriptContentQuery` messages.
      *

--- a/apps/vscode-plugin/webpack.config.js
+++ b/apps/vscode-plugin/webpack.config.js
@@ -78,6 +78,17 @@ module.exports = (env, argv) => {
                         to: "assets",
                     },
                     {
+                        // Single source of truth: the manifest JSON Schema lives in
+                        // libs/shared next to the type it mirrors. Copied (not
+                        // imported) because `contributes.jsonValidation.url` resolves
+                        // it as a file relative to the packaged extension root.
+                        from: path.resolve(
+                            __dirname,
+                            "../../libs/shared/src/lib/variableManifest.schema.json",
+                        ),
+                        to: "schemas/bpmn-vars.schema.json",
+                    },
+                    {
                         from: path.resolve(__dirname, "../../images/miragon-logo.png"),
                         to: "assets",
                         noErrorOnMissing: true,

--- a/docs/vscode/features/inline-scripting.md
+++ b/docs/vscode/features/inline-scripting.md
@@ -175,6 +175,21 @@ diagrams in different folders don't collide. The config folder defaults to
 - The manifest is watched: edits, creation, and deletion update completion
   live while the script editor is open. A malformed manifest is ignored
   (it never breaks completion for the rest of the diagram).
+- A bundled **JSON Schema** is associated with every `*.bpmn.vars.json`
+  file, so editing one gives you completion, hover docs, and validation
+  (e.g. a missing `name` or a misspelled key is flagged) in both VS Code
+  and the standalone IntelliJ-based app — no `$schema` line needed.
+
+#### Declare from the script — the 💡 lightbulb
+
+You don't have to create the manifest by hand. When you reference a
+variable the model doesn't know, put the caret on it and open the
+quick-fix menu (💡, or `Ctrl`/`Cmd`+`.`): **"Declare '&lt;name&gt;' in
+variable manifest"** appends a name-only entry to the diagram's manifest
+and opens that file so you can fill in the `type` and `description`. The
+new variable then appears in completion as an authored entry immediately,
+since the manifest is watched. The same action is available in the
+standalone IntelliJ-based app via `Alt`+`Enter` on a Groovy script tab.
 
 ## Pair with an AI Assistant
 

--- a/docs/vscode/features/inline-scripting.md
+++ b/docs/vscode/features/inline-scripting.md
@@ -129,6 +129,46 @@ scope.
      `setVariable`, `getVariable`, `getProcessBusinessKey`, etc. with their
      signatures visible. -->
 
+### Process-variable completions
+
+Inside a `getVariable("…")` / `setVariable("…")` string argument — and at
+the start of a line — you also get completions for the **process
+variables** the modeler discovered in the diagram. These are inferred
+heuristically from input/output mappings, form fields, result variables,
+call-activity mappings, and `setVariable(…)` / `${…}` occurrences.
+
+### Declaring variables with a `*.bpmn.vars.json` manifest
+
+Heuristic discovery cannot see variables injected from outside the model
+(a REST start payload, a correlated message, a parent process), and it
+cannot carry author-supplied types or documentation. To declare those
+explicitly, drop a manifest next to the diagram named after it with a
+`.vars.json` suffix:
+
+```
+order-process.bpmn
+order-process.bpmn.vars.json
+```
+
+```json
+{
+  "variables": [
+    { "name": "orderId", "type": "String", "description": "Set by the REST start request" },
+    { "name": "amount", "type": "Long" },
+    { "name": "approved" }
+  ]
+}
+```
+
+- `name` is required; `type` and `description` are optional.
+- The `description` is shown in the completion documentation popup.
+- Manifest entries **merge with** the discovered variables and **win** on a
+  name clash, so a declared `type` overrides whatever the heuristic
+  guessed.
+- The manifest is watched: edits, creation, and deletion update completion
+  live while the script editor is open. A malformed manifest is ignored
+  (it never breaks completion for the rest of the diagram).
+
 ## Pair with an AI Assistant
 
 Because the script editor is a real VS Code document, AI assistants that

--- a/docs/vscode/features/inline-scripting.md
+++ b/docs/vscode/features/inline-scripting.md
@@ -142,13 +142,20 @@ call-activity mappings, and `setVariable(…)` / `${…}` occurrences.
 Heuristic discovery cannot see variables injected from outside the model
 (a REST start payload, a correlated message, a parent process), and it
 cannot carry author-supplied types or documentation. To declare those
-explicitly, drop a manifest next to the diagram named after it with a
-`.vars.json` suffix:
+explicitly, add a manifest named after the diagram with a `.vars.json`
+suffix under the config folder's `vars/` subfolder, mirroring the
+diagram's workspace-relative path (the same convention as
+element-templates and code-link):
 
 ```
 order-process.bpmn
-order-process.bpmn.vars.json
+.camunda/vars/order-process.bpmn.vars.json
 ```
+
+A diagram in a subfolder mirrors that path too — `src/order-process.bpmn`
+→ `.camunda/vars/src/order-process.bpmn.vars.json` — so two same-named
+diagrams in different folders don't collide. The config folder defaults to
+`.camunda` and is overridable via `miragon.bpmnModeler.configFolder`.
 
 ```json
 {

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -70,3 +70,6 @@ export * from "./scriptTask/domain/ScriptVariableStore";
 export * from "./scriptTask/domain/scriptApi";
 export * from "./scriptTask/domain/scriptCompletion";
 export * from "./scriptTask/domain/scriptLanguage";
+
+// ── scriptTask: service ──────────────────────────────────────────────────────
+export * from "./scriptTask/service/ScriptVariableManifestService";

--- a/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.spec.ts
@@ -8,14 +8,18 @@ import { ScriptVariableStore } from "./ScriptVariableStore";
 const EDITOR = "file:///work/diagram.bpmn";
 const HASH = ScriptUri.hashEditorId(EDITOR);
 
-function variable(name: string): VariableDef {
-    return { name, origin: "test", confidence: "declared" };
+function extracted(name: string): VariableDef {
+    return { name, origin: "extracted", confidence: "declared" };
+}
+
+function authored(name: string, typeHint?: string): VariableDef {
+    return { name, origin: "manifest", typeHint, confidence: "authored" };
 }
 
 describe("ScriptVariableStore", () => {
-    it("stores variables keyed by the editor hash", () => {
+    it("returns extracted variables keyed by the editor hash", () => {
         const store = new ScriptVariableStore();
-        store.set(EDITOR, [variable("a")]);
+        store.setExtracted(EDITOR, [extracted("a")]);
         expect(store.getByEditorHash(HASH).map((v) => v.name)).toEqual(["a"]);
     });
 
@@ -23,16 +27,45 @@ describe("ScriptVariableStore", () => {
         expect(new ScriptVariableStore().getByEditorHash("unknown")).toEqual([]);
     });
 
-    it("replaces the previous model on set", () => {
+    it("replaces only the extracted source on setExtracted", () => {
         const store = new ScriptVariableStore();
-        store.set(EDITOR, [variable("a")]);
-        store.set(EDITOR, [variable("b")]);
-        expect(store.getByEditorHash(HASH).map((v) => v.name)).toEqual(["b"]);
+        store.setManifest(EDITOR, [authored("m")]);
+        store.setExtracted(EDITOR, [extracted("a")]);
+        store.setExtracted(EDITOR, [extracted("b")]);
+        expect(
+            store
+                .getByEditorHash(HASH)
+                .map((v) => v.name)
+                .sort(),
+        ).toEqual(["b", "m"]);
     });
 
-    it("clears an editor's variables", () => {
+    it("merges manifest and extracted sources", () => {
         const store = new ScriptVariableStore();
-        store.set(EDITOR, [variable("a")]);
+        store.setExtracted(EDITOR, [extracted("a")]);
+        store.setManifest(EDITOR, [authored("b")]);
+        expect(
+            store
+                .getByEditorHash(HASH)
+                .map((v) => v.name)
+                .sort(),
+        ).toEqual(["a", "b"]);
+    });
+
+    it("lets a manifest entry win a name clash with an extracted one", () => {
+        const store = new ScriptVariableStore();
+        store.setExtracted(EDITOR, [extracted("shared")]);
+        store.setManifest(EDITOR, [authored("shared", "Boolean")]);
+        const result = store.getByEditorHash(HASH);
+        expect(result).toHaveLength(1);
+        expect(result[0].typeHint).toBe("Boolean");
+        expect(result[0].confidence).toBe("authored");
+    });
+
+    it("clears both sources", () => {
+        const store = new ScriptVariableStore();
+        store.setExtracted(EDITOR, [extracted("a")]);
+        store.setManifest(EDITOR, [authored("b")]);
         store.clear(EDITOR);
         expect(store.getByEditorHash(HASH)).toEqual([]);
     });

--- a/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.ts
+++ b/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.ts
@@ -9,7 +9,8 @@ import { ScriptUri } from "./ScriptUri";
  *
  * Two sources are kept apart and merged on read: the *extracted* model the
  * webview heuristically derives from the diagram, and the *manifest* model read
- * from a sibling `*.bpmn.vars.json`. They arrive on independent schedules (the
+ * from a `*.bpmn.vars.json` manifest under `<configFolder>/vars/`. They arrive
+ * on independent schedules (the
  * webview on every model edit, the manifest on file change), so storing them
  * separately lets either update without clobbering the other. {@link dedupeVariables}
  * does the merge; the manifest's `authored` tier wins any name clash.

--- a/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.ts
+++ b/libs/modeler-core/src/scriptTask/domain/ScriptVariableStore.ts
@@ -1,4 +1,4 @@
-import { VariableDef } from "@miragon/bpmn-modeler-shared";
+import { dedupeVariables, VariableDef } from "@miragon/bpmn-modeler-shared";
 
 import { ScriptUri } from "./ScriptUri";
 
@@ -7,6 +7,13 @@ import { ScriptUri } from "./ScriptUri";
  * completion provider can serve variable-name suggestions for any inline script
  * opened from that editor.
  *
+ * Two sources are kept apart and merged on read: the *extracted* model the
+ * webview heuristically derives from the diagram, and the *manifest* model read
+ * from a sibling `*.bpmn.vars.json`. They arrive on independent schedules (the
+ * webview on every model edit, the manifest on file change), so storing them
+ * separately lets either update without clobbering the other. {@link dedupeVariables}
+ * does the merge; the manifest's `authored` tier wins any name clash.
+ *
  * Keyed by the one-way {@link ScriptUri.hashEditorId} hash rather than the raw
  * editor id because that hash is the only addressing a `bpmn-script://` URI
  * carries — the provider recovers it from the document path, never the original
@@ -14,20 +21,34 @@ import { ScriptUri } from "./ScriptUri";
  * plugin and the bridge tests drive it directly.
  */
 export class ScriptVariableStore {
-    private readonly byEditorHash = new Map<string, VariableDef[]>();
+    private readonly extractedByEditorHash = new Map<string, VariableDef[]>();
+    private readonly manifestByEditorHash = new Map<string, VariableDef[]>();
 
-    /** Replaces the variable model for an editor (full re-extraction, never merge). */
-    set(editorId: string, variables: VariableDef[]): void {
-        this.byEditorHash.set(ScriptUri.hashEditorId(editorId), variables);
+    /** Replaces the heuristic (webview-extracted) model for an editor. */
+    setExtracted(editorId: string, variables: VariableDef[]): void {
+        this.extractedByEditorHash.set(ScriptUri.hashEditorId(editorId), variables);
     }
 
-    /** Variables for a script URI's editor hash; empty when the editor is unknown. */
+    /** Replaces the manifest (`*.bpmn.vars.json`) model for an editor. */
+    setManifest(editorId: string, variables: VariableDef[]): void {
+        this.manifestByEditorHash.set(ScriptUri.hashEditorId(editorId), variables);
+    }
+
+    /**
+     * Merged variables for a script URI's editor hash; empty when the editor is
+     * unknown. Manifest entries are listed first so their `authored` tier is the
+     * one `dedupeVariables` keeps on a clash — order is intent, not dependence.
+     */
     getByEditorHash(editorHash: string): VariableDef[] {
-        return this.byEditorHash.get(editorHash) ?? [];
+        const manifest = this.manifestByEditorHash.get(editorHash) ?? [];
+        const extracted = this.extractedByEditorHash.get(editorHash) ?? [];
+        return dedupeVariables([...manifest, ...extracted]);
     }
 
-    /** Drops an editor's variables on teardown so closed editors leave no stale completions. */
+    /** Drops both sources on teardown so closed editors leave no stale completions. */
     clear(editorId: string): void {
-        this.byEditorHash.delete(ScriptUri.hashEditorId(editorId));
+        const hash = ScriptUri.hashEditorId(editorId);
+        this.extractedByEditorHash.delete(hash);
+        this.manifestByEditorHash.delete(hash);
     }
 }

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
@@ -45,6 +45,10 @@ class FakeWorkspace implements Partial<WorkspacePort> {
         return content;
     }
 
+    async writeFile(path: string, content: string): Promise<void> {
+        this.files.set(path, content);
+    }
+
     createWatcher(rootPath: string, glob: string, handlers: WatcherHandlers): { dispose(): void } {
         this.lastWatch = { rootPath, glob, handlers };
         return { dispose: this.dispose };
@@ -116,6 +120,58 @@ describe("ScriptVariableManifestService", () => {
         const handle = await service(ws).createWatcher(DOCUMENT, vi.fn());
         handle.dispose();
         expect(ws.dispose).toHaveBeenCalledOnce();
+    });
+
+    describe("upsert", () => {
+        it("creates the manifest under <configFolder>/vars/ when absent and returns its path", async () => {
+            const manifestPath = await service(ws).upsert(DOCUMENT, { name: "orderId" });
+
+            expect(manifestPath).toBe(MANIFEST_PATH);
+            expect(JSON.parse(ws.files.get(MANIFEST_PATH)!)).toEqual({
+                variables: [{ name: "orderId" }],
+            });
+            // Trailing newline so the file is POSIX-clean and diffs minimally.
+            expect(ws.files.get(MANIFEST_PATH)!.endsWith("}\n")).toBe(true);
+        });
+
+        it("appends to an existing manifest, preserving order and unknown fields", async () => {
+            ws.files.set(
+                MANIFEST_PATH,
+                JSON.stringify({
+                    $schema: "./vars.schema.json",
+                    variables: [{ name: "orderId", type: "String" }],
+                }),
+            );
+
+            await service(ws).upsert(DOCUMENT, { name: "amount" });
+
+            expect(JSON.parse(ws.files.get(MANIFEST_PATH)!)).toEqual({
+                $schema: "./vars.schema.json",
+                variables: [{ name: "orderId", type: "String" }, { name: "amount" }],
+            });
+        });
+
+        it("is a no-op when an entry with that name already exists", async () => {
+            ws.files.set(
+                MANIFEST_PATH,
+                JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
+            );
+
+            await service(ws).upsert(DOCUMENT, { name: "orderId" });
+
+            // The existing typed entry must survive untouched (no nameless overwrite).
+            expect(JSON.parse(ws.files.get(MANIFEST_PATH)!)).toEqual({
+                variables: [{ name: "orderId", type: "String" }],
+            });
+        });
+
+        it("propagates a parse error rather than clobbering a malformed manifest", async () => {
+            ws.files.set(MANIFEST_PATH, "{ not json");
+
+            await expect(service(ws).upsert(DOCUMENT, { name: "orderId" })).rejects.toThrow();
+            // The hand-broken content is left intact for the author to fix.
+            expect(ws.files.get(MANIFEST_PATH)).toBe("{ not json");
+        });
     });
 
     // On Windows the host fs path uses backslashes; getDocumentDirectory already

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
@@ -1,0 +1,103 @@
+import { posix } from "path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FileNotFound } from "../../shared/domain/errors";
+import { WorkspacePort } from "../../shared/domain/hostPorts";
+import { ScriptVariableManifestService } from "./ScriptVariableManifestService";
+
+const DOCUMENT = "/work/diagram.bpmn";
+const MANIFEST_PATH = "/work/diagram.bpmn.vars.json";
+
+interface WatcherHandlers {
+    onChange?: (path: string) => void;
+    onCreate?: (path: string) => void;
+    onDelete?: (path: string) => void;
+}
+
+/**
+ * Minimal in-memory {@link WorkspacePort} exercising only the three methods the
+ * service touches (getDocumentDirectory / readFile / createWatcher); the rest
+ * throw so an accidental new dependency surfaces loudly.
+ */
+class FakeWorkspace implements Partial<WorkspacePort> {
+    files = new Map<string, string>();
+    lastWatch?: { rootPath: string; glob: string; handlers: WatcherHandlers };
+    dispose = vi.fn();
+
+    getDocumentDirectory(document: string): string {
+        return posix.dirname(document);
+    }
+
+    async readFile(path: string): Promise<string> {
+        const content = this.files.get(path);
+        if (content === undefined) {
+            throw new FileNotFound(path);
+        }
+        return content;
+    }
+
+    createWatcher(rootPath: string, glob: string, handlers: WatcherHandlers): { dispose(): void } {
+        this.lastWatch = { rootPath, glob, handlers };
+        return { dispose: this.dispose };
+    }
+}
+
+function service(ws: FakeWorkspace): ScriptVariableManifestService {
+    return new ScriptVariableManifestService(ws as unknown as WorkspacePort);
+}
+
+describe("ScriptVariableManifestService", () => {
+    let ws: FakeWorkspace;
+
+    beforeEach(() => {
+        ws = new FakeWorkspace();
+    });
+
+    it("loads the sibling manifest as authored variables", async () => {
+        ws.files.set(
+            MANIFEST_PATH,
+            JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
+        );
+
+        const vars = await service(ws).load(DOCUMENT);
+
+        expect(vars).toEqual([
+            {
+                name: "orderId",
+                origin: "declared in diagram.bpmn.vars.json",
+                typeHint: "String",
+                description: undefined,
+                confidence: "authored",
+            },
+        ]);
+    });
+
+    it("returns [] when the manifest is absent", async () => {
+        expect(await service(ws).load(DOCUMENT)).toEqual([]);
+    });
+
+    it("returns [] for a malformed manifest rather than throwing", async () => {
+        ws.files.set(MANIFEST_PATH, "{ not json");
+        expect(await service(ws).load(DOCUMENT)).toEqual([]);
+    });
+
+    it("watches the document directory for the manifest filename", () => {
+        const onChange = vi.fn();
+        service(ws).createWatcher(DOCUMENT, onChange);
+
+        expect(ws.lastWatch?.rootPath).toBe("/work");
+        expect(ws.lastWatch?.glob).toBe("diagram.bpmn.vars.json");
+
+        ws.lastWatch?.handlers.onCreate?.(MANIFEST_PATH);
+        ws.lastWatch?.handlers.onChange?.(MANIFEST_PATH);
+        ws.lastWatch?.handlers.onDelete?.(MANIFEST_PATH);
+        expect(onChange).toHaveBeenCalledTimes(3);
+    });
+
+    it("disposes the underlying watcher handle", () => {
+        const handle = service(ws).createWatcher(DOCUMENT, vi.fn());
+        handle.dispose();
+        expect(ws.dispose).toHaveBeenCalledOnce();
+    });
+});

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
@@ -100,4 +100,44 @@ describe("ScriptVariableManifestService", () => {
         handle.dispose();
         expect(ws.dispose).toHaveBeenCalledOnce();
     });
+
+    // On Windows the host fs path uses backslashes; getDocumentDirectory already
+    // normalizes to posix, so the manifest basename must not be derived from a raw
+    // posix.basename of the backslash path (which would return the whole string).
+    describe("with a Windows-style backslash document path", () => {
+        const WINDOWS_DOCUMENT = "C:\\work\\diagram.bpmn";
+        const WINDOWS_MANIFEST_PATH = "C:/work/diagram.bpmn.vars.json";
+
+        beforeEach(() => {
+            // getDocumentDirectory is robust (normalizes to posix) — only the
+            // basename split regressed, so model the realistic posix directory.
+            ws.getDocumentDirectory = () => "C:/work";
+        });
+
+        it("computes the manifest filename from the normalized path", async () => {
+            ws.files.set(
+                WINDOWS_MANIFEST_PATH,
+                JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
+            );
+
+            const vars = await service(ws).load(WINDOWS_DOCUMENT);
+
+            expect(vars).toEqual([
+                {
+                    name: "orderId",
+                    origin: "declared in diagram.bpmn.vars.json",
+                    typeHint: "String",
+                    description: undefined,
+                    confidence: "authored",
+                },
+            ]);
+        });
+
+        it("scopes the watcher glob to the bare manifest filename", () => {
+            service(ws).createWatcher(WINDOWS_DOCUMENT, vi.fn());
+
+            expect(ws.lastWatch?.rootPath).toBe("C:/work");
+            expect(ws.lastWatch?.glob).toBe("diagram.bpmn.vars.json");
+        });
+    });
 });

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
@@ -3,11 +3,12 @@ import { posix } from "path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FileNotFound } from "../../shared/domain/errors";
-import { WorkspacePort } from "../../shared/domain/hostPorts";
+import { SettingsPort, WorkspacePort } from "../../shared/domain/hostPorts";
+import { ArtifactService } from "../../shared/service/ArtifactService";
 import { ScriptVariableManifestService } from "./ScriptVariableManifestService";
 
 const DOCUMENT = "/work/diagram.bpmn";
-const MANIFEST_PATH = "/work/diagram.bpmn.vars.json";
+const MANIFEST_PATH = "/work/.camunda/vars/diagram.bpmn.vars.json";
 
 interface WatcherHandlers {
     onChange?: (path: string) => void;
@@ -16,9 +17,10 @@ interface WatcherHandlers {
 }
 
 /**
- * Minimal in-memory {@link WorkspacePort} exercising only the three methods the
- * service touches (getDocumentDirectory / readFile / createWatcher); the rest
- * throw so an accidental new dependency surfaces loudly.
+ * Minimal in-memory {@link WorkspacePort} exercising only the methods the
+ * service and a real {@link ArtifactService} touch (getDocumentDirectory /
+ * getWorkspaceFolderForDocument / readFile / createWatcher); the rest throw so
+ * an accidental new dependency surfaces loudly.
  */
 class FakeWorkspace implements Partial<WorkspacePort> {
     files = new Map<string, string>();
@@ -27,6 +29,12 @@ class FakeWorkspace implements Partial<WorkspacePort> {
 
     getDocumentDirectory(document: string): string {
         return posix.dirname(document);
+    }
+
+    // In these tests the document directory *is* the workspace root, so the real
+    // ArtifactService resolves the root by echoing back what it is handed.
+    getWorkspaceFolderForDocument(document: string): string {
+        return document;
     }
 
     async readFile(path: string): Promise<string> {
@@ -43,8 +51,15 @@ class FakeWorkspace implements Partial<WorkspacePort> {
     }
 }
 
+const FAKE_SETTINGS = { getConfigFolder: () => ".camunda" } as unknown as SettingsPort;
+
 function service(ws: FakeWorkspace): ScriptVariableManifestService {
-    return new ScriptVariableManifestService(ws as unknown as WorkspacePort);
+    const artifactSvc = new ArtifactService(ws as unknown as WorkspacePort, FAKE_SETTINGS);
+    return new ScriptVariableManifestService(
+        ws as unknown as WorkspacePort,
+        FAKE_SETTINGS,
+        artifactSvc,
+    );
 }
 
 describe("ScriptVariableManifestService", () => {
@@ -54,7 +69,7 @@ describe("ScriptVariableManifestService", () => {
         ws = new FakeWorkspace();
     });
 
-    it("loads the sibling manifest as authored variables", async () => {
+    it("loads the manifest under <configFolder>/vars/ as authored variables", async () => {
         ws.files.set(
             MANIFEST_PATH,
             JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
@@ -82,12 +97,14 @@ describe("ScriptVariableManifestService", () => {
         expect(await service(ws).load(DOCUMENT)).toEqual([]);
     });
 
-    it("watches the document directory for the manifest filename", () => {
+    it("watches the config folder for the manifest path", async () => {
         const onChange = vi.fn();
-        service(ws).createWatcher(DOCUMENT, onChange);
+        await service(ws).createWatcher(DOCUMENT, onChange);
 
         expect(ws.lastWatch?.rootPath).toBe("/work");
-        expect(ws.lastWatch?.glob).toBe("diagram.bpmn.vars.json");
+        // `**/` prefix is required for the chokidar adapter to match the absolute
+        // manifest path; VS Code matches root-relative either way.
+        expect(ws.lastWatch?.glob).toBe("**/.camunda/vars/diagram.bpmn.vars.json");
 
         ws.lastWatch?.handlers.onCreate?.(MANIFEST_PATH);
         ws.lastWatch?.handlers.onChange?.(MANIFEST_PATH);
@@ -95,18 +112,19 @@ describe("ScriptVariableManifestService", () => {
         expect(onChange).toHaveBeenCalledTimes(3);
     });
 
-    it("disposes the underlying watcher handle", () => {
-        const handle = service(ws).createWatcher(DOCUMENT, vi.fn());
+    it("disposes the underlying watcher handle", async () => {
+        const handle = await service(ws).createWatcher(DOCUMENT, vi.fn());
         handle.dispose();
         expect(ws.dispose).toHaveBeenCalledOnce();
     });
 
     // On Windows the host fs path uses backslashes; getDocumentDirectory already
-    // normalizes to posix, so the manifest basename must not be derived from a raw
-    // posix.basename of the backslash path (which would return the whole string).
+    // normalizes to posix, so the workspace-relative path must be derived from
+    // that normalized directory, not a raw posix split of the backslash path
+    // (which would return the whole string and yield a garbage relative path).
     describe("with a Windows-style backslash document path", () => {
         const WINDOWS_DOCUMENT = "C:\\work\\diagram.bpmn";
-        const WINDOWS_MANIFEST_PATH = "C:/work/diagram.bpmn.vars.json";
+        const WINDOWS_MANIFEST_PATH = "C:/work/.camunda/vars/diagram.bpmn.vars.json";
 
         beforeEach(() => {
             // getDocumentDirectory is robust (normalizes to posix) — only the
@@ -114,7 +132,7 @@ describe("ScriptVariableManifestService", () => {
             ws.getDocumentDirectory = () => "C:/work";
         });
 
-        it("computes the manifest filename from the normalized path", async () => {
+        it("computes the manifest path from the normalized relative path", async () => {
             ws.files.set(
                 WINDOWS_MANIFEST_PATH,
                 JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
@@ -133,11 +151,13 @@ describe("ScriptVariableManifestService", () => {
             ]);
         });
 
-        it("scopes the watcher glob to the bare manifest filename", () => {
-            service(ws).createWatcher(WINDOWS_DOCUMENT, vi.fn());
+        it("scopes the watcher glob to the relative manifest path, not garbage", async () => {
+            await service(ws).createWatcher(WINDOWS_DOCUMENT, vi.fn());
 
             expect(ws.lastWatch?.rootPath).toBe("C:/work");
-            expect(ws.lastWatch?.glob).toBe("diagram.bpmn.vars.json");
+            // Relative path is clean (`diagram.bpmn.vars.json`), proving the path
+            // is computed in posix space rather than from the backslash raw path.
+            expect(ws.lastWatch?.glob).toBe("**/.camunda/vars/diagram.bpmn.vars.json");
         });
     });
 });

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
@@ -1,0 +1,67 @@
+import { posix } from "path";
+
+import { parseVariableManifest, VariableDef } from "@miragon/bpmn-modeler-shared";
+
+import { FileNotFound } from "../../shared/domain/errors";
+import { WorkspacePort } from "../../shared/domain/hostPorts";
+
+/**
+ * Reads (and watches) the `*.bpmn.vars.json` manifest that may sit next to a
+ * diagram, turning it into the `authored`-tier variable model that overrides
+ * heuristic extraction. Both hosts reuse it because it depends only on the
+ * shared {@link WorkspacePort}; the merge with extracted variables happens in
+ * the caller (the VS Code store / the bridge editor) via `dedupeVariables`.
+ *
+ * The service speaks the port's plain-fs-path vocabulary, not editor URIs: the
+ * two {@link WorkspacePort} adapters disagree on scheme handling (VS Code reads
+ * via `Uri.file`, expecting a bare path; the bridge strips `file://` itself), so
+ * each host converts its editor URI to an fs path at the boundary — which is
+ * also where the `file:`-scheme guard belongs, since a `git:`/`untitled:` diff
+ * editor has no sibling on disk.
+ */
+export class ScriptVariableManifestService {
+    constructor(private readonly workspace: WorkspacePort) {}
+
+    /**
+     * Loads `<documentPath>.vars.json` as authored variables. Returns `[]` when
+     * the manifest is absent so a diagram without one is indistinguishable from
+     * one with an empty manifest. A malformed manifest yields `[]` from
+     * {@link parseVariableManifest} (never throws); only unexpected read errors
+     * propagate, so the host can surface them.
+     */
+    async load(documentPath: string): Promise<VariableDef[]> {
+        const manifestPath = this.manifestPathFor(documentPath);
+        let jsonText: string;
+        try {
+            jsonText = await this.workspace.readFile(manifestPath);
+        } catch (error) {
+            if (error instanceof FileNotFound) {
+                return [];
+            }
+            throw error;
+        }
+        return parseVariableManifest(jsonText, posix.basename(manifestPath));
+    }
+
+    /**
+     * Watches the document directory for create/change/delete of the manifest
+     * and fires `onChange` so the caller can reload + re-merge. Scoped to the
+     * exact manifest filename so edits to a sibling diagram's manifest don't
+     * trigger a needless reload.
+     */
+    createWatcher(documentPath: string, onChange: () => void): { dispose(): void } {
+        const directory = this.workspace.getDocumentDirectory(documentPath);
+        const glob = posix.basename(this.manifestPathFor(documentPath));
+        return this.workspace.createWatcher(directory, glob, {
+            onCreate: () => onChange(),
+            onChange: () => onChange(),
+            onDelete: () => onChange(),
+        });
+    }
+
+    /** `foo.bpmn` → `<dir>/foo.bpmn.vars.json`, in the port's fs-path space. */
+    private manifestPathFor(documentPath: string): string {
+        const directory = this.workspace.getDocumentDirectory(documentPath);
+        return posix.join(directory, `${posix.basename(documentPath)}.vars.json`);
+    }
+}

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
@@ -3,34 +3,49 @@ import { posix } from "path";
 import { parseVariableManifest, VariableDef } from "@miragon/bpmn-modeler-shared";
 
 import { FileNotFound } from "../../shared/domain/errors";
-import { WorkspacePort } from "../../shared/domain/hostPorts";
+import { SettingsPort, WorkspacePort } from "../../shared/domain/hostPorts";
+import { ArtifactService } from "../../shared/service/ArtifactService";
+
+const VARS_DIR = "vars";
 
 /**
- * Reads (and watches) the `*.bpmn.vars.json` manifest that may sit next to a
- * diagram, turning it into the `authored`-tier variable model that overrides
- * heuristic extraction. Both hosts reuse it because it depends only on the
- * shared {@link WorkspacePort}; the merge with extracted variables happens in
- * the caller (the VS Code store / the bridge editor) via `dedupeVariables`.
+ * Reads (and watches) the `*.bpmn.vars.json` process-variable manifest, turning
+ * it into the `authored`-tier variable model that overrides heuristic
+ * extraction. Both hosts reuse it because it depends only on the shared
+ * {@link WorkspacePort}/{@link SettingsPort} and {@link ArtifactService}; the
+ * merge with extracted variables happens in the caller (the VS Code store / the
+ * bridge editor) via `dedupeVariables`.
+ *
+ * The manifest lives under `<configFolder>/vars/<relativeBpmnPath>.vars.json`
+ * (e.g. `src/order.bpmn` → `.camunda/vars/src/order.bpmn.vars.json`) rather than
+ * beside the diagram. This declutters the diagram folder and mirrors the
+ * code-link convention ({@link ArtifactService}/`CodeLinkMapService`): the
+ * workspace-relative path is preserved so two same-named diagrams in different
+ * folders don't collide.
  *
  * The service speaks the port's plain-fs-path vocabulary, not editor URIs: the
  * two {@link WorkspacePort} adapters disagree on scheme handling (VS Code reads
  * via `Uri.file`, expecting a bare path; the bridge strips `file://` itself), so
  * each host converts its editor URI to an fs path at the boundary — which is
  * also where the `file:`-scheme guard belongs, since a `git:`/`untitled:` diff
- * editor has no sibling on disk.
+ * editor has no manifest on disk.
  */
 export class ScriptVariableManifestService {
-    constructor(private readonly workspace: WorkspacePort) {}
+    constructor(
+        private readonly workspace: WorkspacePort,
+        private readonly settings: SettingsPort,
+        private readonly artifactSvc: ArtifactService,
+    ) {}
 
     /**
-     * Loads `<documentPath>.vars.json` as authored variables. Returns `[]` when
-     * the manifest is absent so a diagram without one is indistinguishable from
-     * one with an empty manifest. A malformed manifest yields `[]` from
+     * Loads the diagram's manifest as authored variables. Returns `[]` when the
+     * manifest is absent so a diagram without one is indistinguishable from one
+     * with an empty manifest. A malformed manifest yields `[]` from
      * {@link parseVariableManifest} (never throws); only unexpected read errors
      * propagate, so the host can surface them.
      */
     async load(documentPath: string): Promise<VariableDef[]> {
-        const manifestPath = this.manifestPathFor(documentPath);
+        const manifestPath = await this.manifestPathFor(documentPath);
         let jsonText: string;
         try {
             jsonText = await this.workspace.readFile(manifestPath);
@@ -40,34 +55,51 @@ export class ScriptVariableManifestService {
             }
             throw error;
         }
+        // The origin label uses the bare manifest basename, unchanged by the
+        // relocation (`order.bpmn.vars.json`), so origin strings stay stable.
         return parseVariableManifest(jsonText, posix.basename(manifestPath));
     }
 
     /**
-     * Watches the document directory for create/change/delete of the manifest
-     * and fires `onChange` so the caller can reload + re-merge. Scoped to the
-     * exact manifest filename so edits to a sibling diagram's manifest don't
+     * Watches the config folder for create/change/delete of this diagram's
+     * manifest and fires `onChange` so the caller can reload + re-merge. Scoped
+     * to the exact manifest path so edits to another diagram's manifest don't
      * trigger a needless reload.
      */
-    createWatcher(documentPath: string, onChange: () => void): { dispose(): void } {
-        const directory = this.workspace.getDocumentDirectory(documentPath);
-        const glob = posix.basename(this.manifestPathFor(documentPath));
-        return this.workspace.createWatcher(directory, glob, {
+    async createWatcher(documentPath: string, onChange: () => void): Promise<{ dispose(): void }> {
+        const documentDir = this.workspace.getDocumentDirectory(documentPath);
+        const workspaceRoot = await this.artifactSvc.getWorkspaceRoot(documentDir);
+        const manifestPath = await this.manifestPathFor(documentPath);
+        // The chokidar/node adapter anchors the glob (`^…$`) and matches against
+        // absolute paths, so a root-relative glob must be prefixed `**/` to match
+        // the bridge the same way VS Code does (the template watcher does the same).
+        const glob = `**/${posix.relative(workspaceRoot, manifestPath)}`;
+        return this.workspace.createWatcher(workspaceRoot, glob, {
             onCreate: () => onChange(),
             onChange: () => onChange(),
             onDelete: () => onChange(),
         });
     }
 
-    /** `foo.bpmn` → `<dir>/foo.bpmn.vars.json`, in the port's fs-path space. */
-    private manifestPathFor(documentPath: string): string {
-        const directory = this.workspace.getDocumentDirectory(documentPath);
-        // Host fs paths aren't guaranteed posix: on Windows both VS Code's
-        // `uri.fsPath` and the bridge `fsPath` use backslashes, so a raw
-        // `posix.basename` would return the whole string and the computed
-        // manifest path (and watcher glob) would never match. Normalize
-        // separators first — `getDocumentDirectory` already does the equivalent.
+    /**
+     * `<root>/src/foo.bpmn` → `<root>/<configFolder>/vars/src/foo.bpmn.vars.json`,
+     * mirroring the diagram's workspace-relative path under the config folder.
+     */
+    private async manifestPathFor(documentPath: string): Promise<string> {
+        // Compute everything in the `uri.path` space `getDocumentDirectory`
+        // returns: on Windows the raw `documentPath` is `fsPath` (`c:\a\b`) while
+        // the directory is `uri.path` (`/c:/a/b`), so a relative path derived
+        // from the raw path would be garbage. Take the basename from the
+        // normalized path and join it onto the directory.
+        const documentDir = this.workspace.getDocumentDirectory(documentPath);
+        const workspaceRoot = await this.artifactSvc.getWorkspaceRoot(documentDir);
         const fileName = posix.basename(documentPath.replace(/\\/g, "/"));
-        return posix.join(directory, `${fileName}.vars.json`);
+        const relBpmn = posix.relative(workspaceRoot, posix.join(documentDir, fileName));
+        return posix.join(
+            workspaceRoot,
+            this.settings.getConfigFolder(),
+            VARS_DIR,
+            `${relBpmn}.vars.json`,
+        );
     }
 }

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
@@ -62,6 +62,12 @@ export class ScriptVariableManifestService {
     /** `foo.bpmn` → `<dir>/foo.bpmn.vars.json`, in the port's fs-path space. */
     private manifestPathFor(documentPath: string): string {
         const directory = this.workspace.getDocumentDirectory(documentPath);
-        return posix.join(directory, `${posix.basename(documentPath)}.vars.json`);
+        // Host fs paths aren't guaranteed posix: on Windows both VS Code's
+        // `uri.fsPath` and the bridge `fsPath` use backslashes, so a raw
+        // `posix.basename` would return the whole string and the computed
+        // manifest path (and watcher glob) would never match. Normalize
+        // separators first — `getDocumentDirectory` already does the equivalent.
+        const fileName = posix.basename(documentPath.replace(/\\/g, "/"));
+        return posix.join(directory, `${fileName}.vars.json`);
     }
 }

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
@@ -1,6 +1,11 @@
 import { posix } from "path";
 
-import { parseVariableManifest, VariableDef } from "@miragon/bpmn-modeler-shared";
+import {
+    parseVariableManifest,
+    VariableDef,
+    VariableManifest,
+    VariableManifestEntry,
+} from "@miragon/bpmn-modeler-shared";
 
 import { FileNotFound } from "../../shared/domain/errors";
 import { SettingsPort, WorkspacePort } from "../../shared/domain/hostPorts";
@@ -58,6 +63,57 @@ export class ScriptVariableManifestService {
         // The origin label uses the bare manifest basename, unchanged by the
         // relocation (`order.bpmn.vars.json`), so origin strings stay stable.
         return parseVariableManifest(jsonText, posix.basename(manifestPath));
+    }
+
+    /**
+     * Appends a name-only (or fully authored) entry to the diagram's manifest,
+     * creating the file if absent, and returns the resolved manifest path so the
+     * caller can open/reveal it for the author to fill in `type`/`description`.
+     *
+     * The raw on-disk JSON is round-tripped — parsed to the {@link VariableManifest}
+     * shape rather than lowered through {@link parseVariableManifest} — so existing
+     * entries keep their order and any unknown fields survive the rewrite. A
+     * duplicate `name` is a no-op (the manifest watcher still won't re-fire on an
+     * unchanged write, but skipping the push keeps the file byte-stable). A
+     * malformed existing manifest propagates the parse error rather than silently
+     * clobbering hand-edited content the author would lose.
+     */
+    async upsert(documentPath: string, entry: VariableManifestEntry): Promise<string> {
+        const manifestPath = await this.manifestPathFor(documentPath);
+        const manifest = await this.readRawManifest(manifestPath);
+
+        if (!manifest.variables.some((existing) => existing.name === entry.name)) {
+            manifest.variables.push(entry);
+        }
+
+        await this.workspace.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+        return manifestPath;
+    }
+
+    /**
+     * Reads the manifest as its mutable on-disk shape: an absent file starts from
+     * an empty manifest; a present one keeps every top-level field (spread) so an
+     * `upsert` only ever appends to `variables`. `variables` is coerced to an
+     * array so a manifest that omits the key (or sets it to a non-array) still
+     * accepts the new entry.
+     */
+    private async readRawManifest(
+        manifestPath: string,
+    ): Promise<VariableManifest & { variables: VariableManifestEntry[] }> {
+        let jsonText: string;
+        try {
+            jsonText = await this.workspace.readFile(manifestPath);
+        } catch (error) {
+            if (error instanceof FileNotFound) {
+                return { variables: [] };
+            }
+            throw error;
+        }
+        const parsed = JSON.parse(jsonText) as Partial<VariableManifest> & Record<string, unknown>;
+        return {
+            ...parsed,
+            variables: Array.isArray(parsed.variables) ? [...parsed.variables] : [],
+        };
     }
 
     /**

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -7,4 +7,5 @@ export * from "./lib/modeler";
 export * from "./lib/theme";
 export * from "./lib/propertiesPanelResizer";
 export * from "./lib/processVariables";
+export * from "./lib/variableManifest";
 export * from "./lib/bpmnFlowOrder";

--- a/libs/shared/src/lib/processVariables.spec.ts
+++ b/libs/shared/src/lib/processVariables.spec.ts
@@ -293,4 +293,29 @@ describe("dedupeVariables", () => {
         expect(deduped).toHaveLength(1);
         expect(deduped[0].typeHint).toBe("String");
     });
+
+    it("lets an authored entry win over a declared one regardless of order", () => {
+        const authored = {
+            name: "x",
+            origin: "declared in foo.bpmn.vars.json",
+            typeHint: "Boolean",
+            confidence: "authored" as const,
+        };
+        const declared = { name: "x", origin: "form field", confidence: "declared" as const };
+
+        expect(dedupeVariables([authored, declared])[0]).toEqual(authored);
+        expect(dedupeVariables([declared, authored])[0]).toEqual(authored);
+    });
+
+    it("lets an authored entry win even when it has no type and the rival is typed", () => {
+        const authored = { name: "x", origin: "manifest", confidence: "authored" as const };
+        const declaredTyped = {
+            name: "x",
+            origin: "form field",
+            typeHint: "String",
+            confidence: "declared" as const,
+        };
+
+        expect(dedupeVariables([declaredTyped, authored])[0]).toEqual(authored);
+    });
 });

--- a/libs/shared/src/lib/processVariables.ts
+++ b/libs/shared/src/lib/processVariables.ts
@@ -11,25 +11,32 @@
  * `getDefinitions()` — so the same code runs in the webview and against
  * object-literal fixtures in tests.
  *
- * Two confidence tiers drive how aggressively a name is surfaced: a `declared`
- * variable has a concrete producer (an output mapping, a result variable, a
- * form field, a `setVariable` call) and outranks a merely `referenced` one
- * (seen only inside a `${...}` read), which might be a typo or a variable
- * injected from outside the model.
+ * Three confidence tiers drive how aggressively a name is surfaced. An
+ * `authored` variable comes from an explicit `*.bpmn.vars.json` manifest the
+ * author wrote next to the diagram and outranks everything — the manifest is
+ * authoritative, so it always wins a name clash regardless of type. Below it, a
+ * `declared` variable has a concrete producer (an output mapping, a result
+ * variable, a form field, a `setVariable` call) and outranks a merely
+ * `referenced` one (seen only inside a `${...}` read), which might be a typo or
+ * a variable injected from outside the model.
  */
 
-export type VariableConfidence = "declared" | "referenced";
+export type VariableConfidence = "authored" | "declared" | "referenced";
 
 /**
- * A single process variable discovered from static model evidence.
+ * A single process variable discovered from static model evidence or declared
+ * in a `*.bpmn.vars.json` manifest.
  *
  * {@link origin} is human-facing (shown in completion docs) and names the
  * element + evidence kind so the author can trace where a suggestion came from.
+ * {@link description} is the author-supplied doc carried only by `authored`
+ * (manifest) entries; it is surfaced alongside the origin in completion docs.
  */
 export interface VariableDef {
     readonly name: string;
     readonly origin: string;
     readonly typeHint?: string;
+    readonly description?: string;
     readonly confidence: VariableConfidence;
 }
 
@@ -124,10 +131,11 @@ export function collectExpressionRefs(expression: string): string[] {
 }
 
 /**
- * Collapses duplicate names to one entry each, with `declared` evidence winning
- * over `referenced` (a concrete producer beats a bare read), and — among equal
- * confidence — a typed entry winning over an untyped one. Order of first
- * appearance is otherwise preserved so the completion list stays stable.
+ * Collapses duplicate names to one entry each, ranked by confidence tier
+ * (`authored` > `declared` > `referenced`) and — among equal tier — a typed
+ * entry winning over an untyped one. An `authored` manifest entry therefore
+ * always wins a clash against heuristic evidence. Order of first appearance is
+ * otherwise preserved so the completion list stays stable.
  */
 export function dedupeVariables(vars: VariableDef[]): VariableDef[] {
     const byName = new Map<string, VariableDef>();
@@ -138,10 +146,20 @@ export function dedupeVariables(vars: VariableDef[]): VariableDef[] {
     return [...byName.values()];
 }
 
+// Higher rank wins. Listed top-down so the ordinal mirrors the doc's
+// `authored` > `declared` > `referenced` precedence.
+const CONFIDENCE_RANK: Record<VariableConfidence, number> = {
+    authored: 2,
+    declared: 1,
+    referenced: 0,
+};
+
 /** Picks the stronger of two same-named variable definitions. */
 function preferred(a: VariableDef, b: VariableDef): VariableDef {
-    if (a.confidence !== b.confidence) {
-        return a.confidence === "declared" ? a : b;
+    const rankA = CONFIDENCE_RANK[a.confidence];
+    const rankB = CONFIDENCE_RANK[b.confidence];
+    if (rankA !== rankB) {
+        return rankA > rankB ? a : b;
     }
     if (a.typeHint && !b.typeHint) {
         return a;

--- a/libs/shared/src/lib/variableManifest.schema.json
+++ b/libs/shared/src/lib/variableManifest.schema.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://miragon.io/schemas/bpmn-vars.schema.json",
+    "title": "BPMN process-variable manifest",
+    "description": "Declares process variables for a BPMN diagram's inline scripts. Lives at <configFolder>/vars/<relativeBpmnPath>.bpmn.vars.json and is merged on top of the heuristic variable discovery (authored entries win a name clash).",
+    "type": "object",
+    "required": ["variables"],
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "Optional JSON Schema reference. The modeler already associates this schema by file name, so this is only needed for editors that don't."
+        },
+        "variables": {
+            "type": "array",
+            "description": "The declared process variables. Each entry adds (or overrides, on a name clash) a variable offered in inline-script completion.",
+            "items": { "$ref": "#/definitions/variable" }
+        }
+    },
+    "definitions": {
+        "variable": {
+            "type": "object",
+            "required": ["name"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The variable name as referenced in scripts (e.g. execution.getVariable(\"orderId\")). Required."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Optional author type hint, shown in completion. A few hints (e.g. SpinJsonNode) also drive member completion; otherwise any label is fine (String, Long, Boolean, ...).",
+                    "examples": ["String", "Long", "Boolean", "Date", "Object", "SpinJsonNode"]
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional human-readable documentation, shown in the completion popup."
+                }
+            }
+        }
+    }
+}

--- a/libs/shared/src/lib/variableManifest.spec.ts
+++ b/libs/shared/src/lib/variableManifest.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { parseVariableManifest } from "./variableManifest";
+
+const MANIFEST = "diagram.bpmn.vars.json";
+
+describe("parseVariableManifest", () => {
+    it("maps entries to authored variables with name, type, and description", () => {
+        const vars = parseVariableManifest(
+            JSON.stringify({
+                variables: [
+                    { name: "orderId", type: "String", description: "Set by REST start" },
+                ],
+            }),
+            MANIFEST,
+        );
+
+        expect(vars).toEqual([
+            {
+                name: "orderId",
+                origin: `declared in ${MANIFEST}`,
+                typeHint: "String",
+                description: "Set by REST start",
+                confidence: "authored",
+            },
+        ]);
+    });
+
+    it("leaves typeHint and description undefined when omitted or empty", () => {
+        const vars = parseVariableManifest(
+            JSON.stringify({ variables: [{ name: "amount", type: "", description: "" }] }),
+            MANIFEST,
+        );
+
+        expect(vars[0].typeHint).toBeUndefined();
+        expect(vars[0].description).toBeUndefined();
+        expect(vars[0].confidence).toBe("authored");
+    });
+
+    it("skips entries with a missing or empty name", () => {
+        const vars = parseVariableManifest(
+            JSON.stringify({ variables: [{ name: "" }, { type: "String" }, { name: "keep" }] }),
+            MANIFEST,
+        );
+
+        expect(vars.map((v) => v.name)).toEqual(["keep"]);
+    });
+
+    it("returns [] on invalid JSON rather than throwing", () => {
+        expect(parseVariableManifest("{ not json", MANIFEST)).toEqual([]);
+    });
+
+    it("returns [] when variables is missing or not an array", () => {
+        expect(parseVariableManifest(JSON.stringify({}), MANIFEST)).toEqual([]);
+        expect(parseVariableManifest(JSON.stringify({ variables: 42 }), MANIFEST)).toEqual([]);
+        expect(parseVariableManifest(JSON.stringify([]), MANIFEST)).toEqual([]);
+    });
+});

--- a/libs/shared/src/lib/variableManifest.ts
+++ b/libs/shared/src/lib/variableManifest.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure, dependency-free parser for a `*.bpmn.vars.json` manifest — the explicit,
+ * author-written override that sits next to a diagram and declares process
+ * variables the heuristic extraction (see {@link import("./processVariables")})
+ * can't see: variables injected from outside the model (REST start, message
+ * correlation, a parent process) plus author-supplied types and docs.
+ *
+ * The parser deliberately never throws. A malformed or hand-edited manifest must
+ * not break completion for the whole diagram, so any structural problem (bad
+ * JSON, a non-array `variables`) degrades to an empty result; the host boundary
+ * is where the read error is surfaced to the author, not here.
+ */
+
+import { VariableDef } from "./processVariables";
+
+/** A single declared variable in a `*.bpmn.vars.json` manifest. */
+export interface VariableManifestEntry {
+    readonly name: string;
+    readonly type?: string;
+    readonly description?: string;
+}
+
+/** The on-disk shape of a `*.bpmn.vars.json` manifest. */
+export interface VariableManifest {
+    readonly variables: VariableManifestEntry[];
+}
+
+/**
+ * Parses a `*.bpmn.vars.json` manifest into `authored`-tier {@link VariableDef}s.
+ *
+ * Entries with a missing/empty `name` are skipped (a nameless variable can't be
+ * completed). `manifestName` names the source file in each entry's `origin` so
+ * completion docs can trace the suggestion back to the manifest. Returns `[]` on
+ * any parse/shape error — never throws (see the file doc).
+ */
+export function parseVariableManifest(jsonText: string, manifestName: string): VariableDef[] {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(jsonText);
+    } catch {
+        return [];
+    }
+
+    const variables = (parsed as Partial<VariableManifest> | null)?.variables;
+    if (!Array.isArray(variables)) {
+        return [];
+    }
+
+    const out: VariableDef[] = [];
+    for (const entry of variables) {
+        const name = (entry as VariableManifestEntry)?.name;
+        if (typeof name !== "string" || !name) {
+            continue;
+        }
+        const type = (entry as VariableManifestEntry).type;
+        const description = (entry as VariableManifestEntry).description;
+        out.push({
+            name,
+            origin: `declared in ${manifestName}`,
+            typeHint: typeof type === "string" && type ? type : undefined,
+            description:
+                typeof description === "string" && description ? description : undefined,
+            confidence: "authored",
+        });
+    }
+    return out;
+}


### PR DESCRIPTION
**Issue**

Closes: #1117

**Description**

Adds an explicit, authoritative `*.bpmn.vars.json` manifest that sits next to a diagram (`foo.bpmn` → `foo.bpmn.vars.json`) and declares process variables the heuristic extractor can't see — variables injected from outside the model (REST start, message correlation, parent process) plus author-supplied types and descriptions. Its entries merge into the heuristic model under a new top `authored` confidence tier so they win name clashes, and the type/description surface in inline-script completion on both hosts. Reading and merging happen host-side because the webview is sandboxed: a shared `ScriptVariableManifestService` (over `WorkspacePort`) is reused by both hosts, the VS Code `ScriptVariableStore` merges its two sources, and the IntelliJ bridge merges before it sends — no RPC protocol change. Manifests are watched so completion updates live on create/change/delete, and a malformed manifest is ignored rather than breaking completion. Adds unit coverage for the `authored` tier, manifest parsing, the two-source store, the manifest service (fake `WorkspacePort`), and the bridge `script/open` merge, plus a docs section.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
