### PR TITLE
feat(vscode-plugin): improve output channel logging (#1210)

### DIFF
--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -10,8 +10,10 @@ import {
     DiffCounts,
     DiffSide,
     ElementTemplatesQuery,
+    LogDebugCommand,
     LogErrorCommand,
     LogInfoCommand,
+    LogWarningCommand,
     PropertiesPanelStateQuery,
     Query,
     sortIdsByOrder,
@@ -213,8 +215,16 @@ class MockHost extends MockHostApi<StateType, MessageType> {
                 );
                 break;
             }
+            case message.type === "LogDebugCommand": {
+                console.debug((message as LogDebugCommand).message);
+                break;
+            }
             case message.type === "LogInfoCommand": {
                 console.info((message as LogInfoCommand).message);
+                break;
+            }
+            case message.type === "LogWarningCommand": {
+                console.warn((message as LogWarningCommand).message);
                 break;
             }
             case message.type === "LogErrorCommand": {

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -23,7 +23,7 @@ import {
     ImplementationStatusQuery,
     LanguageQuery,
     LogErrorCommand,
-    LogInfoCommand,
+    LogWarningCommand,
     NoModelerError,
     OpenScriptEditorCommand,
     PropertiesPanelStateQuery,
@@ -56,6 +56,24 @@ import type { LintConfigService } from "./app/bpmnlint";
 import { WebviewStateManager } from "./app/state";
 
 const host = getHostApi();
+
+// Global safety net for throws the per-message try/catch in onReceiveMessage
+// can't reach — bpmn-js event-bus callbacks (e.g. onCommandStackChanged) run
+// outside it, so an error there would otherwise vanish into the webview console
+// and never reach the output channel. Registered eagerly so it covers failures
+// during the initial modeler bootstrap too.
+window.addEventListener("error", (event: ErrorEvent) => {
+    host.postMessage(new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack));
+});
+window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason: unknown = event.reason;
+    host.postMessage(
+        new LogErrorCommand(
+            `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
+            reason instanceof Error ? reason.stack : undefined,
+        ),
+    );
+});
 
 /**
  * Singleton modeler instance shared across all message handlers.
@@ -260,6 +278,18 @@ window.onload = async function () {
     // Phase 1: restore viewport (canvas exists after openXml)
     stateManager.restoreViewport();
 
+    // Surface templates bpmn-js rejects (invalid schema, bad `appliesTo`, …).
+    // Subscribed *before* GetElementTemplatesCommand so the errors fired while
+    // the loader validates the reply are observed. It's a warning, not an error:
+    // bpmn-js skips an invalid template non-fatally, and its message already
+    // carries the offending template's id/name.
+    bpmnModeler.onElementTemplatesErrors((errors) => {
+        for (const error of errors ?? []) {
+            const message = error instanceof Error ? error.message : String(error);
+            host.postMessage(new LogWarningCommand(`Element template rejected: ${message}`));
+        }
+    });
+
     // Request templates + settings + panel state, wait for all to apply
     host.postMessage(new GetElementTemplatesCommand());
     host.postMessage(new GetBpmnModelerSettingCommand());
@@ -339,8 +369,8 @@ async function openXml(bpmn?: string): Promise<void> {
     }
 
     if (result.warnings.length > 0) {
-        const warnings = `with following warnings: ${formatErrors(result.warnings)}`;
-        host.postMessage(new LogInfoCommand(warnings));
+        const warnings = `Diagram opened with following warnings: ${formatErrors(result.warnings)}`;
+        host.postMessage(new LogWarningCommand(warnings));
     }
 }
 
@@ -381,7 +411,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
         case queryOrCommand.type === "ElementTemplatesQuery": {
             try {
                 const elementTemplates = (message.data as ElementTemplatesQuery).elementTemplates;
-                console.log("Received element templates: ", elementTemplates);
+                console.debug("Received element templates: ", elementTemplates);
                 bpmnModeler.setElementTemplates(elementTemplates);
                 elementTemplatesResolver.done(message.data as ElementTemplatesQuery);
             } catch (error: any) {
@@ -397,7 +427,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     .apply(query.config);
 
                 for (const warning of warnings) {
-                    host.postMessage(new LogInfoCommand(warning));
+                    host.postMessage(new LogWarningCommand(warning));
                 }
             } catch (error: any) {
                 host.postMessage(new LogErrorCommand(errorPrefix + error.message));

--- a/apps/dmn-webview/src/app/host.ts
+++ b/apps/dmn-webview/src/app/host.ts
@@ -2,6 +2,10 @@ import {
     Command,
     DmnFileQuery,
     DmnModelerSettingQuery,
+    LogDebugCommand,
+    LogErrorCommand,
+    LogInfoCommand,
+    LogWarningCommand,
     PropertiesPanelStateQuery,
     Query,
     HostApi,
@@ -93,6 +97,26 @@ class MockHost extends MockHostApi<StateType, MessageType> {
             }
             case message.type === "SetPropertiesPanelStateCommand": {
                 // No host to persist to in standalone browser runs.
+                break;
+            }
+            // The webview forwards log entries to the host; in a standalone
+            // browser run there's no host, so mirror them onto the dev console.
+            // Cases are required because the base MockHost throws on unknown
+            // types — and the global error listeners now emit LogErrorCommand.
+            case message.type === "LogDebugCommand": {
+                console.debug((message as LogDebugCommand).message);
+                break;
+            }
+            case message.type === "LogInfoCommand": {
+                console.info((message as LogInfoCommand).message);
+                break;
+            }
+            case message.type === "LogWarningCommand": {
+                console.warn((message as LogWarningCommand).message);
+                break;
+            }
+            case message.type === "LogErrorCommand": {
+                console.error((message as LogErrorCommand).message);
                 break;
             }
             default: {

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -17,7 +17,7 @@ import {
     initResizer,
     initTheme,
     LogErrorCommand,
-    LogInfoCommand,
+    LogWarningCommand,
     NoModelerError,
     PropertiesPanelStateQuery,
     Query,
@@ -37,6 +37,22 @@ import {
 } from "./app";
 
 const host = getHostApi();
+
+// Global safety net for throws outside the per-message try/catch below — dmn-js
+// event-bus callbacks run outside it, so an error there would otherwise vanish
+// into the webview console instead of reaching the output channel.
+window.addEventListener("error", (event: ErrorEvent) => {
+    host.postMessage(new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack));
+});
+window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason: unknown = event.reason;
+    host.postMessage(
+        new LogErrorCommand(
+            `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
+            reason instanceof Error ? reason.stack : undefined,
+        ),
+    );
+});
 
 const stateManager = new WebviewStateManager(host);
 
@@ -138,7 +154,7 @@ async function openXML(dmn: string | undefined) {
         );
         const message = `Diagram was opened with following warnings: ${formatErrors(warnings)}
             `;
-        host.postMessage(new LogInfoCommand(message));
+        host.postMessage(new LogWarningCommand(message));
     }
 }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/HostNotifications.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/HostNotifications.kt
@@ -36,6 +36,7 @@ class HostNotifications(private val project: Project) {
         when (level) {
             "error" -> log.warn(text)
             "warn" -> log.warn(text)
+            "debug" -> log.debug(text)
             else -> log.info(text)
         }
     }

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -386,6 +386,12 @@ describe("RpcNotifier", () => {
             params: { message: "boom" },
         });
 
+        notifier.logDebug("trace");
+        expect(last(frames)).toEqual({
+            method: "notifier/log",
+            params: { level: "debug", message: "trace" },
+        });
+
         notifier.logWarning("careful");
         expect(last(frames)).toEqual({
             method: "notifier/log",
@@ -396,6 +402,14 @@ describe("RpcNotifier", () => {
         expect(last(frames)).toEqual({
             method: "notifier/log",
             params: { level: "error", message: "bad" },
+        });
+
+        // A bare string (e.g. a webview-forwarded stack) is forwarded verbatim,
+        // not re-wrapped in an Error.
+        notifier.logError("[webview] raw stack");
+        expect(last(frames)).toEqual({
+            method: "notifier/log",
+            params: { level: "error", message: "[webview] raw stack" },
         });
 
         notifier.openLoggingConsole();

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -360,6 +360,10 @@ export class RpcNotifier implements NotifierPort {
         this.rpc.notify(METHODS.notifierOpenConsole, {});
     }
 
+    logDebug(message: string): void {
+        this.rpc.notify(METHODS.notifierLog, { level: "debug", message });
+    }
+
     logInfo(message: string): void {
         this.rpc.notify(METHODS.notifierLog, { level: "info", message });
     }
@@ -368,8 +372,12 @@ export class RpcNotifier implements NotifierPort {
         this.rpc.notify(METHODS.notifierLog, { level: "warn", message });
     }
 
-    logError(error: Error): void {
-        this.rpc.notify(METHODS.notifierLog, { level: "error", message: error.message });
+    /** A bare `string` (e.g. a webview stack) is forwarded verbatim, not re-wrapped. */
+    logError(error: string | Error): void {
+        this.rpc.notify(METHODS.notifierLog, {
+            level: "error",
+            message: error instanceof Error ? error.message : error,
+        });
     }
 
     /**

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -1,5 +1,5 @@
 import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
-import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
+import { BpmnModelerService, registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
 
 import { RpcEditorHandle } from "../adapters";
 import { METHODS } from "../protocol/descriptor";
@@ -44,7 +44,7 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
     deps.router
         .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
             if (await bpmnService.display(editorId)) {
-                deps.notifier.logInfo("BPMN modeler is ready");
+                deps.notifier.logDebug("BPMN modeler is ready");
             }
         })
         .on("SyncDocumentCommand", async (message: Command, editorId: string) => {
@@ -57,6 +57,9 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
         .on("GetPropertiesPanelStateCommand", (_m: Command, editorId: string) => {
             deps.store.postMessage(editorId, query("PropertiesPanelStateQuery", { visible: true }));
         });
+
+    // Route the webview's Log*Commands into `idea.log` via the notifier/log RPC.
+    registerWebviewLogHandlers(deps.router, deps.notifier);
 
     deps.rpc.on(METHODS.sessionRegister, async (params: RegisterParams) => {
         // Seed settings before any discovery so `getConfigFolder()` is correct on

--- a/apps/modeler-bridge/src/composition/sharedDeps.ts
+++ b/apps/modeler-bridge/src/composition/sharedDeps.ts
@@ -63,7 +63,7 @@ export function buildSharedDeps(
     // onOpenCountChanged is the VS Code setContext hook; irrelevant out-of-process.
     const store = new EditorSessionStore(() => {});
 
-    const artifactSvc = new ArtifactService(nodeWorkspace, settings);
+    const artifactSvc = new ArtifactService(nodeWorkspace, settings, notifier);
 
     // One router shared across features: each feature registers its own
     // webview-message surface on it. The core enforces one handler per type, so

--- a/apps/modeler-bridge/src/protocol/types.ts
+++ b/apps/modeler-bridge/src/protocol/types.ts
@@ -216,7 +216,7 @@ export interface NotifierOpenDocumentParams {
 
 /** `notifier/log` — a leveled line to the IDE log/console. */
 export interface NotifierLogParams {
-    level: "info" | "warn" | "error";
+    level: "debug" | "info" | "warn" | "error";
     message: string;
 }
 

--- a/apps/vscode-plugin/README.md
+++ b/apps/vscode-plugin/README.md
@@ -78,6 +78,19 @@ Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`
 | BPMN Modeler: Toggle Standard Text Editor | `Ctrl+Shift+E` | Open the XML text editor next to the BPMN modeler                |
 | BPMN Modeler: Display Logging Information |                | Open a console showing modeler log output                        |
 
+## Troubleshooting
+
+The modeler logs to the **`bpmn.modeler`** output channel. Open it via the
+Output panel (View → Output → select *bpmn.modeler*) or the command **BPMN
+Modeler: Display Logging Information** (`bpmn-modeler.openLoggingConsole`).
+
+By default the channel shows `Info` and above. When a diagram, element
+template, or the webview misbehaves, raise the level to see the full trace:
+run **Developer: Set Log Level…**, pick *bpmn.modeler*, and choose **Debug**.
+Debug adds the per-message transport trace, the element-template discovery scan
+(which config folder was searched and what was found), and any warnings or
+errors the webview forwards (prefixed with `[webview]`).
+
 ## Support and feedback
 
 - Documentation: <https://miragon.github.io/bpmn-modeler/>

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -2,6 +2,7 @@ import { ExtensionContext } from "vscode";
 
 import { PropertiesPanelStateRepository } from "../modeler/bpmn/infrastructure/PropertiesPanelStateRepository";
 import { WebviewMessageRouter } from "@miragon/bpmn-modeler-core";
+import { registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
 import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
 import { BpmnClipboardMediator } from "@miragon/bpmn-modeler-core";
 import { BpmnElementTemplatesService } from "@miragon/bpmn-modeler-core";
@@ -193,12 +194,16 @@ export function register(
             ),
         )
         .on("SyncActivitiesCommand", syncActivitiesHandler(codeLink.codeLinkMap));
+    // Route the webview's own Log*Commands into the output channel; without this
+    // the router drops them as unknown types and webview diagnostics never surface.
+    registerWebviewLogHandlers(bpmnMessageRouter, deps.notifier);
     const dmnMessageRouter = new WebviewMessageRouter()
         .on("GetDmnFileCommand", getDmnFileHandler(dmnService, deps.notifier))
         .on("GetDmnModelerSettingCommand", getDmnModelerSettingHandler(dmnSettingsBroadcaster))
         .on("GetPropertiesPanelStateCommand", getPropertiesPanelStateHandler(dmnPanelSvc))
         .on("SetPropertiesPanelStateCommand", setPropertiesPanelStateHandler(dmnPanelSvc))
         .on("SyncDocumentCommand", syncDmnDocumentHandler(dmnService));
+    registerWebviewLogHandlers(dmnMessageRouter, deps.notifier);
 
     new ModelerEditorController(deps.editorStore, deps.notifier, {
         viewType: BPMN_VIEW_TYPE,

--- a/apps/vscode-plugin/src/composition/sharedDeps.ts
+++ b/apps/vscode-plugin/src/composition/sharedDeps.ts
@@ -47,6 +47,9 @@ export function buildSharedDeps(context: ExtensionContext): SharedDeps {
 
     const vsWorkspace = new VsCodeWorkspace();
     const vsSettings = new VsCodeSettings();
+    // Hoisted so it can seed ArtifactService's optional logger for the
+    // element-template discovery diagnostics.
+    const notifier = new VsCodeNotifier();
 
     return {
         editorStore,
@@ -54,10 +57,10 @@ export function buildSharedDeps(context: ExtensionContext): SharedDeps {
         vsWorkspace,
         vsSettings,
         statusBar: new VsCodeStatusBar(),
-        notifier: new VsCodeNotifier(),
+        notifier,
         picker: new VsCodePicker(vsWorkspace),
         clipboard: new VsCodeClipboard(),
         textEditor: new VsCodeTextEditor(),
-        artifactSvc: new ArtifactService(vsWorkspace, vsSettings),
+        artifactSvc: new ArtifactService(vsWorkspace, vsSettings, notifier),
     };
 }

--- a/apps/vscode-plugin/src/deployment/controller/DeploymentController.spec.ts
+++ b/apps/vscode-plugin/src/deployment/controller/DeploymentController.spec.ts
@@ -60,6 +60,7 @@ function createController() {
     const notifier = {
         showInfo: vi.fn(),
         showError: vi.fn(),
+        logDebug: vi.fn(),
         logInfo: vi.fn(),
         logError: vi.fn(),
     };

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.spec.ts
@@ -42,7 +42,7 @@ function createService() {
     } as unknown as BpmnModelerService;
 }
 
-const notifier = { logInfo: vi.fn() } as unknown as VsCodeNotifier;
+const notifier = { logDebug: vi.fn() } as unknown as VsCodeNotifier;
 
 describe("BpmnRenderParticipant", () => {
     it("registers the modeler session on resolve", () => {

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.ts
@@ -26,7 +26,7 @@ export class BpmnRenderParticipant implements EditorSessionParticipant {
                 event.documentPath().endsWith(".bpmn") &&
                 session.editorId === event.documentUriString()
             ) {
-                this.notifier.logInfo("OnDidChangeTextDocument -> display");
+                this.notifier.logDebug("OnDidChangeTextDocument -> display");
                 this.bpmnService.display(session.editorId);
             }
         });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -44,21 +44,21 @@ beforeEach(() => {
 describe("getBpmnFileHandler", () => {
     it("logs readiness only when the diagram actually rendered", async () => {
         const bpmnService = { display: vi.fn().mockResolvedValue(true) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getBpmnFileHandler(bpmnService as never, notifier as never)(ANY, EDITOR);
 
         expect(bpmnService.display).toHaveBeenCalledWith(EDITOR);
-        expect(notifier.logInfo).toHaveBeenCalledOnce();
+        expect(notifier.logDebug).toHaveBeenCalledOnce();
     });
 
     it("does not log when rendering was skipped", async () => {
         const bpmnService = { display: vi.fn().mockResolvedValue(false) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getBpmnFileHandler(bpmnService as never, notifier as never)(ANY, EDITOR);
 
-        expect(notifier.logInfo).not.toHaveBeenCalled();
+        expect(notifier.logDebug).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -40,7 +40,7 @@ export function getBpmnFileHandler(
 ): MessageHandler {
     return async (_message: Command, editorId: string) => {
         if (await bpmnService.display(editorId)) {
-            notifier.logInfo("Bpmn modeler is ready");
+            notifier.logDebug("Bpmn modeler is ready");
         }
     };
 }

--- a/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.spec.ts
@@ -41,7 +41,7 @@ function createService() {
     } as unknown as DmnModelerService;
 }
 
-const notifier = { logInfo: vi.fn() } as unknown as VsCodeNotifier;
+const notifier = { logDebug: vi.fn() } as unknown as VsCodeNotifier;
 
 describe("DmnRenderParticipant", () => {
     it("registers the modeler session on resolve", () => {

--- a/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.ts
@@ -25,7 +25,7 @@ export class DmnRenderParticipant implements EditorSessionParticipant {
                 event.documentPath().endsWith(".dmn") &&
                 session.editorId === event.documentUriString()
             ) {
-                this.notifier.logInfo("OnDidChangeTextDocument -> display");
+                this.notifier.logDebug("OnDidChangeTextDocument -> display");
                 this.dmnService.display(session.editorId);
             }
         });

--- a/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.spec.ts
@@ -24,21 +24,21 @@ beforeEach(() => {
 describe("getDmnFileHandler", () => {
     it("logs readiness only when the diagram actually rendered", async () => {
         const dmnService = { display: vi.fn().mockResolvedValue(true) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getDmnFileHandler(dmnService as never, notifier as never)(ANY, EDITOR);
 
         expect(dmnService.display).toHaveBeenCalledWith(EDITOR);
-        expect(notifier.logInfo).toHaveBeenCalledOnce();
+        expect(notifier.logDebug).toHaveBeenCalledOnce();
     });
 
     it("does not log when rendering was skipped", async () => {
         const dmnService = { display: vi.fn().mockResolvedValue(false) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getDmnFileHandler(dmnService as never, notifier as never)(ANY, EDITOR);
 
-        expect(notifier.logInfo).not.toHaveBeenCalled();
+        expect(notifier.logDebug).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.ts
@@ -18,7 +18,7 @@ export function getDmnFileHandler(
 ): MessageHandler {
     return async (_message: Command, editorId: string) => {
         if (await dmnService.display(editorId)) {
-            notifier.logInfo("Dmn modeler is ready");
+            notifier.logDebug("Dmn modeler is ready");
         }
     };
 }

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.spec.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.spec.ts
@@ -46,6 +46,7 @@ function createFakeStore() {
 
 function createNotifier() {
     return {
+        logDebug: vi.fn(),
         logInfo: vi.fn(),
         logError: vi.fn(),
         showError: vi.fn(),

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
@@ -150,10 +150,12 @@ export class ModelerEditorController implements CustomTextEditorProvider {
      */
     private subscribeToMessageEvent(editorId: string): void {
         this.editorStore.subscribeToMessageEvent(editorId, async (message: Command, id: string) => {
-            this.notifier.logInfo(`Message received -> ${message.type}`);
+            // Per-message transport tracing: useful when diagnosing a stuck
+            // webview handshake, but far too frequent for the default level.
+            this.notifier.logDebug(`Message received -> ${message.type}`);
             try {
                 await this.options.messageRouter.dispatch(message, id);
-                this.notifier.logInfo(`Message processed -> ${message.type}`);
+                this.notifier.logDebug(`Message processed -> ${message.type}`);
             } catch (error) {
                 // VS Code's event emitter does not await this async listener, so
                 // a rejected dispatch would otherwise surface as an unhandled

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
@@ -3,21 +3,26 @@ import { commands, LogOutputChannel, ProgressLocation, Uri, window } from "vscod
 import { NotifierPort } from "@miragon/bpmn-modeler-core";
 
 const LOG_CHANNEL_ID = "bpmn.modeler";
-const LOG_PREFIX = `[${LOG_CHANNEL_ID}] `;
 
 /**
  * Adapter for user-facing messages and diagnostic logging.
  *
- * Owns a single VS Code log output channel and the toast notification
+ * Owns a single VS Code {@link LogOutputChannel} and the toast notification
  * API so services and controllers can surface information to the user
  * without importing from `vscode` directly.
+ *
+ * The channel is created with `{ log: true }`, so VS Code supplies the level
+ * filtering (Output panel gear / *Developer: Set Log Level…*), per-line
+ * timestamps, and persistence to the extension log file. The channel-name
+ * prefix each line used to carry is therefore redundant — the channel already
+ * identifies itself — and the ctor no longer `clear()`s, so the previous
+ * session's trail survives a reload.
  */
 export class VsCodeNotifier implements NotifierPort {
     private readonly channel: LogOutputChannel;
 
     constructor() {
         this.channel = window.createOutputChannel(LOG_CHANNEL_ID, { log: true });
-        this.channel.clear();
     }
 
     showInfo(message: string): void {
@@ -43,16 +48,24 @@ export class VsCodeNotifier implements NotifierPort {
         this.channel.show(true);
     }
 
+    logDebug(message: string): void {
+        this.channel.debug(message);
+    }
+
     logInfo(message: string): void {
-        this.channel.info(LOG_PREFIX + message);
+        this.channel.info(message);
     }
 
     logWarning(message: string): void {
-        this.channel.warn(LOG_PREFIX + message);
+        this.channel.warn(message);
     }
 
-    logError(error: Error): void {
-        this.channel.error(LOG_PREFIX, error);
+    /**
+     * A `string` is passed through untouched so a webview-forwarded stack prints
+     * verbatim; an `Error` keeps VS Code's own formatting (message + stack).
+     */
+    logError(error: string | Error): void {
+        this.channel.error(error);
     }
 
     /**

--- a/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.spec.ts
+++ b/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.spec.ts
@@ -48,6 +48,7 @@ function createDispatcher() {
     const notifier = {
         showInfo: vi.fn(),
         showError: vi.fn(),
+        logDebug: vi.fn(),
         logInfo: vi.fn(),
         logError: vi.fn(),
     };

--- a/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.ts
+++ b/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.ts
@@ -56,7 +56,7 @@ export class DeploymentMessageDispatcher {
      * ignored — the protocol is closed and a stray discriminant is not an error.
      */
     async handle(message: Command): Promise<void> {
-        this.notifier.logInfo(`Deployment message received -> ${message.type}`);
+        this.notifier.logDebug(`Deployment message received -> ${message.type}`);
         switch (message.type) {
             case "RequestFormDefaultsCommand":
                 this.sendFormDefaults();

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./shared/service/ArtifactService";
 export * from "./shared/service/BpmnLintConfigLocator";
 export * from "./shared/infrastructure/EditorSessionStore";
 export * from "./shared/infrastructure/WebviewMessageRouter";
+export * from "./shared/infrastructure/webviewLogHandlers";
 export * from "./shared/infrastructure/helpers";
 
 // ── modeler ─────────────────────────────────────────────────────────────────

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.spec.ts
@@ -28,7 +28,12 @@ function createService() {
         showElementTemplatesReady: vi.fn(),
         hideElementTemplatesStatus: vi.fn(),
     };
-    const notifier = { notifyError: vi.fn(), logError: vi.fn(), logInfo: vi.fn() };
+    const notifier = {
+        notifyError: vi.fn(),
+        logError: vi.fn(),
+        logInfo: vi.fn(),
+        logDebug: vi.fn(),
+    };
 
     const service = new BpmnElementTemplatesService(
         editorStore as never,

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.ts
@@ -27,6 +27,11 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
             const documentDir = posix.dirname(this.vsDocument.getFilePath(editorId));
 
             const [artifacts] = await this.artifactSvc.getArtifactPaths(documentDir);
+            this.notifier.logDebug(
+                artifacts.length > 0
+                    ? `Element-template files resolved: ${artifacts.join(", ")}`
+                    : "No element-template files resolved.",
+            );
 
             const parsed = await Promise.all(
                 artifacts.map(async (a) => {
@@ -51,7 +56,13 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
             if (await this.editorStore.postMessage(editorId, new ElementTemplatesQuery(sorted))) {
                 this.statusBar.showElementTemplatesReady(sorted.length);
                 if (artifacts.length > 0) {
-                    this.notifier.logInfo(`${artifacts.length} element templates are set.`);
+                    // Report templates loaded vs. files scanned separately — a
+                    // file can hold several templates, so conflating the two (the
+                    // old message reported the file count as the template count)
+                    // misled anyone cross-checking the status-bar count.
+                    this.notifier.logInfo(
+                        `${sorted.length} element template(s) loaded from ${artifacts.length} file(s).`,
+                    );
                 }
                 return true;
             } else {

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -19,19 +19,36 @@ import { AuthTypePayload, Engine } from "@miragon/bpmn-modeler-shared";
 import { MigrationScope } from "../../migration/domain/MigrationPlan";
 
 /**
+ * Levelled diagnostic logging to the host's log surface (VS Code's
+ * `bpmn.modeler` output channel, IntelliJ's `idea.log`). Split out of
+ * {@link NotifierPort} so pure-logging callers — webview-log routing, artifact
+ * discovery diagnostics — depend only on logging, not the whole notifier.
+ *
+ * `logDebug` is the level for high-frequency transport/lifecycle noise the user
+ * only wants when diagnosing (raised via *Developer: Set Log Level…*). `logError`
+ * accepts a bare `string` so a webview-supplied stack prints verbatim; wrapping
+ * it in a host-side `Error` would replace the original throw site's stack.
+ */
+export interface LoggerPort {
+    logDebug(message: string): void;
+    logInfo(message: string): void;
+    logWarning(message: string): void;
+    logError(error: string | Error): void;
+}
+
+/**
  * User-facing messages and diagnostic logging. Keeps services free of
  * `window.show*Message` / output-channel wiring and centralises the
- * log-then-toast convention behind {@link notifyError}.
+ * log-then-toast convention behind {@link notifyError}. Extends
+ * {@link LoggerPort}, so every notifier is also a logger — injection sites that
+ * only need to log can narrow to `LoggerPort` without extra wiring.
  */
-export interface NotifierPort {
+export interface NotifierPort extends LoggerPort {
     showInfo(message: string): void;
     showError(message: string): void;
     /** Logs `error`, then surfaces a toast pairing `context` with the error message. */
     notifyError(context: string, error: Error): void;
     openLoggingConsole(): void;
-    logInfo(message: string): void;
-    logWarning(message: string): void;
-    logError(error: Error): void;
     /** Runs `task` under a status-bar progress indicator titled `title`. */
     withProgress<T>(title: string, task: () => Promise<T>): Promise<T>;
     /** Opens the file at `absolutePath` in its registered editor. */

--- a/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.spec.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    LogDebugCommand,
+    LogErrorCommand,
+    LogInfoCommand,
+    LogWarningCommand,
+} from "@miragon/bpmn-modeler-shared";
+
+import { LoggerPort } from "../domain/hostPorts";
+import { WebviewMessageRouter } from "./WebviewMessageRouter";
+import { registerWebviewLogHandlers } from "./webviewLogHandlers";
+
+const EDITOR = "file:///w/a.bpmn";
+
+/** Wires a router to a spy logger so tests can dispatch a command and read the call. */
+function setup() {
+    const logger = {
+        logDebug: vi.fn(),
+        logInfo: vi.fn(),
+        logWarning: vi.fn(),
+        logError: vi.fn(),
+    };
+    const router = new WebviewMessageRouter();
+    registerWebviewLogHandlers(router, logger as unknown as LoggerPort);
+    return { logger, router };
+}
+
+describe("registerWebviewLogHandlers", () => {
+    it("routes each level to its logger method with a [webview] prefix", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogDebugCommand("d"), EDITOR);
+        await router.dispatch(new LogInfoCommand("i"), EDITOR);
+        await router.dispatch(new LogWarningCommand("w"), EDITOR);
+        await router.dispatch(new LogErrorCommand("e"), EDITOR);
+
+        expect(logger.logDebug).toHaveBeenCalledWith("[webview] d");
+        expect(logger.logInfo).toHaveBeenCalledWith("[webview] i");
+        expect(logger.logWarning).toHaveBeenCalledWith("[webview] w");
+        expect(logger.logError).toHaveBeenCalledWith("[webview] e");
+    });
+
+    it("appends the stack to an error command when present", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogErrorCommand("boom", "at foo (x.js:1)"), EDITOR);
+
+        expect(logger.logError).toHaveBeenCalledWith("[webview] boom\nat foo (x.js:1)");
+    });
+
+    it("omits the stack when the error command carries none", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogErrorCommand("boom"), EDITOR);
+
+        expect(logger.logError).toHaveBeenCalledWith("[webview] boom");
+    });
+
+    it("does not cross-fire levels (a debug command logs only at debug)", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogDebugCommand("d"), EDITOR);
+
+        expect(logger.logInfo).not.toHaveBeenCalled();
+        expect(logger.logWarning).not.toHaveBeenCalled();
+        expect(logger.logError).not.toHaveBeenCalled();
+    });
+});

--- a/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.ts
@@ -1,0 +1,41 @@
+import { Command, LogMessageCommand } from "@miragon/bpmn-modeler-shared";
+
+import { LoggerPort } from "../domain/hostPorts";
+import { WebviewMessageRouter } from "./WebviewMessageRouter";
+
+/**
+ * Routes the four webview `Log*Command`s onto the host's {@link LoggerPort}.
+ *
+ * The sandboxed webview cannot write to the output channel / `idea.log`, so it
+ * forwards log entries as commands. Without these handlers the router treats an
+ * unknown type as a no-op, so webview diagnostics are silently dropped — the
+ * exact "webview errors never reach the output channel" gap issue #1210
+ * describes. Shared by every host (VS Code + the IntelliJ bridge) so the two
+ * transports can't drift.
+ *
+ * Each line is tagged `[webview]` to mark its origin in a channel the host also
+ * writes to directly; the error handler appends the command's textual `stack`
+ * (an `Error` doesn't survive `postMessage`) so the original throw site prints.
+ */
+export function registerWebviewLogHandlers(router: WebviewMessageRouter, logger: LoggerPort): void {
+    router
+        .on("LogDebugCommand", (message: Command) => {
+            logger.logDebug(prefix(message as LogMessageCommand));
+        })
+        .on("LogInfoCommand", (message: Command) => {
+            logger.logInfo(prefix(message as LogMessageCommand));
+        })
+        .on("LogWarningCommand", (message: Command) => {
+            logger.logWarning(prefix(message as LogMessageCommand));
+        })
+        .on("LogErrorCommand", (message: Command) => {
+            const command = message as LogMessageCommand;
+            const body = command.stack ? `${command.message}\n${command.stack}` : command.message;
+            logger.logError(`[webview] ${body}`);
+        });
+}
+
+/** Prefixes a log command's message with the webview-origin marker. */
+function prefix(command: LogMessageCommand): string {
+    return `[webview] ${command.message}`;
+}

--- a/libs/modeler-core/src/shared/service/ArtifactService.ts
+++ b/libs/modeler-core/src/shared/service/ArtifactService.ts
@@ -1,7 +1,7 @@
 import { posix } from "path";
 
 import { DirectoryNotFound, NoWorkspaceFolderFoundError } from "../domain/errors";
-import { SettingsPort, WorkspacePort } from "../domain/hostPorts";
+import { LoggerPort, SettingsPort, WorkspacePort } from "../domain/hostPorts";
 
 /**
  * Implemented by {@link import("../../modeler/bpmn/service/BpmnElementTemplatesService").BpmnElementTemplatesService}
@@ -29,6 +29,10 @@ export class ArtifactService {
     constructor(
         private readonly vsWorkspace: WorkspacePort,
         private readonly vsSettings: SettingsPort,
+        // Optional so the two hosts (VS Code + bridge) can opt in without every
+        // ArtifactService call-site or test having to supply a logger. Used only
+        // for debug-level "why did nothing load?" diagnostics.
+        private readonly logger?: LoggerPort,
     ) {}
 
     /**
@@ -103,6 +107,22 @@ export class ArtifactService {
             workspaceRoot,
             configFolder,
         );
+
+        // Debug-level trail for the "no templates showed up" support case: the
+        // resolved config folder + root are the two inputs that most often
+        // explain an empty scan, and an explicit "no directory found" line names
+        // the range walked so the user knows where the modeler looked.
+        this.logger?.logDebug(
+            `Element-template scan: configFolder="${configFolder}", root="${workspaceRoot}", ` +
+                `documentDir="${documentDir}" → ${templateDirs.length} directory(ies)` +
+                (templateDirs.length > 0 ? `: ${templateDirs.join(", ")}` : ""),
+        );
+        if (templateDirs.length === 0) {
+            this.logger?.logDebug(
+                `No "${configFolder}/element-templates" directory found between ` +
+                    `${documentDir} and ${workspaceRoot}.`,
+            );
+        }
 
         const allPaths: string[] = [];
         for (const dir of templateDirs) {

--- a/libs/shared/src/lib/messages.ts
+++ b/libs/shared/src/lib/messages.ts
@@ -8,7 +8,9 @@
  * Also contains cross-cutting concrete commands that are not specific to any one
  * modeler feature:
  * - {@link SyncDocumentCommand} — webview notifies the host to persist the current XML to disk
- * - {@link LogInfoCommand} / {@link LogErrorCommand} — webview forwards log entries to the host's output channel
+ * - {@link LogDebugCommand} / {@link LogInfoCommand} / {@link LogWarningCommand} /
+ *   {@link LogErrorCommand} — webview forwards a levelled log entry to the host's
+ *   output channel
  *
  * @see modeler.ts for the modeler-specific Query and Command implementations that
  * extend these base classes.
@@ -47,13 +49,29 @@ export class LogMessageCommand implements Command {
 
     public readonly message: string;
 
-    constructor(log: string) {
+    /**
+     * The originating error's stack, carried as text: a real `Error` doesn't
+     * survive `postMessage` (structured clone drops the stack), so the webview
+     * passes it as a string the host appends verbatim. Absent for non-error logs.
+     */
+    public readonly stack?: string;
+
+    constructor(log: string, stack?: string) {
         this.message = log;
+        this.stack = stack;
     }
+}
+
+export class LogDebugCommand extends LogMessageCommand {
+    public override readonly type: string = "LogDebugCommand";
 }
 
 export class LogInfoCommand extends LogMessageCommand {
     public override readonly type: string = "LogInfoCommand";
+}
+
+export class LogWarningCommand extends LogMessageCommand {
+    public override readonly type: string = "LogWarningCommand";
 }
 
 export class LogErrorCommand extends LogMessageCommand {


### PR DESCRIPTION
**Issue**

Closes: #1210 

**Description**

The bpmn.modeler output channel was cluttered with per-message transport noise while real diagnostics never arrived: the host silently dropped the webview's Log*Commands and bpmn-js element-template validation errors were never surfaced.

- add a LoggerPort domain port with a debug level; VsCodeNotifier drops the redundant channel prefix and no longer clears the prior session's trail
- demote per-message transport/lifecycle lines to debug level
- add LogWarning/LogDebug commands and a textual stack payload
- route the webview's Log*Commands into the output channel (shared handler used by both the VS Code host and the IntelliJ bridge)
- surface uncaught webview errors and rejected element templates to the host
- debug-level diagnostics for element-template discovery
- document the channel and how to raise the level to Debug

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
