### PR TITLE
refactor(webview): rename vscode host channel to host-neutral HostApi

### DIFF
--- a/apps/bpmn-webview/src/app/__fixtures__/mock-bpmn.ts
+++ b/apps/bpmn-webview/src/app/__fixtures__/mock-bpmn.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal BPMN XML used in development mode.
+ *
+ * Contains a Start Event, a Call Activity, a Service Task, and an End Event
+ * so that element template selection can be tested for different element
+ * types. Used by the dev-mode host mock for standalone browser runs and
+ * tree-shaken out of the production bundle.
+ */
+export const MOCK_BPMN_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+                  id="Definitions_1"
+                  targetNamespace="http://bpmn.io/schema/bpmn"
+                  exporter="bpmn-js"
+                  exporterVersion="18.0.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:callActivity id="CallActivity_1" name="Call Activity">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:serviceTask id="ServiceTask_1" name="Service Task">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_1" name="End">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="CallActivity_1" />
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="CallActivity_1" targetRef="ServiceTask_1" />
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="202" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_1_di" bpmnElement="CallActivity_1">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="592" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="600" y="202" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="592" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;

--- a/apps/bpmn-webview/src/app/__fixtures__/mock-diff.ts
+++ b/apps/bpmn-webview/src/app/__fixtures__/mock-diff.ts
@@ -1,7 +1,7 @@
 /**
  * Fixture BPMN XMLs for the dev-mode diff preview.
  *
- * Used exclusively by the `MockedVsCodeApi` in `vscode.ts` when the webview
+ * Used exclusively by the `MockHost` in `host.ts` when the webview
  * is booted with `?mode=diff-before` or `?mode=diff-after`.  The two diagrams
  * differ in every category `bpmn-js-differ` reports:
  *

--- a/apps/bpmn-webview/src/app/diff/DiffMode.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffMode.ts
@@ -7,11 +7,11 @@ import {
     SwapCompareSidesCommand,
     SyncCursorQuery,
     SyncViewportQuery,
-    VsCodeApi,
+    HostApi,
     ViewportChangedCommand,
 } from "@miragon/bpmn-modeler-shared";
 
-import { WebviewState } from "../vscode";
+import { WebviewState } from "../host";
 import { DiffLegend } from "./DiffLegend";
 import { DiffViewer } from "./DiffViewer";
 
@@ -54,7 +54,7 @@ export class DiffMode {
     constructor(
         canvasSelector: string,
         legendParent: HTMLElement,
-        private readonly vscode: VsCodeApi<WebviewState, MessageType>,
+        private readonly host: HostApi<WebviewState, MessageType>,
     ) {
         this.viewer = new DiffViewer(canvasSelector);
         this.legend = new DiffLegend(legendParent, {
@@ -64,11 +64,11 @@ export class DiffMode {
             // toggles its display based on origin), so the host side will only
             // ever receive this command from a compare-files session.  The
             // host still validates origin defensively before acting.
-            onSwap: () => this.vscode.postMessage(new SwapCompareSidesCommand()),
+            onSwap: () => this.host.postMessage(new SwapCompareSidesCommand()),
         });
 
         this.viewer.onViewportChanged((viewport) => {
-            this.vscode.postMessage(new ViewportChangedCommand(viewport));
+            this.host.postMessage(new ViewportChangedCommand(viewport));
         });
     }
 
@@ -106,7 +106,7 @@ export class DiffMode {
             console.error("DiffViewer import failed", error);
             return;
         }
-        this.vscode.postMessage(new DiffReadyCommand());
+        this.host.postMessage(new DiffReadyCommand());
     }
 
     private paint(query: ApplyDiffHighlightsQuery): void {
@@ -199,7 +199,7 @@ export class DiffMode {
         }
 
         if (emit) {
-            this.vscode.postMessage(new CursorChangedCommand(this.cursor));
+            this.host.postMessage(new CursorChangedCommand(this.cursor));
         }
     }
 

--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -16,89 +16,18 @@ import {
     Query,
     sortIdsByOrder,
     SyncDocumentCommand,
-    VsCodeApi,
-    VsCodeImpl,
-    VsCodeMock,
+    HostApi,
+    HostApiImpl,
+    MockHostApi,
     ViewportChangedCommand,
 } from "@miragon/bpmn-modeler-shared";
 
 import c7Samples from "./__fixtures__/c7-samples.json";
 import c8Samples from "./__fixtures__/c8-samples.json";
+import { MOCK_BPMN_XML } from "./__fixtures__/mock-bpmn";
 import { MOCK_DIFF_AFTER_XML, MOCK_DIFF_BEFORE_XML } from "./__fixtures__/mock-diff";
 
 declare const process: { env: { NODE_ENV: string } };
-
-/**
- * Minimal BPMN XML used in development mode.
- *
- * Contains a Start Event, a Call Activity, a Service Task, and an End Event
- * so that element template selection can be tested for different element types.
- */
-const MOCK_BPMN_XML = `<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
-                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
-                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
-                  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
-                  id="Definitions_1"
-                  targetNamespace="http://bpmn.io/schema/bpmn"
-                  exporter="bpmn-js"
-                  exporterVersion="18.0.0">
-  <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1" name="Start">
-      <bpmn:outgoing>Flow_1</bpmn:outgoing>
-    </bpmn:startEvent>
-    <bpmn:callActivity id="CallActivity_1" name="Call Activity">
-      <bpmn:incoming>Flow_1</bpmn:incoming>
-      <bpmn:outgoing>Flow_2</bpmn:outgoing>
-    </bpmn:callActivity>
-    <bpmn:serviceTask id="ServiceTask_1" name="Service Task">
-      <bpmn:incoming>Flow_2</bpmn:incoming>
-      <bpmn:outgoing>Flow_3</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:endEvent id="EndEvent_1" name="End">
-      <bpmn:incoming>Flow_3</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="CallActivity_1" />
-    <bpmn:sequenceFlow id="Flow_2" sourceRef="CallActivity_1" targetRef="ServiceTask_1" />
-    <bpmn:sequenceFlow id="Flow_3" sourceRef="ServiceTask_1" targetRef="EndEvent_1" />
-  </bpmn:process>
-  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="159" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="185" y="202" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CallActivity_1_di" bpmnElement="CallActivity_1">
-        <dc:Bounds x="270" y="137" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1_di" bpmnElement="ServiceTask_1">
-        <dc:Bounds x="430" y="137" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="592" y="159" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="600" y="202" width="20" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
-        <di:waypoint x="215" y="177" />
-        <di:waypoint x="270" y="177" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_2_di" bpmnElement="Flow_2">
-        <di:waypoint x="370" y="177" />
-        <di:waypoint x="430" y="177" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_3_di" bpmnElement="Flow_3">
-        <di:waypoint x="530" y="177" />
-        <di:waypoint x="592" y="177" />
-      </bpmndi:BPMNEdge>
-    </bpmndi:BPMNPlane>
-  </bpmndi:BPMNDiagram>
-</bpmn:definitions>`;
 
 /**
  * Canvas position and zoom level captured from diagram-js.
@@ -111,7 +40,7 @@ export interface ViewportData {
 }
 
 /**
- * Shape of the data persisted via `vscode.setState` / `vscode.getState`.
+ * Shape of the data persisted via the host's `setState` / `getState`.
  */
 export interface WebviewState {
     viewport?: ViewportData;
@@ -131,16 +60,17 @@ type StateType = WebviewState;
 type MessageType = Command | Query;
 
 /**
- * Returns the appropriate host-channel implementation. In `development` mode a
- * {@link MockedVsCodeApi} is returned for standalone browser runs; otherwise
- * the real {@link VsCodeImpl} is used (the IntelliJ host injects the same
- * `acquireVsCodeApi()` shim, so it takes this path too).
+ * Returns the channel to the host application embedding this webview. In
+ * `development` mode a {@link MockHost} is returned for standalone browser
+ * runs; otherwise the real {@link HostApiImpl} is used (VS Code, IntelliJ, and
+ * the desktop app all inject the same `acquireVsCodeApi()` shim, so they share
+ * this path).
  */
-export function getVsCodeApi(): VsCodeApi<StateType, MessageType> {
+export function getHostApi(): HostApi<StateType, MessageType> {
     if (process.env.NODE_ENV === "development") {
-        return new MockedVsCodeApi();
+        return new MockHost();
     }
-    return new VsCodeImpl<StateType, MessageType>();
+    return new HostApiImpl<StateType, MessageType>();
 }
 
 /**
@@ -187,8 +117,8 @@ function readDevMode(): DevMode {
 }
 
 /**
- * Development-only mock that simulates the VS Code extension host by
- * dispatching synthetic `MessageEvent`s in response to outbound commands.
+ * Development-only mock that simulates the host application by dispatching
+ * synthetic `MessageEvent`s in response to outbound commands.
  *
  * Selects behaviour from a {@link DevMode} derived from the URL.  Diff modes
  * lazily import `bpmn-moddle` + `bpmn-js-differ` on the first
@@ -196,7 +126,7 @@ function readDevMode(): DevMode {
  * (dead-code-eliminated along with the whole class when `NODE_ENV` is
  * production).
  */
-class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
+class MockHost extends MockHostApi<StateType, MessageType> {
     private readonly devMode: DevMode = readDevMode();
 
     private cachedDiff: CachedDiff | undefined;
@@ -226,7 +156,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
 
     /**
      * Intercepts outbound messages and dispatches the corresponding inbound
-     * response so the webview can operate without a real VS Code host.
+     * response so the webview can operate without a real host.
      *
      * @param message The outbound command sent by the webview.
      */
@@ -392,7 +322,7 @@ class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
 
         // Dynamic imports keep these ~200 KB of dev-only dependencies out of
         // the production webview bundle (Rollup emits them as separate chunks
-        // that the dead-code-eliminated MockedVsCodeApi never loads).
+        // that the dead-code-eliminated MockHost never loads).
         //
         // `bpmn-moddle`'s default export is the `simple` factory, not a class —
         // it must be called without `new` (call it as a plain function).

--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -3,4 +3,4 @@ export * from "./viewport";
 export * from "./selection";
 export * from "./state";
 export * from "./propertiesPanelClipboard";
-export * from "./vscode";
+export * from "./host";

--- a/apps/bpmn-webview/src/app/state.spec.ts
+++ b/apps/bpmn-webview/src/app/state.spec.ts
@@ -4,17 +4,17 @@ import { WebviewStateManager } from "./state";
 
 /**
  * Builds a `WebviewStateManager` wired to spies for the only collaborators
- * `restoreViewport` touches: `vscode.getState` (the saved-state source that
+ * `restoreViewport` touches: `host.getState` (the saved-state source that
  * discriminates fresh open from tab-switch rebuild) and the viewport methods.
  */
 function setup(savedState: unknown) {
     const getState = vi.fn().mockReturnValue(savedState);
     const setViewport = vi.fn();
     const fitViewport = vi.fn();
-    const vscode = { getState } as any;
+    const host = { getState } as any;
     const modeler = { viewport: { setViewport, fitViewport } } as any;
     return {
-        manager: new WebviewStateManager(vscode, modeler),
+        manager: new WebviewStateManager(host, modeler),
         setViewport,
         fitViewport,
     };

--- a/apps/bpmn-webview/src/app/state.ts
+++ b/apps/bpmn-webview/src/app/state.ts
@@ -1,5 +1,5 @@
-import { Command, Query, VsCodeApi } from "@miragon/bpmn-modeler-shared";
-import { WebviewState } from "./vscode";
+import { Command, Query, HostApi } from "@miragon/bpmn-modeler-shared";
+import { WebviewState } from "./host";
 import { BpmnModeler } from "./modeler";
 
 const PANEL_SCROLL_CONTAINER = ".bio-properties-panel-scroll-container";
@@ -29,7 +29,7 @@ function isGroupOpen(group: HTMLElement): boolean {
  */
 export class WebviewStateManager {
     constructor(
-        private readonly vscode: VsCodeApi<WebviewState, Command | Query>,
+        private readonly host: HostApi<WebviewState, Command | Query>,
         private readonly modeler: BpmnModeler,
     ) {}
 
@@ -125,7 +125,7 @@ export class WebviewStateManager {
 
     private getSavedState(): WebviewState | undefined {
         try {
-            return this.vscode.getState();
+            return this.host.getState();
         } catch {
             return undefined;
         }
@@ -136,9 +136,9 @@ export class WebviewStateManager {
      */
     private persistPartialState(partial: Partial<WebviewState>): void {
         try {
-            this.vscode.updateState(partial);
+            this.host.updateState(partial);
         } catch {
-            this.vscode.setState(partial as WebviewState);
+            this.host.setState(partial as WebviewState);
         }
     }
 

--- a/apps/bpmn-webview/src/app/viewport.ts
+++ b/apps/bpmn-webview/src/app/viewport.ts
@@ -1,4 +1,4 @@
-import { ViewportData } from "./vscode";
+import { ViewportData } from "./host";
 
 /**
  * Function type for accessing a service from the bpmn-js DI container.

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -47,7 +47,7 @@ import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-model
 import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import {
     BpmnModeler,
-    getVsCodeApi,
+    getHostApi,
     installContentEditableClipboardPolyfill,
     UnsupportedEngineError,
 } from "./app";
@@ -55,7 +55,7 @@ import { DiffMode } from "./app/diff/DiffMode";
 import type { LintConfigService } from "./app/bpmnlint";
 import { WebviewStateManager } from "./app/state";
 
-const vscode = getVsCodeApi();
+const host = getHostApi();
 
 /**
  * Singleton modeler instance shared across all message handlers.
@@ -125,22 +125,22 @@ window.onload = async function () {
     if (process.env.NODE_ENV !== "development") {
         const requestElementClipboard = async (): Promise<string> => {
             elementClipboardResolver = createResolver<ClipboardQuery>();
-            vscode.postMessage(new GetClipboardCommand());
+            host.postMessage(new GetClipboardCommand());
             const q = await elementClipboardResolver.wait();
             return q?.text ?? "";
         };
         const writeElementClipboard = (text: string): void => {
-            vscode.postMessage(new SetClipboardCommand(text));
+            host.postMessage(new SetClipboardCommand(text));
         };
 
         const requestTextClipboard = async (): Promise<string> => {
             textClipboardResolver = createResolver<TextClipboardQuery>();
-            vscode.postMessage(new GetTextClipboardCommand());
+            host.postMessage(new GetTextClipboardCommand());
             const q = await textClipboardResolver.wait();
             return q?.text ?? "";
         };
         const writeTextClipboard = (text: string): void => {
-            vscode.postMessage(new SetTextClipboardCommand(text));
+            host.postMessage(new SetTextClipboardCommand(text));
         };
 
         clipboardModules = [
@@ -175,7 +175,7 @@ window.onload = async function () {
         installContentEditableClipboardPolyfill(requestTextClipboard, writeTextClipboard);
     }
 
-    vscode.postMessage(new GetBpmnFileCommand());
+    host.postMessage(new GetBpmnFileCommand());
 
     const bpmnFileQuery = await bpmnFileResolver.wait();
 
@@ -191,7 +191,7 @@ window.onload = async function () {
             console.error("Diff mode: missing #js-canvas or #js-drop-zone");
             return;
         }
-        const diffMode = new DiffMode("#js-canvas", dropZone, vscode);
+        const diffMode = new DiffMode("#js-canvas", dropZone, host);
         await diffMode.startWith(bpmnFileQuery.content);
         return;
     }
@@ -204,7 +204,7 @@ window.onload = async function () {
         onLabelChange: (apply) => i18n.onChange(apply),
     });
     const vsCodeBridgeModule = {
-        vsCodeBridge: ["value", { postMessage: (m: unknown) => vscode.postMessage(m as never) }],
+        vsCodeBridge: ["value", { postMessage: (m: unknown) => host.postMessage(m as never) }],
     };
     const extraModules = [TranslateModule, vsCodeBridgeModule, ...(clipboardModules ?? [])];
     await initializeModeler(bpmnFileQuery?.content, bpmnFileQuery?.engine, extraModules);
@@ -218,7 +218,7 @@ window.onload = async function () {
      */
     if (bpmnFileQuery?.engine === "c7") {
         bpmnModeler.onOpenScriptEditor((data) => {
-            vscode.postMessage(
+            host.postMessage(
                 new OpenScriptEditorCommand(
                     data.elementId,
                     data.kind,
@@ -245,7 +245,7 @@ window.onload = async function () {
                 return;
             }
             lastVariablesJson = json;
-            vscode.postMessage(new UpdateScriptVariablesCommand(variables));
+            host.postMessage(new UpdateScriptVariablesCommand(variables));
         }, 300);
         bpmnModeler.onCommandStackChanged(() => void sendVariables());
         // commandStack.changed doesn't fire on import, and a webview reload starts
@@ -255,16 +255,16 @@ window.onload = async function () {
 
     console.debug("[DEBUG] Modeler is initialized...");
 
-    stateManager = new WebviewStateManager(vscode, bpmnModeler);
+    stateManager = new WebviewStateManager(host, bpmnModeler);
 
     // Phase 1: restore viewport (canvas exists after openXml)
     stateManager.restoreViewport();
 
     // Request templates + settings + panel state, wait for all to apply
-    vscode.postMessage(new GetElementTemplatesCommand());
-    vscode.postMessage(new GetBpmnModelerSettingCommand());
-    vscode.postMessage(new GetPropertiesPanelStateCommand());
-    vscode.postMessage(new GetBpmnlintConfigCommand());
+    host.postMessage(new GetElementTemplatesCommand());
+    host.postMessage(new GetBpmnModelerSettingCommand());
+    host.postMessage(new GetPropertiesPanelStateCommand());
+    host.postMessage(new GetBpmnlintConfigCommand());
 
     const [, , panelStateQuery] = await Promise.all([
         elementTemplatesResolver.wait(),
@@ -280,7 +280,7 @@ window.onload = async function () {
     // Report user toggles back to the host so the global default tracks the
     // latest preference across all BPMN editors.
     propertiesPanelHandle.onVisibilityChanged((visible) => {
-        vscode.postMessage(new SetPropertiesPanelStateCommand(visible));
+        host.postMessage(new SetPropertiesPanelStateCommand(visible));
     });
 
     // Phase 2: restore selection + panel-side UI state (safe now — side-effects done)
@@ -304,7 +304,7 @@ async function initializeModeler(
     extraModules?: any[],
 ): Promise<void> {
     if (!engine) {
-        vscode.postMessage(new LogErrorCommand("ExecutionPlatformVersion undefined!"));
+        host.postMessage(new LogErrorCommand("ExecutionPlatformVersion undefined!"));
         return;
     }
 
@@ -314,11 +314,11 @@ async function initializeModeler(
         await openXml(bpmn);
     } catch (error: any) {
         if (error instanceof NoModelerError) {
-            vscode.postMessage(new LogErrorCommand(error.message));
+            host.postMessage(new LogErrorCommand(error.message));
         } else if (error instanceof UnsupportedEngineError) {
-            vscode.postMessage(new LogErrorCommand(error.message));
+            host.postMessage(new LogErrorCommand(error.message));
         } else {
-            vscode.postMessage(new LogErrorCommand(`Unable to open XML\n${error.message}`));
+            host.postMessage(new LogErrorCommand(`Unable to open XML\n${error.message}`));
         }
     }
 }
@@ -340,7 +340,7 @@ async function openXml(bpmn?: string): Promise<void> {
 
     if (result.warnings.length > 0) {
         const warnings = `with following warnings: ${formatErrors(result.warnings)}`;
-        vscode.postMessage(new LogInfoCommand(warnings));
+        host.postMessage(new LogInfoCommand(warnings));
     }
 }
 
@@ -350,12 +350,12 @@ async function openXml(bpmn?: string): Promise<void> {
  */
 async function sendXmlChanges(): Promise<void> {
     const bpmn = await bpmnModeler.exportDiagram();
-    vscode.postMessage(new SyncDocumentCommand(bpmn));
+    host.postMessage(new SyncDocumentCommand(bpmn));
     bpmnModeler.alignElementsToOrigin();
 }
 
 /**
- * Routes incoming messages from the VS Code extension host to the appropriate
+ * Routes incoming messages from the host application to the appropriate
  * handler.
  *
  * @param message The raw `MessageEvent` from `window.addEventListener("message", …)`.
@@ -374,7 +374,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     bpmnFileResolver.done(bpmnFileQuery);
                 }
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -385,7 +385,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                 bpmnModeler.setElementTemplates(elementTemplates);
                 elementTemplatesResolver.done(message.data as ElementTemplatesQuery);
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -397,10 +397,10 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     .apply(query.config);
 
                 for (const warning of warnings) {
-                    vscode.postMessage(new LogInfoCommand(warning));
+                    host.postMessage(new LogInfoCommand(warning));
                 }
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -410,7 +410,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                 bpmnModeler.setSettings(setting);
                 settingsResolver.done(message.data as BpmnModelerSettingQuery);
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -439,7 +439,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     await refreshDiagram();
                 }
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -448,9 +448,9 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                 const command = message.data as GetDiagramAsSVGCommand;
                 // Populate the SVG field and echo the command back to the host.
                 command.svg = await bpmnModeler.getDiagramSvg();
-                vscode.postMessage(command);
+                host.postMessage(command);
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -464,7 +464,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     query.content,
                 );
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -478,7 +478,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     query.scriptFormat,
                 );
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }
@@ -487,7 +487,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                 const query = message.data as ImplementationStatusQuery;
                 bpmnModeler.applyImplementationStatus(query.resolved);
             } catch (error: any) {
-                vscode.postMessage(new LogErrorCommand(errorPrefix + error.message));
+                host.postMessage(new LogErrorCommand(errorPrefix + error.message));
             }
             break;
         }

--- a/apps/bpmn-webview/src/types/bpmn-js-differ.d.ts
+++ b/apps/bpmn-webview/src/types/bpmn-js-differ.d.ts
@@ -1,6 +1,6 @@
 /**
  * Ambient type declarations for `bpmn-js-differ`, which ships without its own
- * `.d.ts`.  The dev-only `MockedVsCodeApi` runs the differ in the browser to
+ * `.d.ts`.  The dev-only `MockHost` runs the differ in the browser to
  * preview the diff UI; outside of dev the library is dead-code-eliminated.
  */
 declare module "bpmn-js-differ" {

--- a/apps/deployment-webview/src/app/form.ts
+++ b/apps/deployment-webview/src/app/form.ts
@@ -9,14 +9,14 @@ import {
     Query,
     RequestAdditionalFilesCommand,
     RequestStoredCredentialsCommand,
-    VsCodeApi,
+    HostApi,
 } from "@miragon/bpmn-modeler-shared";
 
-import { WebviewState } from "./vscode";
+import { WebviewState } from "./host";
 
 /**
  * Intentionally framework-free — manipulates the DOM directly and talks to
- * the extension host via the `postMessage` API wrapped by {@link VsCodeApi}.
+ * the extension host via the `postMessage` API wrapped by {@link HostApi}.
  */
 export class DeploymentForm {
     private static readonly DEFAULT_COLLAPSED_SECTIONS: string[] = [];
@@ -62,7 +62,7 @@ export class DeploymentForm {
     /**
      * @throws {Error} If any expected DOM element is missing.
      */
-    constructor(private readonly vscode: VsCodeApi<unknown, Command | Query>) {
+    constructor(private readonly host: HostApi<unknown, Command | Query>) {
         this.deploymentNameInput = this.requireElement<HTMLInputElement>("#deployment-name");
         this.tenantIdInput = this.requireElement<HTMLInputElement>("#tenant-id");
         this.endpointInput = this.requireElement<HTMLInputElement>("#endpoint");
@@ -108,7 +108,7 @@ export class DeploymentForm {
             : "";
 
         if (defaults.authType !== "none") {
-            this.vscode.postMessage(new RequestStoredCredentialsCommand());
+            this.host.postMessage(new RequestStoredCredentialsCommand());
         }
     }
 
@@ -249,7 +249,7 @@ export class DeploymentForm {
 
         let collapsed: string[];
         try {
-            const state = this.vscode.getState() as WebviewState | undefined;
+            const state = this.host.getState() as WebviewState | undefined;
             collapsed = state?.collapsedSections ?? this.defaultCollapsedSections();
         } catch {
             collapsed = this.defaultCollapsedSections();
@@ -304,7 +304,7 @@ export class DeploymentForm {
             }
         }
 
-        this.vscode.setState({ collapsedSections } as WebviewState);
+        this.host.setState({ collapsedSections } as WebviewState);
     }
 
     private defaultCollapsedSections(): string[] {
@@ -315,19 +315,19 @@ export class DeploymentForm {
         this.authTypeSelect.addEventListener("change", () => {
             this.toggleAuthFields();
             if (this.authTypeSelect.value !== "none") {
-                this.vscode.postMessage(new RequestStoredCredentialsCommand());
+                this.host.postMessage(new RequestStoredCredentialsCommand());
             }
         });
 
         this.additionalFilesBtn.addEventListener("click", () => {
-            this.vscode.postMessage(new RequestAdditionalFilesCommand());
+            this.host.postMessage(new RequestAdditionalFilesCommand());
         });
 
         this.deployBtn.addEventListener("click", () => {
             try {
                 const payload = this.getConfigPayload();
                 this.showProgress();
-                this.vscode.postMessage(new DeployCommand(payload));
+                this.host.postMessage(new DeployCommand(payload));
             } catch (err) {
                 this.statusBanner.className = "status-banner error";
                 this.statusBanner.textContent = err instanceof Error ? err.message : String(err);

--- a/apps/deployment-webview/src/app/host.ts
+++ b/apps/deployment-webview/src/app/host.ts
@@ -8,15 +8,15 @@ import {
     SelectedPayloadFileQuery,
     StartInstanceResultQuery,
     StoredCredentialsQuery,
-    VsCodeApi,
-    VsCodeImpl,
-    VsCodeMock,
+    HostApi,
+    HostApiImpl,
+    MockHostApi,
 } from "@miragon/bpmn-modeler-shared";
 
 declare const process: { env: { NODE_ENV: string } };
 
 /**
- * Shape of the data persisted via `vscode.setState` / `vscode.getState`.
+ * Shape of the data persisted via `host.setState` / `host.getState`.
  */
 export interface WebviewState {
     formData?: Record<string, string>;
@@ -27,24 +27,25 @@ type StateType = WebviewState;
 type MessageType = Command | Query;
 
 /**
- * Returns the appropriate VS Code API implementation.
+ * Returns the channel to the host application embedding this webview.
  *
- * In `development` mode a {@link MockedVsCodeApi} is returned so the webview
- * can be run standalone in a browser without a VS Code host.  In all other
- * environments the real {@link VsCodeImpl} is used.
+ * In `development` mode a {@link MockHost} is returned so the webview can be
+ * run standalone in a browser without any host. In all other environments the
+ * real {@link HostApiImpl} is used (VS Code, IntelliJ, and the desktop app all
+ * inject the same `acquireVsCodeApi()` shim, so they share this path).
  */
-export function getVsCodeApi(): VsCodeApi<StateType, MessageType> {
+export function getHostApi(): HostApi<StateType, MessageType> {
     if (process.env.NODE_ENV === "development") {
-        return new MockedVsCodeApi();
+        return new MockHost();
     }
-    return new VsCodeImpl<StateType, MessageType>();
+    return new HostApiImpl<StateType, MessageType>();
 }
 
 /**
- * Development-only mock that simulates the VS Code extension host by
- * dispatching synthetic `MessageEvent`s in response to outbound commands.
+ * Development-only mock that simulates the host application by dispatching
+ * synthetic `MessageEvent`s in response to outbound commands.
  */
-class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
+class MockHost extends MockHostApi<StateType, MessageType> {
     /**
      * Intercepts outbound messages and dispatches synthetic inbound responses
      * so the deployment form can be developed standalone in a browser.

--- a/apps/deployment-webview/src/app/startInstanceForm.ts
+++ b/apps/deployment-webview/src/app/startInstanceForm.ts
@@ -7,7 +7,7 @@ import {
     StartInstanceCommand,
     StartInstanceConfigPayload,
     StartInstanceResultQuery,
-    VsCodeApi,
+    HostApi,
 } from "@miragon/bpmn-modeler-shared";
 
 /**
@@ -33,13 +33,13 @@ export class StartInstanceForm {
     /**
      * Wires up all DOM element references and attaches event listeners.
      *
-     * @param vscode The VS Code API instance used to post messages.
+     * @param host The host channel used to post messages.
      * @param getSharedAuth Callback to read the current auth config from the shared form fields.
      * @param getSharedConnection Callback to read endpoint and engine from the shared form fields.
      * @throws {Error} If any expected DOM element is missing.
      */
     constructor(
-        private readonly vscode: VsCodeApi<unknown, Command | Query>,
+        private readonly host: HostApi<unknown, Command | Query>,
         private readonly getSharedAuth: () => AuthConfigPayload,
         private readonly getSharedConnection: () => {
             endpoint: string;
@@ -112,14 +112,14 @@ export class StartInstanceForm {
      */
     private bindEvents(): void {
         this.selectPayloadBtn.addEventListener("click", () => {
-            this.vscode.postMessage(new RequestPayloadFilesCommand());
+            this.host.postMessage(new RequestPayloadFilesCommand());
         });
 
         this.startInstanceBtn.addEventListener("click", () => {
             try {
                 const payload = this.getConfigPayload();
                 this.showProgress();
-                this.vscode.postMessage(new StartInstanceCommand(payload));
+                this.host.postMessage(new StartInstanceCommand(payload));
             } catch (err) {
                 this.statusBanner.className = "status-banner error";
                 this.statusBanner.textContent = err instanceof Error ? err.message : String(err);

--- a/apps/deployment-webview/src/main.ts
+++ b/apps/deployment-webview/src/main.ts
@@ -16,9 +16,9 @@ import {
 import { DeploymentForm } from "./app/form";
 import { FORM_TEMPLATE } from "./app/formTemplate";
 import { StartInstanceForm } from "./app/startInstanceForm";
-import { getVsCodeApi } from "./app/vscode";
+import { getHostApi } from "./app/host";
 
-const vscode = getVsCodeApi();
+const host = getHostApi();
 
 /**
  * Entry point: initialises the deployment and start-instance forms once the
@@ -36,9 +36,9 @@ window.onload = function () {
     }
 
     try {
-        form = new DeploymentForm(vscode);
+        form = new DeploymentForm(host);
         startForm = new StartInstanceForm(
-            vscode,
+            host,
             () => form.getAuthPayload(),
             () => form.getConnectionPayload(),
         );
@@ -54,7 +54,7 @@ window.onload = function () {
     });
 
     // Request pre-populated defaults from the extension host.
-    vscode.postMessage(new RequestFormDefaultsCommand());
+    host.postMessage(new RequestFormDefaultsCommand());
 };
 
 /**
@@ -69,7 +69,7 @@ function initTabs(): void {
 
     // Restore persisted active tab.
     try {
-        const state = vscode.getState() as Record<string, unknown> | undefined;
+        const state = host.getState() as Record<string, unknown> | undefined;
         const savedTab = state?.activeTab as string | undefined;
         if (savedTab) {
             activateTab(savedTab, tabBtns, tabPanels);
@@ -83,8 +83,8 @@ function initTabs(): void {
             const tab = btn.dataset.tab;
             if (!tab) return;
             activateTab(tab, tabBtns, tabPanels);
-            vscode.setState({
-                ...((vscode.getState() as Record<string, unknown>) ?? {}),
+            host.setState({
+                ...((host.getState() as Record<string, unknown>) ?? {}),
                 activeTab: tab,
             });
         });
@@ -112,7 +112,7 @@ function activateTab(
 }
 
 /**
- * Routes messages from the VS Code extension host to the appropriate form method.
+ * Routes messages from the host application to the appropriate form method.
  *
  * @param event The raw `MessageEvent` from `window.addEventListener("message", …)`.
  * @param form The active {@link DeploymentForm} instance.

--- a/apps/dmn-webview/src/app/host.ts
+++ b/apps/dmn-webview/src/app/host.ts
@@ -4,15 +4,15 @@ import {
     DmnModelerSettingQuery,
     PropertiesPanelStateQuery,
     Query,
-    VsCodeApi,
-    VsCodeImpl,
-    VsCodeMock,
+    HostApi,
+    HostApiImpl,
+    MockHostApi,
 } from "@miragon/bpmn-modeler-shared";
 
 declare const process: { env: { NODE_ENV: string } };
 
 /**
- * Shape of the data persisted via `vscode.setState` / `vscode.getState`.
+ * Shape of the data persisted via `host.setState` / `host.getState`.
  */
 export interface WebviewState {
     // Scroll position of `.bio-properties-panel-scroll-container`.
@@ -30,16 +30,17 @@ type StateType = WebviewState;
 type MessageType = Command | Query;
 
 /**
- * Returns the appropriate host-channel implementation. In `development` mode a
- * {@link MockedVsCodeApi} is returned for standalone browser runs; otherwise
- * the real {@link VsCodeImpl} is used (the IntelliJ host injects the same
- * `acquireVsCodeApi()` shim, so it takes this path too).
+ * Returns the channel to the host application embedding this webview. In
+ * `development` mode a {@link MockHost} is returned for standalone browser
+ * runs; otherwise the real {@link HostApiImpl} is used (VS Code, IntelliJ, and
+ * the desktop app all inject the same `acquireVsCodeApi()` shim, so they share
+ * this path).
  */
-export function getVsCodeApi(): VsCodeApi<StateType, MessageType> {
+export function getHostApi(): HostApi<StateType, MessageType> {
     if (process.env.NODE_ENV === "development") {
-        return new MockedVsCodeApi();
+        return new MockHost();
     }
-    return new VsCodeImpl<StateType, MessageType>();
+    return new HostApiImpl<StateType, MessageType>();
 }
 
 // Minimal DRD for standalone browser runs, so the palette and an element's
@@ -59,7 +60,7 @@ const SAMPLE_DMN = `<?xml version="1.0" encoding="UTF-8"?>
   </dmndi:DMNDI>
 </definitions>`;
 
-class MockedVsCodeApi extends VsCodeMock<StateType, MessageType> {
+class MockHost extends MockHostApi<StateType, MessageType> {
     /**
      * Merges `state` into the current mock state, initialising it when no
      * state has been set yet (i.e. when {@link getState} would throw).

--- a/apps/dmn-webview/src/app/index.ts
+++ b/apps/dmn-webview/src/app/index.ts
@@ -1,3 +1,3 @@
 export * from "./modeler";
 export * from "./state";
-export * from "./vscode";
+export * from "./host";

--- a/apps/dmn-webview/src/app/state.ts
+++ b/apps/dmn-webview/src/app/state.ts
@@ -1,5 +1,5 @@
-import { Command, Query, VsCodeApi } from "@miragon/bpmn-modeler-shared";
-import { WebviewState } from "./vscode";
+import { Command, Query, HostApi } from "@miragon/bpmn-modeler-shared";
+import { WebviewState } from "./host";
 
 const PANEL_SCROLL_CONTAINER = ".bio-properties-panel-scroll-container";
 const PANEL_GROUP = ".bio-properties-panel-group";
@@ -31,7 +31,7 @@ function isGroupOpen(group: HTMLElement): boolean {
  * 2. {@link startPersisting}       — installs the change listeners
  */
 export class WebviewStateManager {
-    constructor(private readonly vscode: VsCodeApi<WebviewState, Command | Query>) {}
+    constructor(private readonly host: HostApi<WebviewState, Command | Query>) {}
 
     /**
      * Restores the properties-panel UI state (expanded groups + scroll) in a
@@ -82,7 +82,7 @@ export class WebviewStateManager {
 
     private getSavedState(): WebviewState | undefined {
         try {
-            return this.vscode.getState();
+            return this.host.getState();
         } catch {
             return undefined;
         }
@@ -90,9 +90,9 @@ export class WebviewStateManager {
 
     private persistPartialState(partial: Partial<WebviewState>): void {
         try {
-            this.vscode.updateState(partial);
+            this.host.updateState(partial);
         } catch {
-            this.vscode.setState(partial as WebviewState);
+            this.host.setState(partial as WebviewState);
         }
     }
 

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -30,15 +30,15 @@ import { i18n } from "@miragon/bpmn-modeler-i18n";
 import {
     createModeler,
     exportDiagram,
-    getVsCodeApi,
+    getHostApi,
     loadDiagram,
     onCommandStackChanged,
     WebviewStateManager,
 } from "./app";
 
-const vscode = getVsCodeApi();
+const host = getHostApi();
 
-const stateManager = new WebviewStateManager(vscode);
+const stateManager = new WebviewStateManager(host);
 
 /**
  * Debounce the openXML function to avoid multiple calls when the user types fast.
@@ -81,9 +81,9 @@ window.onload = async function () {
         onLabelChange: (apply) => i18n.onChange(apply),
     });
 
-    vscode.postMessage(new GetDmnFileCommand());
-    vscode.postMessage(new GetPropertiesPanelStateCommand());
-    vscode.postMessage(new GetDmnModelerSettingCommand());
+    host.postMessage(new GetDmnFileCommand());
+    host.postMessage(new GetPropertiesPanelStateCommand());
+    host.postMessage(new GetDmnModelerSettingCommand());
     const dmnFile = await dmnFileResolver.wait();
     await initializeModeler(dmnFile?.content);
     modelerIsInitialized = true;
@@ -97,7 +97,7 @@ window.onload = async function () {
     const panelState = await panelStateResolver.wait();
     propertiesPanelHandle.setVisible(panelState?.visible ?? true);
     propertiesPanelHandle.onVisibilityChanged((visible) => {
-        vscode.postMessage(new SetPropertiesPanelStateCommand(visible));
+        host.postMessage(new SetPropertiesPanelStateCommand(visible));
     });
 
     stateManager.restorePanelUiState();
@@ -111,10 +111,10 @@ async function initializeModeler(dmnFile: string | undefined) {
         await openXML(dmnFile);
     } catch (error) {
         if (error instanceof NoModelerError) {
-            vscode.postMessage(new LogErrorCommand(error.message));
+            host.postMessage(new LogErrorCommand(error.message));
         } else {
             const message = error instanceof Error ? error.message : `${error}`;
-            vscode.postMessage(new LogErrorCommand(`Unable to open XML ${message}`));
+            host.postMessage(new LogErrorCommand(`Unable to open XML ${message}`));
         }
     }
 }
@@ -138,13 +138,13 @@ async function openXML(dmn: string | undefined) {
         );
         const message = `Diagram was opened with following warnings: ${formatErrors(warnings)}
             `;
-        vscode.postMessage(new LogInfoCommand(message));
+        host.postMessage(new LogInfoCommand(message));
     }
 }
 
 async function sendChanges() {
     const dmn = await exportDiagram();
-    vscode.postMessage(new SyncDocumentCommand(dmn));
+    host.postMessage(new SyncDocumentCommand(dmn));
 }
 
 async function onReceiveMessage(message: MessageEvent<Query | Command>) {
@@ -161,7 +161,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>) {
                 }
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : `${error}`;
-                vscode.postMessage(
+                host.postMessage(
                     new LogErrorCommand(
                         `Something went wrong when receiving the message ${errorMessage}`,
                     ),

--- a/libs/shared/src/index.ts
+++ b/libs/shared/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./lib/types";
-export * from "./lib/vscode";
+export * from "./lib/host";
 export * from "./lib/asyncDebounce";
 export * from "./lib/utils";
 export * from "./lib/messages";

--- a/libs/shared/src/lib/host.ts
+++ b/libs/shared/src/lib/host.ts
@@ -1,6 +1,15 @@
 import type { WebviewApi } from "vscode-webview";
 
-export interface VsCodeApi<T, M> {
+/**
+ * Channel between a webview and the host application embedding it.
+ *
+ * A "host" is whatever product renders the webview — the VS Code extension,
+ * the IntelliJ plugin, or the standalone desktop app. Every host exposes the
+ * same VS Code-style webview bridge, so the webview talks to all of them
+ * through this one interface: send messages to the host and persist a little
+ * view state across reloads.
+ */
+export interface HostApi<T, M> {
     /**
      * Get the current state of the webview.
      * @throws MissingStateError if the state is missing
@@ -20,21 +29,26 @@ export class MissingStateError extends Error {
     }
 }
 
-export class VsCodeImpl<T, M> implements VsCodeApi<T, M> {
-    private vscode: WebviewApi<T>;
+/**
+ * Production {@link HostApi} backed by the host-injected `acquireVsCodeApi()`
+ * bridge. VS Code, IntelliJ, and the desktop app all provide this same shim,
+ * so this single implementation serves every host.
+ */
+export class HostApiImpl<T, M> implements HostApi<T, M> {
+    private host: WebviewApi<T>;
 
     constructor() {
-        this.vscode = acquireVsCodeApi();
+        this.host = acquireVsCodeApi();
     }
 
     getState(): T {
-        const state = this.vscode.getState();
+        const state = this.host.getState();
         if (!state) throw new MissingStateError();
         return state;
     }
 
     setState(state: T) {
-        this.vscode.setState({
+        this.host.setState({
             ...state,
         });
     }
@@ -47,11 +61,15 @@ export class VsCodeImpl<T, M> implements VsCodeApi<T, M> {
     }
 
     postMessage(message: M) {
-        this.vscode.postMessage(message);
+        this.host.postMessage(message);
     }
 }
 
-export abstract class VsCodeMock<T, M> implements VsCodeApi<T, M> {
+/**
+ * Base for development mocks that stand in for a real host, letting a webview
+ * run standalone in the browser without any embedding application.
+ */
+export abstract class MockHostApi<T, M> implements HostApi<T, M> {
     protected state: T | undefined;
 
     getState(): T {


### PR DESCRIPTION
## Why

The webview-to-host bridge was named after VS Code (`VsCodeApi`, `getVsCodeApi`, `vscode.ts`), but the webview is embedded by **three** hosts — the VS Code extension, the IntelliJ plugin, and the standalone desktop app — all of which inject the same `acquireVsCodeApi()` shim. The old name was a leaky abstraction: it tied a host-agnostic boundary to one specific host's vocabulary.

This renames the abstraction so the names match what it actually is: a channel to whatever application embeds the webview.

## What

- **shared lib** (`lib/vscode.ts` → `lib/host.ts`): `VsCodeApi` → `HostApi`, `VsCodeImpl` → `HostApiImpl`, `VsCodeMock` → `MockHostApi`, plus a business-focused doc comment explaining a "host" is the VS Code extension, the IntelliJ plugin, or the desktop app.
- **bpmn / dmn / deployment webviews** (`app/vscode.ts` → `app/host.ts`): `getVsCodeApi()` → `getHostApi()`, `MockedVsCodeApi` → `MockHost`, local `vscode` handle → `host`.
- **fixtures**: extracted the inline `MOCK_BPMN_XML` out of the bpmn host file into `app/__fixtures__/mock-bpmn.ts` (next to the existing `mock-diff.ts`).

Deliberately **preserved**: `acquireVsCodeApi()` (the literal host-injected global), the `vsCodeBridge` modeler injection key, and the `vscode-dark` / `vscode-light` theme classes.

## Verification

- `build:libs` + all three webview builds green
- `state.spec.ts` passes
- `format:check` clean, `lint` 0 errors (only pre-existing warnings)
- Repo-wide grep confirms no remaining references to the old symbols/paths