### PR TITLE
chore(release): silence release pipeline warnings

### DIFF
--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - name: Upload ZIP to release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5.0.0

--- a/apps/vscode-plugin/webpack.config.js
+++ b/apps/vscode-plugin/webpack.config.js
@@ -74,6 +74,10 @@ module.exports = (env, argv) => {
                         },
                     },
                     {
+                        from: path.resolve(__dirname, ".vscodeignore"),
+                        to: ".",
+                    },
+                    {
                         from: path.resolve(__dirname, "assets"),
                         to: "assets",
                     },


### PR DESCRIPTION
## What

Clears the warning annotations emitted by the Release Please pipeline.

### `.vscodeignore` missing (open-vsx, vscode, standalone build-vsix)
All three jobs run `vsce package` from `dist/apps/vscode-plugin/`, but the `.vscodeignore` only lived in the source dir — so vsce found no ignore file, warned on every publish, and the webviews' `index.html`/`favicon.ico` leaked into the vsix. Now copied into the build output via `copy-webpack-plugin`, which both silences the warning and actually applies the ignore rules.

### `app-id` deprecated (release-please, intellij)
`actions/create-github-app-token` deprecated the `app-id` input in favour of `client-id`. Switched both usages to `client-id`, backed by a new org variable `RELEASE_PLEASE_APP_CLIENT_ID` (the GitHub App's Client ID). The `RELEASE_PLEASE_APP_PRIVATE_KEY` secret is unchanged.

## Not addressed
The `macos-latest will migrate to macOS 26` note on the DMG job is informational only and left as a deliberate migration to track.