### PR TITLE
fix(intellij-plugin): resolve JetBrains Marketplace verification rejection

### DIFF
--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -58,6 +58,13 @@ dependencies {
 
 kotlin {
     jvmToolchain(21)
+    compilerOptions {
+        // Emit real JVM default methods instead of DefaultImpls override bridges,
+        // which the plugin verifier otherwise flags as internal/experimental/
+        // deprecated usages of the inherited platform defaults (e.g.
+        // ToolWindowFactory.getIcon) — Marketplace-blocking false positives.
+        freeCompilerArgs.add("-jvm-default=no-compatibility")
+    }
 }
 
 tasks.test {
@@ -107,7 +114,6 @@ intellijPlatform {
         failureLevel = listOf(
             FailureLevel.COMPATIBILITY_PROBLEMS,
             FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
-            FailureLevel.MISSING_DEPENDENCIES,
             FailureLevel.INVALID_PLUGIN,
         )
         ides {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
@@ -13,7 +13,6 @@ import com.intellij.ui.JBColor
 import com.intellij.util.containers.ContainerUtil
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.NamedColorUtil
-import com.intellij.util.ui.StartupUiUtil
 import com.intellij.util.ui.UIUtil
 import org.cef.browser.CefBrowser
 
@@ -32,9 +31,9 @@ import org.cef.browser.CefBrowser
  * It owns dark detection, the IDE→`--vscode-*` color mapping, the HTML/JS
  * snippet generation, and the change fan-out — keeping [WebviewServer] and the
  * editors free of theming logic (SRP). Dark detection deliberately uses the
- * **LaF** ([StartupUiUtil.isDarkTheme]), not the editor scheme, so the palette
- * and properties panel match the IDE chrome; the canvas additionally receives
- * the real editor-scheme background/foreground through the injected variables.
+ * **LaF** ([JBColor.isBright]), not the editor scheme, so the palette and
+ * properties panel match the IDE chrome; the canvas additionally receives the
+ * real editor-scheme background/foreground through the injected variables.
  */
 @Service(Service.Level.APP)
 class IdeThemeSignal : Disposable {
@@ -57,7 +56,7 @@ class IdeThemeSignal : Disposable {
     }
 
     /** LaF-based dark detection — matches the IDE chrome the webview sits in. */
-    fun isDark(): Boolean = StartupUiUtil.isDarkTheme
+    fun isDark(): Boolean = !JBColor.isBright()
 
     /** The body class VS Code would set; `app/theme.ts` keys its stylesheet swap off this. */
     fun bodyClass(): String = if (isDark()) "vscode-dark" else "vscode-light"

--- a/apps/intellij-plugin/src/main/resources/META-INF/modeler-jcef.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/modeler-jcef.xml
@@ -1,0 +1,4 @@
+<idea-plugin>
+    <!-- Marker for the optional intellij.platform.ui.jcef dependency; intentionally
+         empty — it exists only for the class-loader link, not to register anything. -->
+</idea-plugin>

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,14 @@
     -->
     <depends optional="true" config-file="modeler-json.xml">com.intellij.modules.json</depends>
 
+    <!--
+        2026.2 split JCEF out of the core class path into its own module, so without
+        this the plugin's class loader can't see JBCefApp and crashes at startup.
+        Optional because the module is absent on the 242 floor (JCEF still core
+        there); where present it becomes a class-loader parent.
+    -->
+    <depends optional="true" config-file="modeler-jcef.xml">intellij.platform.ui.jcef</depends>
+
     <extensions defaultExtensionNs="com.intellij">
         <!--
             Registers `.bpmn` as a real file type so (a) JetBrains Marketplace's


### PR DESCRIPTION
## Why

The IntelliJ plugin's 1.2.0 submission to the JetBrains Marketplace was **rejected by the automated compatibility verification**. Reproduced locally with `./gradlew verifyPlugin` (same tool the Marketplace runs) plus the actual crash stack trace from JetBrains' public plugin-verification TeamCity. Three distinct causes, all fixed here.

## Fixes

### 1. Startup crash on 2026.2 (262) — the hard blocker
`BridgeWarmupActivity` (a `postStartupActivity`) threw at project open:
```
NoClassDefFoundError / ClassNotFoundException: com.intellij.ui.jcef.JBCefApp
  at io.miragon.intellij.bpmn.BridgeWarmupActivity.execute(BridgeWarmupActivity.kt:27)
```
In 2026.2 the platform split JCEF out of the core class path into the content module `intellij.platform.ui.jcef` (its own class loader). The plugin didn't declare it, so its `PluginClassLoader` could no longer see `JBCefApp`.

**Fix:** an **optional** `<depends>` on `intellij.platform.ui.jcef` (where `JBCefApp` lives). On 262+ the module is present → class-loader parent → resolvable. On the 242 floor it's absent → skipped, JCEF still resolves from core. Matches how in-tree JCEF consumers (markdown, images) declare it.

### 2. Internal API usage
`IdeThemeSignal.isDark()` called the internal `StartupUiUtil.isDarkTheme` → switched to public `!JBColor.isBright()`.

### 3. Experimental / deprecated API usages
These were Kotlin-generated DefaultImpls override bridges for inherited platform default methods (`ToolWindowFactory.getIcon/getAnchor/manage`, `StatusBarWidget.getPresentation(PlatformType)`), not hand-written calls. Compiling with `-jvm-default=no-compatibility` stops emitting the bridges — dropping all experimental usages and the bridge deprecations at once.

### Verifier gate
Dropped `MISSING_DEPENDENCIES` from `pluginVerification.failureLevel`: the optional JCEF dep is structurally unresolvable on the 242/261 verify targets (JCEF is core there), which the Marketplace itself treats as non-blocking (verdict stays *Compatible*). Genuine missing *required* deps still surface via `COMPATIBILITY_PROBLEMS` / `INVALID_PLUGIN`.

## Validation

| | before | after |
|---|---|---|
| `verifyPlugin` IC-242 | 7 internal · 2 experimental · 7 deprecated | **Compatible** |
| `verifyPlugin` IU-261 | 1 internal · 6 experimental · 10 deprecated | **Compatible** (3 genuine deprecations) |

`internal = 0`, `experimental = 0`; plugin `test` suite passes.

## Not covered / follow-up
- **262 runtime confirmation:** local resolution of the 2026.2 EAP SDK is blocked by a Gradle snapshot-layout mismatch, so the JCEF-fix's runtime effect is inferred from the JetBrains source + verifier parse — final proof is a real 2026.2 run or the Marketplace re-check.
- 3 genuine deprecations remain on 261 (`ReadAction.compute` ×2, `CredentialAttributes` ctor) — non-blocking.
- Wiring `verifyPlugin` into CI for plugin PRs is a sensible follow-up.