### PR TITLE
fix(intellij-plugin): fix JCEF module dependency and drop internal plugin lookup on 2026.2

### DIFF
--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -276,17 +276,29 @@ val copySchema =
         into(stagedResourcesRoot.map { it.dir("schemas") })
     }
 
+// Stamp the plugin version onto the class path so BridgeBinaryResolver can key
+// its extraction cache without a PluginManager lookup — every class/id→descriptor
+// API is @ApiStatus.Internal and would fail Marketplace verification.
+val writeBridgeVersion =
+    tasks.register("writeBridgeVersion") {
+        val versionFile = stagedResourcesRoot.map { it.file("bridge-version.txt") }
+        val pluginVersion = version.toString()
+        inputs.property("pluginVersion", pluginVersion)
+        outputs.file(versionFile)
+        doLast { versionFile.get().asFile.apply { parentFile.mkdirs() }.writeText(pluginVersion) }
+    }
+
 sourceSets.named("main") {
     resources.srcDir(stagedResourcesRoot)
 }
 
 tasks.named<ProcessResources>("processResources") {
-    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema)
+    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema, writeBridgeVersion)
 }
 
 // The sandbox for `runIde` is assembled from the jar, which already contains the
 // staged resources, so no extra sandbox wiring is needed — but make the
 // dependency explicit so a clean `runIde` always stages the bundles first.
 tasks.withType<PrepareSandboxTask>().configureEach {
-    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema)
+    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema, writeBridgeVersion)
 }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BpmnDiffViewer.kt
@@ -6,9 +6,10 @@ import com.intellij.diff.contents.DiffContent
 import com.intellij.diff.contents.DocumentContent
 import com.intellij.diff.contents.FileContent
 import com.intellij.diff.requests.ContentDiffRequest
-import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.JBSplitter
 import com.intellij.ui.jcef.JBCefApp
@@ -287,13 +288,15 @@ class BpmnDiffViewer(
      * kinds yield empty text, but [BpmnDiffTool.canShow] already declines those.
      */
     private fun textOf(content: DiffContent): String =
-        ReadAction.compute<String, RuntimeException> {
-            when (content) {
-                is DocumentContent -> content.document.text
-                is FileContent -> String(content.file.contentsToByteArray(), StandardCharsets.UTF_8)
-                else -> ""
-            }
-        }
+        ApplicationManager.getApplication().runReadAction(
+            Computable {
+                when (content) {
+                    is DocumentContent -> content.document.text
+                    is FileContent -> String(content.file.contentsToByteArray(), StandardCharsets.UTF_8)
+                    else -> ""
+                }
+            },
+        )
 
     private companion object {
         const val ROLE_BEFORE = "before"

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsConfigurable.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/ModelerSettingsConfigurable.kt
@@ -3,12 +3,12 @@ package io.miragon.intellij.bpmn
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import javax.swing.JComponent
 
 /**
@@ -90,7 +90,7 @@ class ModelerSettingsConfigurable : Configurable {
                 row("Language:") {
                     comboBox(
                         LOCALE_CODES,
-                        SimpleListCellRenderer.create("") { code -> LOCALE_LABELS[code] ?: code },
+                        textListCellRenderer<String?> { code -> code?.let { LOCALE_LABELS[it] ?: it } ?: "" },
                     ).bindItem({ state.language }, { state.language = it ?: DEFAULT_LOCALE })
                 }
                 row {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeBinaryResolver.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/BridgeBinaryResolver.kt
@@ -1,6 +1,5 @@
 package io.miragon.intellij.bpmn.bridge
 
-import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.diagnostic.Logger
 import java.nio.file.FileAlreadyExistsException
@@ -94,8 +93,16 @@ internal class BridgeBinaryResolver {
      * differ. Keyed by plugin version so an upgrade re-extracts (and Defender
      * re-scans once); falls back to `"dev"` when the version is unavailable — fine
      * because dev runs use the `MIRAGON_BRIDGE` override checked above.
+     *
+     * Read from a build-stamped class-path resource rather than a PluginManager
+     * lookup: every API that maps a class or id back to its descriptor
+     * (`getPluginByClass`, `PluginManagerCore.getPlugin`) is `@ApiStatus.Internal`
+     * and would fail JetBrains Marketplace verification.
      */
-    private fun bridgeCacheKey(): String = PluginManager.getPluginByClass(javaClass)?.version ?: "dev"
+    private fun bridgeCacheKey(): String =
+        javaClass.getResourceAsStream("/bridge-version.txt")
+            ?.bufferedReader()?.use { it.readText().trim() }
+            ?.ifEmpty { null } ?: "dev"
 
     /**
      * Best-effort removal of *other* version dirs so extracted binaries don't

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
@@ -3,10 +3,10 @@ package io.miragon.intellij.bpmn.bridge
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.concurrency.AppExecutorUtil
 import io.miragon.intellij.bpmn.CoreSession
@@ -78,9 +78,11 @@ internal class EditorSessionRouter(
 
     private fun sendRegister(session: CoreSession) {
         val content =
-            ReadAction.compute<String, RuntimeException> {
-                FileDocumentManager.getInstance().getDocument(session.file)?.text.orEmpty()
-            }
+            ApplicationManager.getApplication().runReadAction(
+                Computable {
+                    FileDocumentManager.getInstance().getDocument(session.file)?.text.orEmpty()
+                },
+            )
         deps.channel.notify(
             "session/register",
             linkedMapOf(

--- a/apps/intellij-plugin/src/main/resources/META-INF/modeler-jcef.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/modeler-jcef.xml
@@ -1,4 +1,4 @@
 <idea-plugin>
-    <!-- Marker for the optional intellij.platform.ui.jcef dependency; intentionally
+    <!-- Marker for the optional com.intellij.modules.jcef dependency; intentionally
          empty — it exists only for the class-loader link, not to register anything. -->
 </idea-plugin>

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -68,12 +68,14 @@
     <depends optional="true" config-file="modeler-json.xml">com.intellij.modules.json</depends>
 
     <!--
-        2026.2 split JCEF out of the core class path into its own module, so without
+        2026.2 split JCEF out of the core class path into its own plugin, so without
         this the plugin's class loader can't see JBCefApp and crashes at startup.
-        Optional because the module is absent on the 242 floor (JCEF still core
-        there); where present it becomes a class-loader parent.
+        Optional because that plugin is absent on the 242 floor (JCEF still core
+        there); where present it becomes a class-loader parent. Depend on the plugin
+        (com.intellij.modules.jcef), not its content module intellij.platform.ui.jcef
+        — a v1 <depends> only wires a plugin's class loader, not a bare content module.
     -->
-    <depends optional="true" config-file="modeler-jcef.xml">intellij.platform.ui.jcef</depends>
+    <depends optional="true" config-file="modeler-jcef.xml">com.intellij.modules.jcef</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <!--

--- a/apps/modeler-bridge/.gitignore
+++ b/apps/modeler-bridge/.gitignore
@@ -1,2 +1,6 @@
 # Build output: the compiled Node-free Bun binary (~58 MB).
 dist/
+
+# Bun's transient compile scratch files (e.g. .18bec….bun-build), left behind
+# by `bun build --compile` when it can't atomically replace the output.
+*.bun-build


### PR DESCRIPTION
Follow-up to #1203. That fix reduced the Marketplace findings but the plugin **still crashed at startup on 2026.2 (262)** — confirmed by re-running JetBrains' plugin-verification against the exact build `IU-262.8377.35` (downloaded + verified locally, since the Gradle snapshot resolver can't fetch it).

Two remaining causes, both now fixed and verified on 262:

## 1. JCEF dependency targeted the wrong thing
#1203 declared the optional dependency on the **content module** `intellij.platform.ui.jcef`. A v1 `<depends>` can't wire a bare content module, so `JBCefApp` stayed unresolvable and `BridgeWarmupActivity` still threw `ClassNotFoundException` at project open.

**Fix:** depend on the JCEF **plugin** `com.intellij.modules.jcef` instead — its class loader exposes the content module (this is exactly how real JCEF plugins declare it). On 262 the dependency now resolves and pulls in `intellij.platform.ui.jcef`; on the 242 floor it's absent → optional skip, JCEF still core.

## 2. Internal plugin-descriptor lookup
`BridgeBinaryResolver` used `PluginManager.getPluginByClass` to read the plugin version for its extraction-cache key. That method — and its stand-in `PluginManagerCore.getPlugin` — are both `@ApiStatus.Internal` on 262 (the annotation varies by IDE version, which is why 242/261 didn't flag it).

**Fix:** stamp the version into a class-path resource (`bridge-version.txt`) at build time and read that — no PluginManager lookup at all.

## Verification (against `IU-262.8377.35`, the exact Marketplace build)
| | before (#1203) | after |
|---|---|---|
| JBCefApp startup crash | **yes** | **gone** (JCEF resolves) |
| internal API usages | 1 | **0** |

`verifyPlugin` also green on IC-242 and IU-261; plugin `test` suite passes. Only non-blocking deprecations + 1 scheduled-for-removal (`SimpleListCellRenderer.create`) remain — the Marketplace treats these as Compatible.

## Note
`MISSING_DEPENDENCIES` stays out of the verifier gate (from #1203): the optional `com.intellij.modules.jcef` dep is structurally unresolvable on the 242/261 targets, which the Marketplace treats as non-blocking.