### PR TITLE
fix(vscode-plugin): stop contributing Miragon workbench themes (#1190)

### DIFF
--- a/apps/vscode-plugin/package.json
+++ b/apps/vscode-plugin/package.json
@@ -93,20 +93,6 @@
                 "url": "./schemas/bpmn-vars.schema.json"
             }
         ],
-        "themes": [
-            {
-                "id": "miragon-light",
-                "label": "Miragon Light",
-                "uiTheme": "vs",
-                "path": "./themes/miragon-light.json"
-            },
-            {
-                "id": "miragon-dark",
-                "label": "Miragon Dark",
-                "uiTheme": "vs-dark",
-                "path": "./themes/miragon-dark.json"
-            }
-        ],
         "customEditors": [
             {
                 "id": "bpmn-modeler.bpmn",

--- a/apps/vscode-plugin/test/e2e/.vscode-test.mjs
+++ b/apps/vscode-plugin/test/e2e/.vscode-test.mjs
@@ -14,7 +14,7 @@ const here = import.meta.dirname;
 const repoRoot = resolve(here, "../../../..");
 
 // webpack assembles the runnable extension (compiled main.js + a copied
-// package.json + themes + the three webview bundles) here; pointing at the
+// package.json + the three webview bundles) here; pointing at the
 // source `apps/vscode-plugin` would fail because `main: "main.js"` only
 // resolves in the dist dir. So `corepack yarn build` is a prerequisite.
 const extensionDevelopmentPath = resolve(repoRoot, "dist/apps/vscode-plugin");

--- a/apps/vscode-plugin/webpack.config.js
+++ b/apps/vscode-plugin/webpack.config.js
@@ -94,13 +94,6 @@ module.exports = (env, argv) => {
                         noErrorOnMissing: true,
                     },
                     {
-                        // Single source of truth: themes live in the standalone
-                        // extension. `vsce package --no-dependencies` strips
-                        // node_modules, so the JSON must be present in dist.
-                        from: path.resolve(__dirname, "../../libs/standalone-extension/src/themes"),
-                        to: "themes",
-                    },
-                    {
                         from: path.resolve(__dirname, "../../LICENSE"),
                         to: ".",
                         noErrorOnMissing: true,


### PR DESCRIPTION
**Issue**

Closes #1190 — after installing the BPMN Modeler extension, VS Code's entire workbench turned "greenish" and syntax highlighting broke until the extension was disabled/re-enabled.

**Description**

The extension contributed the Miragon Light/Dark color themes, which made VS Code auto-apply the first theme on install and hijack the user's `workbench.colorTheme`. VS Code offers no manifest flag to contribute a theme without this install-time preview, and no plugin runtime reads these themes — they are standalone Theia branding only. This removes the `themes` contribution from `package.json`, the webpack copy that staged the theme JSON into the VSIX, and a stale comment in the e2e config. The standalone Theia app is unaffected (it imports the themes from its own `src/themes`).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created