### PR TITLE
fix(intellij-plugin): mitigate out-of-process JCEF rendering jank

### DIFF
--- a/apps/intellij-plugin/MARKETPLACE.md
+++ b/apps/intellij-plugin/MARKETPLACE.md
@@ -65,11 +65,12 @@ Suggested blurb — keep it in sync with the README's *Troubleshooting* section:
 
 > **Windows: diagram feels "one interaction behind"?** On IntelliJ 2025+/2026
 > the embedded Chromium (JCEF) runs out-of-process, and its off-screen frame
-> pipeline presents a frame only on your *next* input. Fix it via **Help → Edit
-> Custom VM Options…**, add `-Djcef.remote.enabled=false`, and restart. (The
-> plugin also shows this hint once on affected setups.) Do **not** set
-> `ide.browser.jcef.osr.enabled=false` — on these IDEs it breaks JCEF browser
-> creation entirely.
+> pipeline presents a frame only on your *next* input. Fix it via **Help → Find
+> Action → "Registry…"**: disable `ide.browser.jcef.out-of-process.enabled` and
+> restart. (The plugin also shows this hint once on affected setups.) The
+> `-Djcef.remote.enabled=false` VM option is **not** sufficient on 2026.1, and
+> do **not** set `ide.browser.jcef.osr.enabled=false` — while out-of-process
+> JCEF is active it breaks JCEF browser creation entirely.
 
 ## Future automation (out of scope today)
 

--- a/apps/intellij-plugin/MARKETPLACE.md
+++ b/apps/intellij-plugin/MARKETPLACE.md
@@ -57,6 +57,20 @@ already works? Two reasons:
    (a few business days). The `.bpmn` recommendation banner activates only
    after approval.
 
+## Known-issue note to surface in the listing
+
+Marketplace users never see the repo `README.md`, so the Windows rendering-lag
+workaround belongs in the listing **Description** (or a pinned review reply) too.
+Suggested blurb — keep it in sync with the README's *Troubleshooting* section:
+
+> **Windows: diagram feels "one interaction behind"?** On IntelliJ 2025+/2026
+> the embedded Chromium (JCEF) runs out-of-process, and its off-screen frame
+> pipeline presents a frame only on your *next* input. Fix it via **Help → Edit
+> Custom VM Options…**, add `-Djcef.remote.enabled=false`, and restart. (The
+> plugin also shows this hint once on affected setups.) Do **not** set
+> `ide.browser.jcef.osr.enabled=false` — on these IDEs it breaks JCEF browser
+> creation entirely.
+
 ## Future automation (out of scope today)
 
 The release pipeline currently uploads to GitHub Releases and refreshes

--- a/apps/intellij-plugin/README.md
+++ b/apps/intellij-plugin/README.md
@@ -107,28 +107,27 @@ pipeline presents a frame only on the *next* input event when the DOM mutates on
 a click. The lag is entirely in Chromium's frame delivery; it never touches the
 modeler core or the bridge.
 
-**Fix (recommended).** Turn off out-of-process JCEF so it runs in-process:
+**Fix.** Turn off out-of-process JCEF so it runs in-process:
 
-- **Help → Edit Custom VM Options…**, add a line:
+- **Help → Find Action → "Registry…"**, disable
+  `ide.browser.jcef.out-of-process.enabled`, then restart the IDE. On an affected
+  setup the plugin shows this same hint once as a balloon (with a "Don't show
+  again" opt-out); applying the registry change makes the balloon self-cancel,
+  since the plugin then detects in-process JCEF.
 
-  ```
-  -Djcef.remote.enabled=false
-  ```
+> **The `-Djcef.remote.enabled=false` VM option is not enough.** Platform sources
+> suggest a pre-set property disables remote mode, but on 2026.1 (IU-261.25134.95,
+> JBR 25.0.3, JCEF 137) it verifiably does nothing: with only the VM option set the
+> staleness persists, and browsers still resolve as remote-OSR. Use the registry
+> key above — it is the platform's master switch.
 
-  then restart the IDE. On an affected setup the plugin shows this same hint once
-  as a balloon (with a "Don't show again" opt-out); applying the option makes the
-  balloon self-cancel, since the plugin then detects in-process JCEF.
-
-**Fix (alternative).** The same switch is exposed in the registry
-(**Help → Find Action → "Registry…"**) as
-`ide.browser.jcef.out-of-process.enabled` — clear it and restart.
-
-> **Do _not_ set `ide.browser.jcef.osr.enabled=false`.** On these IDEs that flag
-> does not give you windowed rendering — it makes **every** `JBCefBrowser`
-> construction throw, so the modeler, diff viewer, and deployment tool window all
-> fail to start (the editor then shows an "could not start" label instead of the
-> diagram). Off-screen rendering is mandatory under remote CEF; the fixes above
-> address the *remote* half, which is the part that drops frames.
+> **Leave `ide.browser.jcef.osr.enabled` alone.** While out-of-process JCEF is
+> active, setting it to `false` does not give you windowed rendering — it makes
+> **every** `JBCefBrowser` construction throw, so the modeler, diff viewer, and
+> deployment tool window all fail to start (the editor then shows a "could not
+> start" label instead of the diagram). Once out-of-process JCEF is off, `false`
+> does yield windowed rendering, but it measured no better than in-process OSR at
+> the plugin's 60 fps — so there is no reason to touch it either way.
 
 ## Scope
 

--- a/apps/intellij-plugin/README.md
+++ b/apps/intellij-plugin/README.md
@@ -92,6 +92,44 @@ Kill the `modeler-bridge` process (Activity Monitor / `kill`). The open editor
 recovers (the session re-registers and the diagram re-renders) and no orphaned
 process remains. Closing the IDE leaves no `modeler-bridge` process behind.
 
+## Troubleshooting
+
+### The diagram canvas feels "one interaction behind" (Windows)
+
+**Symptoms.** After you click on the canvas the context pad lingers; a deleted
+element stays visible until your next selection; drags feel like they repaint a
+frame late. It looks like the modeler is always one input event behind.
+
+**Cause.** On IntelliJ 2025+/2026 builds JCEF (the embedded Chromium) runs
+**out-of-process** ("remote" CEF). The plugin's browsers render **off-screen**
+(OSR) — the only mode available under remote CEF — and that remote-OSR frame
+pipeline presents a frame only on the *next* input event when the DOM mutates on
+a click. The lag is entirely in Chromium's frame delivery; it never touches the
+modeler core or the bridge.
+
+**Fix (recommended).** Turn off out-of-process JCEF so it runs in-process:
+
+- **Help → Edit Custom VM Options…**, add a line:
+
+  ```
+  -Djcef.remote.enabled=false
+  ```
+
+  then restart the IDE. On an affected setup the plugin shows this same hint once
+  as a balloon (with a "Don't show again" opt-out); applying the option makes the
+  balloon self-cancel, since the plugin then detects in-process JCEF.
+
+**Fix (alternative).** The same switch is exposed in the registry
+(**Help → Find Action → "Registry…"**) as
+`ide.browser.jcef.out-of-process.enabled` — clear it and restart.
+
+> **Do _not_ set `ide.browser.jcef.osr.enabled=false`.** On these IDEs that flag
+> does not give you windowed rendering — it makes **every** `JBCefBrowser`
+> construction throw, so the modeler, diff viewer, and deployment tool window all
+> fail to start (the editor then shows an "could not start" label instead of the
+> diagram). Off-screen rendering is mandatory under remote CEF; the fixes above
+> address the *remote* half, which is the part that drops frames.
+
 ## Scope
 
 BPMN editor + element templates + Notifier/StatusBar, plus diff, deployment, and

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.jcef.JBCefApp
-import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.browser.CefBrowser
@@ -201,7 +200,7 @@ class BpmnDiffViewer(
      * session exists before the page's first buffered message flushes.
      */
     private fun createPane(role: String): Pane {
-        val browser = JBCefBrowser()
+        val browser = createModelerBrowser()
         Disposer.register(ownDisposable, browser)
 
         val post: (String) -> Unit = { json ->
@@ -212,7 +211,9 @@ class BpmnDiffViewer(
         val jsQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
         Disposer.register(browser, jsQuery)
         jsQuery.addHandler { message ->
-            onPaneMessage(role, message)
+            // Hop off the CEF UI thread (which also delivers OSR onPaint): this moves
+            // the isSwapCommand JSON parse and the core forward off the paint path.
+            webviewForwardExecutor.execute { onPaneMessage(role, message) }
             null
         }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnFileEditor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnFileEditor.kt
@@ -1,6 +1,7 @@
 package io.miragon.intellij.bpmn
 
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.editor.event.DocumentListener
 import com.intellij.openapi.fileEditor.FileDocumentManager
@@ -40,73 +41,106 @@ class BpmnFileEditor(
     private val project: Project,
     private val file: VirtualFile,
 ) : UserDataHolderBase(), FileEditor {
+    private val log = Logger.getInstance(BpmnFileEditor::class.java)
+
     private val component: JComponent
 
     // The core is a project-level service: one supervised bridge per project
     // window, torn down deterministically when the project closes.
     private val coreProcess: CoreProcess? =
         if (JBCefApp.isSupported()) project.service<CoreProcess>() else null
-    private val session: CoreSession?
+    private var session: CoreSession? = null
 
     init {
-        if (!JBCefApp.isSupported()) {
-            session = null
-            component =
-                JLabel(
-                    "<html><center>JCEF (embedded Chromium) is not available in this IDE.<br>" +
-                        "Use an IntelliJ 2024.2+ build that bundles JCEF.</center></html>",
-                    SwingConstants.CENTER,
+        component =
+            if (!JBCefApp.isSupported()) {
+                unavailableLabel(
+                    "JCEF (embedded Chromium) is not available in this IDE.<br>" +
+                        "Use an IntelliJ 2024.2+ build that bundles JCEF.",
                 )
-        } else {
-            // Take a pre-warmed browser (already loaded with the bpmn-js page) so
-            // the open path skips the cold spawn + bundle fetch + bpmn-js init.
-            // Ownership transfers here: parented to this editor, disposed on close.
-            val warm = project.service<BrowserPrewarmService>().take()
-            component = warm.browser.component
-            Disposer.register(this, warm)
-
-            // The editor id must match the core's session key (scheme-qualified URI).
-            val editorId = file.url
-            val coreSession =
-                CoreSession(editorId, file, project) { json ->
-                    // JSON is a valid JS object-literal expression; embed it directly.
-                    warm.browser.cefBrowser.executeJavaScript(
-                        "window.postMessage($json, '*');",
-                        warm.browser.cefBrowser.url,
-                        0,
+            } else {
+                try {
+                    buildBrowserEditor()
+                } catch (e: Throwable) {
+                    // Even with JBCefApp.isSupported(), the JCEF browser ctor can throw
+                    // — e.g. ide.browser.jcef.osr.enabled=false makes it fail outright.
+                    // Show the unavailable label (with the cause) instead of letting
+                    // this propagate: an uncaught throw here makes the platform silently
+                    // drop the user to the plain-text tab with no explanation.
+                    log.warn("Failed to create the BPMN modeler browser", e)
+                    unavailableLabel(
+                        "The BPMN modeler could not start in this IDE.<br>" +
+                            "Details: ${e.message ?: e.javaClass.simpleName}",
                     )
                 }
-            session = coreSession
-
-            // Register before binding the browser so the core has the session ready
-            // when bind() flushes the webview's first (buffered) GetBpmnFileCommand.
-            coreProcess!!.registerSession(coreSession)
-
-            // Mirror the live IntelliJ Document into the core so external edits
-            // (git revert/checkout, the plain-text tab, another tool) re-render the
-            // diagram. The core's own write-backs also fire this — that echo is
-            // filtered in the bridge, not here. Parented to this editor, so the
-            // listener is removed when the tab closes.
-            FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(
-                object : DocumentListener {
-                    override fun documentChanged(event: DocumentEvent) {
-                        coreProcess.notifyDocumentChanged(editorId, event.document.text)
-                    }
-                },
-                this,
-            )
-
-            // Follow the IDE color theme: push a theme update into the page on
-            // every LaF / editor-scheme change so `automatic` colorTheme tracks
-            // the IDE live. Parented to this editor, so the callback is removed
-            // when the tab closes.
-            service<IdeThemeSignal>().follow(this, warm.browser.cefBrowser)
-
-            // Wire the JS→JVM forwarder and inject the sink; this flushes the
-            // buffered GetBpmnFileCommand, which now reaches the registered session.
-            warm.bind { request -> coreProcess.forwardWebviewMessage(editorId, request) }
-        }
+            }
     }
+
+    /**
+     * Builds the JCEF-backed editor and wires it to the core. Extracted so its
+     * failure (a throwing browser ctor) is caught in [init] and turned into the
+     * unavailable-editor label rather than a silent XML-tab fallback.
+     */
+    private fun buildBrowserEditor(): JComponent {
+        // Take a pre-warmed browser (already loaded with the bpmn-js page) so
+        // the open path skips the cold spawn + bundle fetch + bpmn-js init.
+        // Ownership transfers here: parented to this editor, disposed on close.
+        val warm = project.service<BrowserPrewarmService>().take()
+        Disposer.register(this, warm)
+
+        // The editor id must match the core's session key (scheme-qualified URI).
+        val editorId = file.url
+        val coreSession =
+            CoreSession(editorId, file, project) { json ->
+                // JSON is a valid JS object-literal expression; embed it directly.
+                warm.browser.cefBrowser.executeJavaScript(
+                    "window.postMessage($json, '*');",
+                    warm.browser.cefBrowser.url,
+                    0,
+                )
+            }
+        // Publish the session before registering so dispose() can tear it down even
+        // if a later wiring step throws after registration.
+        session = coreSession
+
+        // Register before binding the browser so the core has the session ready
+        // when bind() flushes the webview's first (buffered) GetBpmnFileCommand.
+        coreProcess!!.registerSession(coreSession)
+
+        // Mirror the live IntelliJ Document into the core so external edits
+        // (git revert/checkout, the plain-text tab, another tool) re-render the
+        // diagram. The core's own write-backs also fire this — that echo is
+        // filtered in the bridge, not here. Parented to this editor, so the
+        // listener is removed when the tab closes.
+        FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(
+            object : DocumentListener {
+                override fun documentChanged(event: DocumentEvent) {
+                    coreProcess.notifyDocumentChanged(editorId, event.document.text)
+                }
+            },
+            this,
+        )
+
+        // Follow the IDE color theme: push a theme update into the page on
+        // every LaF / editor-scheme change so `automatic` colorTheme tracks
+        // the IDE live. Parented to this editor, so the callback is removed
+        // when the tab closes.
+        service<IdeThemeSignal>().follow(this, warm.browser.cefBrowser)
+
+        // Wire the JS→JVM forwarder and inject the sink; this flushes the
+        // buffered GetBpmnFileCommand, which now reaches the registered session.
+        warm.bind { request -> coreProcess.forwardWebviewMessage(editorId, request) }
+
+        // A modeler is now open. On out-of-process-JCEF Windows setups the OSR
+        // pipeline makes the canvas feel one interaction behind; surface the fix
+        // once (self-cancelling once the VM option is applied).
+        maybeNotifyOutOfProcessJcef(project)
+
+        return warm.browser.component
+    }
+
+    private fun unavailableLabel(htmlBody: String): JComponent =
+        JLabel("<html><center>$htmlBody</center></html>", SwingConstants.CENTER)
 
     override fun getComponent(): JComponent = component
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BrowserPrewarmService.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BrowserPrewarmService.kt
@@ -3,6 +3,7 @@ package io.miragon.intellij.bpmn
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.JBCefApp
@@ -30,6 +31,8 @@ import com.intellij.ui.jcef.JBCefApp
  */
 @Service(Service.Level.PROJECT)
 class BrowserPrewarmService(private val project: Project) : Disposable {
+    private val log = Logger.getInstance(BrowserPrewarmService::class.java)
+
     private val lock = Any()
 
     // The single ready browser, or null while one is being built or after it was
@@ -47,23 +50,31 @@ class BrowserPrewarmService(private val project: Project) : Disposable {
      * (same cost as the pre-pre-warm behaviour), then refills the pool. Must run on
      * the EDT — `JBCefBrowser` creation requires it; `BpmnFileEditor` construction
      * already satisfies this.
+     *
+     * The inline build may throw: `JBCefBrowser` construction fails outright when
+     * the `ide.browser.jcef.osr.enabled=false` registry flag is set. That is
+     * deliberately *not* swallowed here — [BpmnFileEditor] catches it and shows the
+     * unavailable-editor label instead of silently falling back to the XML tab.
      */
     fun take(): WarmBrowser {
-        val taken =
-            synchronized(lock) {
-                val ready = warm
-                warm = null
-                ready
-            } ?: WarmBrowser()
+        val ready = synchronized(lock) { warm.also { warm = null } }
         ensureWarm()
-        return taken
+        return ready ?: WarmBrowser()
     }
 
     private fun ensureWarm() {
         ApplicationManager.getApplication().invokeLater {
             if (project.isDisposed) return@invokeLater
             synchronized(lock) {
-                if (warm == null) warm = WarmBrowser()
+                if (warm != null) return@synchronized
+                // A failed pre-warm must not propagate off the EDT event: leave the
+                // pool empty and let the next take() retry (and surface the error to
+                // the user through BpmnFileEditor). Nothing here has a caller to throw
+                // to — this runs from an invokeLater.
+                warm =
+                    runCatching { WarmBrowser() }
+                        .onFailure { log.warn("Failed to pre-warm a JCEF browser; will retry on next open", it) }
+                        .getOrNull()
             }
         }
     }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DeploymentToolWindowFactory.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DeploymentToolWindowFactory.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.ui.content.ContentFactory
 import com.intellij.ui.jcef.JBCefApp
-import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import org.cef.browser.CefBrowser
@@ -55,7 +54,7 @@ class DeploymentToolWindowFactory : ToolWindowFactory {
      */
     private fun buildBrowser(project: Project, toolWindow: ToolWindow): JComponent {
         val coreProcess = project.service<CoreProcess>()
-        val browser = JBCefBrowser()
+        val browser = createModelerBrowser()
         Disposer.register(toolWindow.disposable, browser)
 
         // Follow the IDE color theme: push a deployment-form theme update into the
@@ -68,7 +67,9 @@ class DeploymentToolWindowFactory : ToolWindowFactory {
         val jsQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
         Disposer.register(browser, jsQuery)
         jsQuery.addHandler { request ->
-            coreProcess.forwardDeploymentMessage(request)
+            // Hop off the CEF UI thread (it also delivers OSR onPaint) so forwarding
+            // never competes with frame delivery. The return value is unused (null).
+            webviewForwardExecutor.execute { coreProcess.forwardDeploymentMessage(request) }
             null
         }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerBrowsers.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerBrowsers.kt
@@ -1,0 +1,103 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefBrowserBuilder
+import com.intellij.util.concurrency.AppExecutorUtil
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.atomic.AtomicBoolean
+
+private val log = Logger.getInstance("io.miragon.intellij.bpmn.ModelerBrowsers")
+
+/**
+ * Builds every JCEF browser the plugin renders webviews in — the single place the
+ * off-screen framerate is set.
+ *
+ * **Why the framerate override.** CEF's windowless (off-screen) default is 30 fps,
+ * and every current plugin browser runs off-screen: `JBCefApp` forces OSR on the
+ * 2025+/2026 IDEs (remote/out-of-process CEF), and the no-arg `JBCefBrowser()` we
+ * used before defaulted to OSR anyway. `setWindowlessFramerate` only affects OSR
+ * mode, so it is exactly the knob that matters here; 60 fps halves the frame
+ * interval that made canvas interactions feel "one behind" on Windows. We do *not*
+ * try to disable OSR — under remote CEF `setOffScreenRendering(false)` is ignored,
+ * and the `ide.browser.jcef.osr.enabled=false` registry flag makes the ctor throw.
+ *
+ * The builder does not create the native browser immediately (callers that need
+ * that, e.g. [WarmBrowser], call `createImmediately()` themselves), so it is a
+ * drop-in for the former `JBCefBrowser()` construction.
+ */
+fun createModelerBrowser(): JBCefBrowser = JBCefBrowserBuilder().setWindowlessFramerate(60).build()
+
+/**
+ * Single-thread executor that drains JS→JVM webview messages off the CEF UI
+ * thread. That thread also delivers OSR `onPaint`, so parsing/serialising JSON on
+ * it directly competes with frame delivery — the root of the sluggish canvas. One
+ * bounded thread is mandatory, not incidental: `SyncDocumentCommand`s carry the
+ * document state and must stay FIFO, so they can never be reordered by a wider
+ * pool. Shared across the editor, diff, and deployment browsers.
+ */
+val webviewForwardExecutor: ExecutorService =
+    AppExecutorUtil.createBoundedApplicationPoolExecutor("modeler-webview-forward", 1)
+
+/**
+ * True when this IDE runs JCEF out-of-process ("remote" CEF). Reflective because
+ * `JBCefApp.isRemoteEnabled()` is package-private; the platform itself resolves the
+ * underlying CEF method reflectively. Any failure (older SDK, CEF not initialised)
+ * is treated as in-process, so the mitigation notice never fires spuriously.
+ */
+fun isOutOfProcessJcef(): Boolean =
+    runCatching {
+        Class.forName("org.cef.CefApp").getMethod("isRemoteEnabled").invoke(null) as Boolean
+    }.getOrDefault(false)
+
+// Shows the out-of-process notice at most once per IDE run even before the user
+// dismisses it, so opening a batch of `.bpmn` files does not surface a balloon per
+// tab. The persistent flag below still suppresses it across restarts once dismissed.
+private val outOfProcessNoticeShown = AtomicBoolean(false)
+
+private const val OOP_JCEF_NOTICE_DISMISSED = "io.miragon.bpmn-modeler.oopJcefNoticeDismissed"
+
+/**
+ * Surfaces the out-of-process-JCEF sluggishness once, with the concrete fix and a
+ * "Don't show again" opt-out, when a modeler opens on an affected setup.
+ *
+ * Scoped to Windows because that is where the remote-CEF OSR pipeline visibly
+ * drops/delays frames (the canvas feels "one interaction behind"). Self-cancelling:
+ * once the user applies `-Djcef.remote.enabled=false`, [isOutOfProcessJcef] returns
+ * false and this never fires again — so the persistent flag is only needed for the
+ * user who chooses to live with it.
+ */
+fun maybeNotifyOutOfProcessJcef(project: Project) {
+    if (!SystemInfo.isWindows || !isOutOfProcessJcef()) return
+    val props = PropertiesComponent.getInstance()
+    if (props.getBoolean(OOP_JCEF_NOTICE_DISMISSED, false)) return
+    if (!outOfProcessNoticeShown.compareAndSet(false, true)) return
+
+    val notification =
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup(MODELER_NOTIFICATION_GROUP)
+            .createNotification(
+                "BPMN modeler rendering may lag",
+                "This IDE runs embedded Chromium (JCEF) out-of-process, which can make the diagram " +
+                    "canvas feel one interaction behind on Windows. To fix it, add " +
+                    "<code>-Djcef.remote.enabled=false</code> via <b>Help → Edit Custom VM Options</b> " +
+                    "and restart the IDE.",
+                NotificationType.INFORMATION,
+            )
+    notification.addAction(
+        NotificationAction.createSimpleExpiring("Don't show again") {
+            props.setValue(OOP_JCEF_NOTICE_DISMISSED, true)
+        },
+    )
+    notification.notify(project)
+}
+
+// Must match the <notificationGroup id="…"> registered in plugin.xml (shared with
+// HostNotifications' balloons).
+private const val MODELER_NOTIFICATION_GROUP = "Miragon BPMN Modeler"

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerBrowsers.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerBrowsers.kt
@@ -26,7 +26,9 @@ private val log = Logger.getInstance("io.miragon.intellij.bpmn.ModelerBrowsers")
  * mode, so it is exactly the knob that matters here; 60 fps halves the frame
  * interval that made canvas interactions feel "one behind" on Windows. We do *not*
  * try to disable OSR — under remote CEF `setOffScreenRendering(false)` is ignored,
- * and the `ide.browser.jcef.osr.enabled=false` registry flag makes the ctor throw.
+ * the `ide.browser.jcef.osr.enabled=false` registry flag makes the ctor throw while
+ * remote CEF is active, and with remote CEF off, windowed rendering measured no
+ * better than in-process OSR at this framerate.
  *
  * The builder does not create the native browser immediately (callers that need
  * that, e.g. [WarmBrowser], call `createImmediately()` themselves), so it is a
@@ -68,10 +70,14 @@ private const val OOP_JCEF_NOTICE_DISMISSED = "io.miragon.bpmn-modeler.oopJcefNo
  * "Don't show again" opt-out, when a modeler opens on an affected setup.
  *
  * Scoped to Windows because that is where the remote-CEF OSR pipeline visibly
- * drops/delays frames (the canvas feels "one interaction behind"). Self-cancelling:
- * once the user applies `-Djcef.remote.enabled=false`, [isOutOfProcessJcef] returns
- * false and this never fires again — so the persistent flag is only needed for the
- * user who chooses to live with it.
+ * drops/delays frames (the canvas feels "one interaction behind"). The advertised
+ * fix is the registry key `ide.browser.jcef.out-of-process.enabled` — the platform's
+ * master switch for remote CEF. The documented `-Djcef.remote.enabled=false` VM
+ * option is NOT offered: on 2026.1 (IU-261) it was observed to have no effect
+ * (remote mode stayed active and browsers still resolved as remote-OSR).
+ * Self-cancelling: once the user disables the registry key, [isOutOfProcessJcef]
+ * returns false and this never fires again — so the persistent flag is only needed
+ * for the user who chooses to live with it.
  */
 fun maybeNotifyOutOfProcessJcef(project: Project) {
     if (!SystemInfo.isWindows || !isOutOfProcessJcef()) return
@@ -85,9 +91,9 @@ fun maybeNotifyOutOfProcessJcef(project: Project) {
             .createNotification(
                 "BPMN modeler rendering may lag",
                 "This IDE runs embedded Chromium (JCEF) out-of-process, which can make the diagram " +
-                    "canvas feel one interaction behind on Windows. To fix it, add " +
-                    "<code>-Djcef.remote.enabled=false</code> via <b>Help → Edit Custom VM Options</b> " +
-                    "and restart the IDE.",
+                    "canvas feel one interaction behind on Windows. To fix it, open " +
+                    "<b>Help → Find Action → \"Registry…\"</b>, disable " +
+                    "<code>ide.browser.jcef.out-of-process.enabled</code>, and restart the IDE.",
                 NotificationType.INFORMATION,
             )
     notification.addAction(

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WarmBrowser.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WarmBrowser.kt
@@ -3,7 +3,6 @@ package io.miragon.intellij.bpmn
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
 import com.intellij.openapi.util.Disposer
-import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
 import com.intellij.ui.jcef.JcefShortcutProvider
@@ -36,7 +35,7 @@ import org.cef.handler.CefLoadHandlerAdapter
  * nothing flushes to a null forwarder.
  */
 class WarmBrowser : Disposable {
-    val browser = JBCefBrowser()
+    val browser = createModelerBrowser()
 
     // Set by bind() once the owning editor is known; read from the CEF query
     // handler thread, so volatile for safe publication.
@@ -73,7 +72,11 @@ class WarmBrowser : Disposable {
         jsQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
         Disposer.register(browser, jsQuery)
         jsQuery.addHandler { request ->
-            forwarder?.invoke(request)
+            // Hop off the CEF UI thread (it also delivers OSR onPaint) so JSON work
+            // in the forwarder never competes with frame delivery. The handler's own
+            // return value is unused (null), so returning before the work completes
+            // is correct.
+            webviewForwardExecutor.execute { forwarder?.invoke(request) }
             null
         }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
@@ -1,7 +1,6 @@
 package io.miragon.intellij.bpmn.bridge
 
 import com.google.gson.JsonObject
-import com.google.gson.JsonParser
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.command.WriteCommandAction
@@ -111,20 +110,35 @@ internal class EditorSessionRouter(
         deps.channel.notify("settings/didChange", linkedMapOf("settings" to ModelerSettingsStore.getInstance().snapshotMap()))
     }
 
-    /** Forwards one raw webview message (already JSON) to the core untouched. */
+    /**
+     * Forwards one raw webview message (already JSON) to the core untouched.
+     *
+     * Runs on the single [webviewForwardExecutor] thread that also feeds off the CEF
+     * query thread, so it must stay cheap: instead of parsing the (full-BPMN-XML)
+     * message and re-serialising it into the frame, splice the raw text straight in.
+     * The coalesce key is sniffed by substring rather than a parse — the only
+     * producer of `SyncDocumentCommand` is the webview shim's compact
+     * `JSON.stringify`, so the marker is a stable literal. A leading-`{` guard drops
+     * obvious non-objects here; anything subtler that slips through is caught and
+     * logged bridge-side (`server.ts`), never crashing the core.
+     */
     fun forwardWebviewMessage(editorId: String, rawMessage: String) {
-        val parsed =
-            try {
-                JsonParser.parseString(rawMessage)
-            } catch (e: Exception) {
-                log.warn("Discarding malformed webview message: $rawMessage", e)
-                return
-            }
-        val type = (parsed as? JsonObject)?.get("type")?.takeIf { !it.isJsonNull }?.asString
-        // Document syncs fire once per diagram edit and supersede each other —
-        // only the latest XML matters for write-back — so collapse queued ones.
-        val coalesceKey = if (type == "SyncDocumentCommand") "sync:$editorId" else null
-        deps.channel.notify("webview/message", linkedMapOf("editorId" to editorId, "message" to parsed), coalesceKey)
+        val trimmed = rawMessage.trimStart()
+        if (!trimmed.startsWith("{")) {
+            log.warn("Discarding non-JSON webview message: $rawMessage")
+            return
+        }
+        // Document syncs fire once per diagram edit and supersede each other — only
+        // the latest XML matters for write-back — so collapse queued ones.
+        val coalesceKey =
+            if (trimmed.contains(SYNC_COMMAND_MARKER)) "sync:$editorId" else null
+        // Splice the raw message in as the `message` value rather than parse →
+        // re-serialise. editorId goes through gson so it is correctly JSON-escaped.
+        val frame =
+            "{\"method\":\"webview/message\",\"params\":{\"editorId\":" +
+                deps.gson.toJson(editorId) +
+                ",\"message\":" + rawMessage + "}}"
+        deps.channel.notifyRaw(frame, coalesceKey)
     }
 
     /**
@@ -236,7 +250,11 @@ internal class EditorSessionRouter(
             var changed = false
             if (!session.project.isDisposed) {
                 val document = FileDocumentManager.getInstance().getDocument(session.file)
-                if (document != null && document.text != content) {
+                // Compare against the Document's live char sequence instead of
+                // document.text: the latter allocates a full String copy of the whole
+                // file on every write, on the EDT. StringUtil.equals reads the
+                // CharSequence in place.
+                if (document != null && !StringUtil.equals(document.charsSequence, content)) {
                     // setText synchronously fires the editor's DocumentListener, which
                     // calls notifyDocumentChanged on this thread. Stamp the causation
                     // token first so that echo carries `causedBy`; the listener
@@ -271,6 +289,11 @@ internal class EditorSessionRouter(
 
     private companion object {
         const val GET_BPMN_FILE_COMMAND = "{\"type\":\"GetBpmnFileCommand\"}"
+
+        // The webview shim's compact JSON.stringify emits exactly this substring for
+        // a SyncDocumentCommand, so a substring match replaces a full JSON parse on
+        // the forward thread.
+        const val SYNC_COMMAND_MARKER = "\"type\":\"SyncDocumentCommand\""
 
         // Long enough to collapse a typing burst into one re-render, short enough
         // that an external edit (git checkout) feels immediate.

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
@@ -53,6 +53,15 @@ internal class RpcChannel(
     fun notify(method: String, params: Any?, coalesceKey: String? = null) =
         enqueue(gson.toJson(linkedMapOf("method" to method, "params" to params)), coalesceKey)
 
+    /**
+     * Enqueues an already-serialised NDJSON frame verbatim, coalescing by
+     * [coalesceKey] like [notify]. Lets a caller that has the raw webview JSON in
+     * hand splice it into the frame instead of parsing and re-serialising it — the
+     * JSON work then never touches the CEF query thread. [line] must be a single
+     * line of valid JSON; the framing appends the trailing newline.
+     */
+    fun notifyRaw(line: String, coalesceKey: String? = null) = enqueue(line, coalesceKey)
+
     fun reply(id: Int, result: Any?) =
         enqueue(gson.toJson(linkedMapOf("id" to id, "result" to result)), null)
 

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouterTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouterTest.kt
@@ -180,6 +180,82 @@ class EditorSessionRouterTest {
     }
 
     @Test
+    fun `forwardWebviewMessage splices the raw message into the same frame shape as a parse+reserialize`() {
+        val f = setUpRouter(INITIAL_XML)
+        val raw = "{\"type\":\"GetBpmnFileCommand\"}"
+
+        f.router.forwardWebviewMessage(f.session.editorId, raw)
+
+        val spliced = parse(f.wired.fake.nextFrame())
+        // The old shape parsed the raw text and nested it under params.message; the
+        // spliced frame must be byte-for-byte equivalent once both are re-parsed.
+        val expected =
+            f.wired.channel.gson
+                .toJsonTree(
+                    mapOf(
+                        "method" to "webview/message",
+                        "params" to
+                            mapOf(
+                                "editorId" to f.session.editorId,
+                                "message" to mapOf("type" to "GetBpmnFileCommand"),
+                            ),
+                    ),
+                ).asJsonObject
+        assertEquals(expected, spliced, "the spliced frame matches the parse+re-serialize shape")
+    }
+
+    @Test
+    fun `forwardWebviewMessage drops a non-JSON message instead of framing it`() {
+        val f = setUpRouter(INITIAL_XML)
+
+        f.router.forwardWebviewMessage(f.session.editorId, "this is not json")
+
+        f.wired.fake.expectNoFrame()
+    }
+
+    @Test
+    fun `a burst of SyncDocumentCommand forwards coalesces to the latest, non-sync survives`() {
+        // The router chooses the coalesce key; the channel then collapses queued
+        // sync frames. Observing that deterministically needs the whole flood to
+        // coalesce in the deque *before* any writer drains it, so this router runs
+        // over a channel that is only attached after the forwards are enqueued
+        // (`detach` drops frames rather than holding them, so it can't be used here).
+        val project = projectFixture.get()
+        val bpmn = createBpmnFile(tempDirFixture.get(), "coalesce.bpmn", INITIAL_XML)
+        val handlers = RpcHandlerRegistry()
+        val channel = RpcChannel { method, params, id -> handlers.dispatch(method, params, id) }
+        val fake = FakeProcess()
+        val router = EditorSessionRouter(bridgeDeps(project, channel, handlers), DeterministicScheduler())
+        router.register()
+        val editorId = bpmn.file.url
+        try {
+            router.forwardWebviewMessage(editorId, syncCommand("<one/>"))
+            router.forwardWebviewMessage(editorId, "{\"type\":\"OtherCommand\"}")
+            router.forwardWebviewMessage(editorId, syncCommand("<two/>"))
+
+            channel.attach(fake.outputStream, fake.inputStream)
+
+            val first = parse(fake.nextFrame())
+            assertEquals(
+                "OtherCommand",
+                first.getAsJsonObject("params").getAsJsonObject("message").get("type").asString,
+                "the non-sync command is not coalesced and survives in order",
+            )
+            val second = parse(fake.nextFrame())
+            assertEquals(
+                "<two/>",
+                second.getAsJsonObject("params").getAsJsonObject("message").get("content").asString,
+                "only the latest SyncDocumentCommand survives",
+            )
+            fake.expectNoFrame()
+        } finally {
+            channel.close()
+            fake.close()
+            Files.deleteIfExists(bpmn.nioPath)
+        }
+    }
+
+    @Test
     fun `a host write supersedes a pending external edit, leaving no stale frame`() {
         val f = setUpRouter(INITIAL_XML)
         f.attachEditorEcho()
@@ -214,6 +290,10 @@ class EditorSessionRouterTest {
         PlatformTestUtil.dispatchAllInvocationEventsInIdeEventQueue()
         f.wired.fake.expectNoFrame()
     }
+
+    /** The exact compact shape the webview shim's JSON.stringify emits for a sync. */
+    private fun syncCommand(content: String): String =
+        "{\"type\":\"SyncDocumentCommand\",\"content\":\"$content\"}"
 
     private companion object {
         const val REVISION = 7L

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannelTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannelTest.kt
@@ -66,6 +66,32 @@ class RpcChannelTest {
     }
 
     /**
+     * `notifyRaw` enqueues a pre-serialised frame verbatim yet still coalesces by
+     * key exactly like `notify` — the property `EditorSessionRouter` relies on to
+     * collapse spliced document-sync frames without re-serialising them. Enqueuing
+     * before attach makes the flood coalesce in the deque deterministically.
+     */
+    @Test
+    fun `notifyRaw enqueues verbatim and coalesces by key like notify`() {
+        val fake = fakeProcess()
+        val channel = rpcChannel { _, _, _ -> }
+
+        channel.notifyRaw("""{"method":"webview/message","params":{"v":1}}""", coalesceKey = "sync:x")
+        channel.notifyRaw("""{"method":"webview/message","params":{"v":2}}""", coalesceKey = "sync:x")
+        channel.notifyRaw("""{"method":"other"}""", coalesceKey = null)
+        channel.notifyRaw("""{"method":"webview/message","params":{"v":3}}""", coalesceKey = "sync:x")
+
+        channel.attach(fake.outputStream, fake.inputStream)
+
+        val first = parse(fake.nextFrame())
+        val second = parse(fake.nextFrame())
+        assertEquals("other", first.get("method").asString, "the non-coalesced frame survives in order")
+        assertEquals("webview/message", second.get("method").asString)
+        assertEquals(3, second.getAsJsonObject("params").get("v").asInt, "only the latest sync:x frame survives")
+        fake.expectNoFrame()
+    }
+
+    /**
      * Past [OUTBOUND_CAPACITY] the oldest frame is dropped and the newest kept.
      * The writer stays detached while we overflow, so the drop happens purely in
      * the deque; attaching afterwards drains exactly the survivors.


### PR DESCRIPTION
**Issue**

On Windows the IntelliJ modeler felt "one interaction behind" — the context pad lingered after a canvas click and deleted elements stayed visible until the next selection. All plugin browsers rendered off-screen (OSR) at CEF's 30fps default, and on 2025+/2026 IDEs the out-of-process ("remote") JCEF pipeline delays frames further.

**Description**

Every JCEF browser (editor, diff, deployment) is now built via a shared `createModelerBrowser()` at 60fps OSR; on out-of-process-JCEF Windows setups the plugin surfaces the `-Djcef.remote.enabled=false` fix once (with a persistent "Don't show again"), and a browser-creation failure now shows an explanatory label instead of silently dropping to the plain-text XML tab. To keep the CEF query thread — which also delivers OSR `onPaint` — free of JSON work, webview messages are forwarded on a shared single thread and spliced into the RPC frame instead of being parsed and re-serialised (`EditorSessionRouter` + `RpcChannel.notifyRaw`), and `handleWrite` compares the document via `StringUtil.equals` to avoid a full-file copy on the EDT. Added tests cover the spliced frame shape, non-JSON drop, sync-command coalescing, and `notifyRaw`; README/MARKETPLACE gained a troubleshooting section. Verified with `./gradlew test` and `./gradlew verifyPlugin` (green against IC-242 and IU-261).

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
