### PR TITLE
fix(vscode-plugin): find element templates on Windows + VS Code

### DIFF
--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeEditorHandle.ts
@@ -9,6 +9,7 @@ import {
     SettingChange,
 } from "@miragon/bpmn-modeler-core";
 import { bootstrapWebview } from "./bootstrapWebview";
+import { canonicalizeDriveLetter } from "./uriPath";
 
 /**
  * VS Code adapter for {@link EditorHandle}: wraps a `WebviewPanel` + the
@@ -55,7 +56,11 @@ export class VsCodeEditorHandle implements EditorHandle {
     }
 
     documentPath(): string {
-        return this.document.uri.path;
+        // Canonicalize the drive letter so `getFilePath()`-derived paths land in
+        // the same space as the workspace root the artifact walk compares them
+        // against; VS Code's document URIs already lowercase it, but this keeps
+        // the guarantee explicit and host-boundary-local (issue #1204).
+        return canonicalizeDriveLetter(this.document.uri.path);
     }
 
     documentFsPath(): string {

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const findFilesMock = vi.fn();
 const createDirectoryMock = vi.fn();
 const writeFileMock = vi.fn();
+const createFileSystemWatcherMock = vi.fn();
 
 vi.mock("vscode", () => ({
     workspace: {
@@ -14,12 +15,31 @@ vi.mock("vscode", () => ({
         },
         findFiles: (...args: unknown[]) => findFilesMock(...args),
         getWorkspaceFolder: vi.fn(),
+        createFileSystemWatcher: (...args: unknown[]) => createFileSystemWatcherMock(...args),
     },
-    Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
+    Uri: {
+        file: (path: string) => ({ scheme: "file", path, fsPath: path }),
+        // Mirror VS Code's decode of a `file://` string so `toUri` can be shown
+        // recovering `/c:/…` from the `%3A`-escaped drive colon.
+        parse: (value: string) => ({
+            scheme: "file",
+            path: decodeURIComponent(value.replace(/^file:\/\//, "")),
+        }),
+    },
+    RelativePattern: class {
+        constructor(
+            readonly base: unknown,
+            readonly pattern: string,
+        ) {}
+    },
     FileType: { File: 1, Directory: 2, SymbolicLink: 64 },
 }));
 
+import { workspace } from "vscode";
+
 import { VsCodeWorkspace } from "./VsCodeWorkspace";
+
+const getWorkspaceFolderMock = workspace.getWorkspaceFolder as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
     findFilesMock.mockReset();
@@ -28,6 +48,13 @@ beforeEach(() => {
     createDirectoryMock.mockResolvedValue(undefined);
     writeFileMock.mockReset();
     writeFileMock.mockResolvedValue(undefined);
+    createFileSystemWatcherMock.mockReset();
+    createFileSystemWatcherMock.mockReturnValue({
+        onDidCreate: vi.fn(),
+        onDidChange: vi.fn(),
+        onDidDelete: vi.fn(),
+        dispose: vi.fn(),
+    });
 });
 
 describe("VsCodeWorkspace.findFiles", () => {
@@ -74,6 +101,72 @@ describe("VsCodeWorkspace.findFiles", () => {
         const result = await sut.findFiles("**/*.bpmn");
 
         expect(result).toEqual(["/x.bpmn", "/nested/y.bpmn"]);
+    });
+
+    it("canonicalizes an uppercase Windows drive letter in the results", async () => {
+        findFilesMock.mockResolvedValueOnce([{ path: "/C:/ws/a.bpmn" }]);
+        const sut = new VsCodeWorkspace();
+
+        await expect(sut.findFiles("**/*.bpmn")).resolves.toEqual(["/c:/ws/a.bpmn"]);
+    });
+});
+
+describe("VsCodeWorkspace.getWorkspaceFolderForDocument", () => {
+    it("lowercases the workspace-folder drive letter so it compares against document paths", () => {
+        // VS Code hands the folder its as-opened uppercase drive while document
+        // URIs are lowercased; without canonicalization the two never match and
+        // the template walk collects nothing (issue #1204).
+        getWorkspaceFolderMock.mockReturnValueOnce({ uri: { path: "/C:/ws" } });
+        const sut = new VsCodeWorkspace();
+
+        expect(sut.getWorkspaceFolderForDocument("/c:/ws/proc/order.bpmn")).toBe("/c:/ws");
+    });
+
+    it("accepts a `file://`-form document string", () => {
+        getWorkspaceFolderMock.mockReturnValueOnce({ uri: { path: "/C:/ws" } });
+        const sut = new VsCodeWorkspace();
+
+        sut.getWorkspaceFolderForDocument("file:///c%3A/ws/proc/order.bpmn");
+
+        // The URI handed to VS Code must have the decoded drive path, not the
+        // doubly-escaped garbage `Uri.file` would have produced.
+        expect(getWorkspaceFolderMock).toHaveBeenCalledWith(
+            expect.objectContaining({ path: "/c:/ws/proc/order.bpmn" }),
+        );
+    });
+});
+
+describe("VsCodeWorkspace.createWatcher", () => {
+    it("builds the RelativePattern from a real Uri base when the root is a `file://` string", () => {
+        const sut = new VsCodeWorkspace();
+
+        sut.createWatcher("file:///c%3A/ws", "**/*.json", {});
+
+        const pattern = createFileSystemWatcherMock.mock.calls[0][0];
+        // A `Uri` base (not the raw `file://` string) is what makes the glob
+        // resolve — the watcher would silently never fire otherwise.
+        expect(pattern.base).toEqual(expect.objectContaining({ path: "/c:/ws" }));
+        expect(pattern.pattern).toBe("**/*.json");
+    });
+
+    it("delivers canonicalized event paths to handlers", () => {
+        const onChange = vi.fn();
+        let changeCb: (uri: { path: string }) => void = () => undefined;
+        createFileSystemWatcherMock.mockReturnValueOnce({
+            onDidCreate: vi.fn(),
+            onDidChange: vi.fn((cb: (uri: { path: string }) => void) => {
+                changeCb = cb;
+                return { dispose: vi.fn() };
+            }),
+            onDidDelete: vi.fn(),
+            dispose: vi.fn(),
+        });
+        const sut = new VsCodeWorkspace();
+
+        sut.createWatcher("/c:/ws", "**/*.json", { onChange });
+        changeCb({ path: "/C:/ws/.camunda/element-templates/x.json" });
+
+        expect(onChange).toHaveBeenCalledWith("/c:/ws/.camunda/element-templates/x.json");
     });
 });
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
@@ -1,6 +1,6 @@
 import { posix } from "path";
 
-import { FileType, RelativePattern, Uri, workspace } from "vscode";
+import { FileType, RelativePattern, workspace } from "vscode";
 
 import {
     DirectoryNotFound,
@@ -8,6 +8,7 @@ import {
     NoWorkspaceFolderFoundError,
 } from "@miragon/bpmn-modeler-core";
 import { WorkspacePort } from "@miragon/bpmn-modeler-core";
+import { canonicalPath, toUri } from "./uriPath";
 
 const fs = workspace.fs;
 
@@ -27,11 +28,11 @@ export class VsCodeWorkspace implements WorkspacePort {
      * @throws {NoWorkspaceFolderFoundError} If the document is not inside any workspace folder.
      */
     getWorkspaceFolderForDocument(document: string): string {
-        const workspaceFolder = workspace.getWorkspaceFolder(Uri.file(document));
+        const workspaceFolder = workspace.getWorkspaceFolder(toUri(document));
         if (!workspaceFolder) {
             throw new NoWorkspaceFolderFoundError();
         }
-        return workspaceFolder.uri.path;
+        return canonicalPath(workspaceFolder.uri);
     }
 
     /**
@@ -44,7 +45,8 @@ export class VsCodeWorkspace implements WorkspacePort {
      * rather than an error.
      */
     findWorkspaceFolderForDocument(document: string): string | undefined {
-        return workspace.getWorkspaceFolder(Uri.file(document))?.uri.path;
+        const workspaceFolder = workspace.getWorkspaceFolder(toUri(document));
+        return workspaceFolder ? canonicalPath(workspaceFolder.uri) : undefined;
     }
 
     /**
@@ -52,20 +54,21 @@ export class VsCodeWorkspace implements WorkspacePort {
      * open (the loose-file / single-file-window case).
      */
     getWorkspaceFolderPaths(): string[] {
-        return (workspace.workspaceFolders ?? []).map((folder) => folder.uri.path);
+        return (workspace.workspaceFolders ?? []).map((folder) => canonicalPath(folder.uri));
     }
 
     /**
      * Returns the directory containing `document` in the `uri.path` form the
      * rest of this adapter speaks.
      *
-     * Routing the OS path through `Uri.file(...).path` is what lets callers
-     * pass a raw `uri.fsPath` and stay free of `vscode.Uri`; the normalization
-     * matters on Windows, where `fsPath` (`c:\a\b`) and `uri.path`
-     * (`/c:/a/b`) diverge.
+     * Routing the OS path through `toUri(...)` + `canonicalPath` is what lets
+     * callers pass a raw `uri.fsPath` (or a `file://` string) and stay free of
+     * `vscode.Uri`; the normalization matters on Windows, where `fsPath`
+     * (`c:\a\b`) and `uri.path` (`/c:/a/b`) diverge and the drive-letter casing
+     * must be canonicalized to compare against the workspace root.
      */
     getDocumentDirectory(document: string): string {
-        return posix.dirname(Uri.file(document).path);
+        return posix.dirname(canonicalPath(toUri(document)));
     }
 
     /**
@@ -113,7 +116,7 @@ export class VsCodeWorkspace implements WorkspacePort {
     async readDirectory(path: string): Promise<[string, "file" | "directory"][]> {
         let dir: [string, FileType][];
         try {
-            dir = await fs.readDirectory(Uri.file(path));
+            dir = await fs.readDirectory(toUri(path));
         } catch {
             throw new DirectoryNotFound(path);
         }
@@ -134,7 +137,7 @@ export class VsCodeWorkspace implements WorkspacePort {
      * @throws {FileNotFound} If the file does not exist or cannot be read.
      */
     async readFile(path: string): Promise<string> {
-        return fs.readFile(Uri.file(path)).then(
+        return fs.readFile(toUri(path)).then(
             (buffer) => buffer.toString(),
             (reason) => {
                 throw new FileNotFound(reason);
@@ -149,11 +152,14 @@ export class VsCodeWorkspace implements WorkspacePort {
      * @param content The string content to write.
      */
     async writeFile(path: string, content: string): Promise<void> {
+        const uri = toUri(path);
         // Create the parent directory first (idempotent). `fs.writeFile` already
         // mkdirps via FileService, so this is platform-proof insurance for the
         // code-link artifact's nested target paths rather than a hard requirement.
-        await fs.createDirectory(Uri.file(posix.dirname(path)));
-        await fs.writeFile(Uri.file(path), Buffer.from(content));
+        // Deriving the parent from `uri.path` keeps this correct for both plain
+        // and `file://`-form inputs.
+        await fs.createDirectory(toUri(posix.dirname(uri.path)));
+        await fs.writeFile(uri, Buffer.from(content));
     }
 
     /**
@@ -170,7 +176,7 @@ export class VsCodeWorkspace implements WorkspacePort {
      */
     async findFiles(pattern: string, exclude?: string | null, limit?: number): Promise<string[]> {
         const uris = await workspace.findFiles(pattern, exclude, limit);
-        return uris.map((uri) => uri.path);
+        return uris.map((uri) => canonicalPath(uri));
     }
 
     /**
@@ -196,17 +202,23 @@ export class VsCodeWorkspace implements WorkspacePort {
             onDelete?: (path: string) => void;
         },
     ): { dispose(): void } {
-        const watcher = workspace.createFileSystemWatcher(new RelativePattern(rootPath, glob));
+        // A `Uri` base keeps `RelativePattern` correct when the root arrives in
+        // `file://` form (`editorId` = `uri.toString()`): a raw string base is
+        // taken literally, so `file:///c%3A/…` would never match anything and
+        // the watcher would silently never fire.
+        const watcher = workspace.createFileSystemWatcher(
+            new RelativePattern(toUri(rootPath), glob),
+        );
         const subscriptions: { dispose(): void }[] = [watcher];
         const { onCreate, onChange, onDelete } = handlers;
         if (onCreate) {
-            subscriptions.push(watcher.onDidCreate((uri) => onCreate(uri.path)));
+            subscriptions.push(watcher.onDidCreate((uri) => onCreate(canonicalPath(uri))));
         }
         if (onChange) {
-            subscriptions.push(watcher.onDidChange((uri) => onChange(uri.path)));
+            subscriptions.push(watcher.onDidChange((uri) => onChange(canonicalPath(uri))));
         }
         if (onDelete) {
-            subscriptions.push(watcher.onDidDelete((uri) => onDelete(uri.path)));
+            subscriptions.push(watcher.onDidDelete((uri) => onDelete(canonicalPath(uri))));
         }
         return {
             dispose(): void {

--- a/apps/vscode-plugin/src/shared/infrastructure/uriPath.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/uriPath.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+// `Uri.file` percent-encodes its argument; `Uri.parse` decodes an existing
+// `file://` string. The stubs mirror just enough of that split for `toUri` to
+// be observed picking the right constructor.
+const fileMock = vi.fn((path: string) => ({ scheme: "file", path, via: "file" }));
+const parseMock = vi.fn((value: string) => ({
+    scheme: "file",
+    path: decodeURIComponent(value.replace(/^file:\/\//, "")),
+    via: "parse",
+}));
+
+vi.mock("vscode", () => ({
+    Uri: {
+        file: (path: string) => fileMock(path),
+        parse: (value: string) => parseMock(value),
+    },
+}));
+
+import { canonicalizeDriveLetter, canonicalPath, toUri } from "./uriPath";
+
+describe("canonicalizeDriveLetter", () => {
+    it("lowercases a leading Windows drive letter", () => {
+        expect(canonicalizeDriveLetter("/C:/Users/proj")).toBe("/c:/Users/proj");
+    });
+
+    it("leaves an already-lowercase drive letter untouched", () => {
+        expect(canonicalizeDriveLetter("/c:/Users/proj")).toBe("/c:/Users/proj");
+    });
+
+    it("leaves a POSIX path without a drive letter untouched", () => {
+        expect(canonicalizeDriveLetter("/home/user/proj")).toBe("/home/user/proj");
+    });
+
+    it("only touches the drive letter, not later path segments", () => {
+        expect(canonicalizeDriveLetter("/C:/A/B")).toBe("/c:/A/B");
+    });
+});
+
+describe("toUri", () => {
+    it("parses a `file://` string so `%3A` is decoded back to a drive path", () => {
+        const uri = toUri("file:///c%3A/Users/proj");
+
+        expect(parseMock).toHaveBeenCalledWith("file:///c%3A/Users/proj");
+        expect(fileMock).not.toHaveBeenCalled();
+        expect(uri.path).toBe("/c:/Users/proj");
+    });
+
+    it("treats a plain path as a filesystem path", () => {
+        const uri = toUri("/c:/Users/proj");
+
+        expect(fileMock).toHaveBeenCalledWith("/c:/Users/proj");
+        expect(uri.path).toBe("/c:/Users/proj");
+    });
+});
+
+describe("canonicalPath", () => {
+    it("canonicalizes the drive letter of a Uri's path", () => {
+        expect(canonicalPath({ path: "/C:/ws" } as never)).toBe("/c:/ws");
+    });
+
+    it("collapses an uppercase-drive folder and a lowercase-drive document to the same string", () => {
+        // The exact skew from issue #1204: `WorkspaceFolder.uri.path` keeps the
+        // as-opened uppercase drive while the document URI is lowercased.
+        const folder = canonicalPath({ path: "/C:/ws" } as never);
+        const document = canonicalPath({ path: "/c:/ws/sub" } as never);
+
+        expect(document.startsWith(folder + "/")).toBe(true);
+    });
+});

--- a/apps/vscode-plugin/src/shared/infrastructure/uriPath.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/uriPath.ts
@@ -1,0 +1,46 @@
+import { Uri } from "vscode";
+
+/**
+ * Path/URI canonicalization at the VS Code host boundary.
+ *
+ * VS Code hands out two mutually inconsistent spellings of the same Windows
+ * path: document/file-service URIs and `findFiles` results carry a *lowercase*
+ * drive letter (`/c:/…`), while `WorkspaceFolder.uri` preserves the casing the
+ * folder was opened with — typically *uppercase* from Explorer (`/C:/…`). Since
+ * `uri.path` strings compare case-sensitively, a document under `/c:/…` never
+ * tests as being inside a `/C:/…` workspace root, so the template/config walk
+ * collects nothing (issue #1204, microsoft/vscode#194692). Funnelling every
+ * path this adapter emits through {@link canonicalizeDriveLetter} removes the
+ * skew; lowercase is the canon because that is what the URIs we compare against
+ * already use.
+ */
+
+/**
+ * Lowercases a leading Windows drive letter in a POSIX-form `uri.path`
+ * (`/C:/Users` → `/c:/Users`). Non-Windows paths and already-lowercase drives
+ * pass through untouched.
+ */
+export function canonicalizeDriveLetter(path: string): string {
+    return path.replace(/^\/([A-Z]):/, (match) => match.toLowerCase());
+}
+
+/**
+ * Parses a string that may be either a `file://` URI (`file:///c%3A/…`, as
+ * produced by `uri.toString()`) or a plain OS/`uri.path` string into a `Uri`.
+ *
+ * `Uri.file` percent-encodes its argument, so feeding it a `file://` string
+ * yields a doubly-escaped garbage path; `Uri.parse` is required for that form.
+ * Scheme-tolerance here mirrors the `NodeWorkspace` contract, letting callers
+ * pass whichever spelling of the path they hold without leaking `Uri` outward.
+ */
+export function toUri(pathOrUri: string): Uri {
+    return pathOrUri.startsWith("file://") ? Uri.parse(pathOrUri) : Uri.file(pathOrUri);
+}
+
+/**
+ * Returns `uri.path` in canonical form — i.e. with a Windows drive letter
+ * lowercased so paths from different VS Code sources compare equal.
+ */
+export function canonicalPath(uri: Uri): string {
+    return canonicalizeDriveLetter(uri.path);
+}

--- a/libs/modeler-core/src/shared/service/ArtifactService.spec.ts
+++ b/libs/modeler-core/src/shared/service/ArtifactService.spec.ts
@@ -159,6 +159,18 @@ describe("ArtifactService.collectTemplateDirs", () => {
         expect(vsWorkspace.readDirectory).toHaveBeenCalledTimes(1);
     });
 
+    it("collects dirs when the workspace root carries a trailing slash (drive-root)", async () => {
+        const { service, vsWorkspace } = createService();
+        vsWorkspace.readDirectory.mockResolvedValue([]);
+
+        // A drive-root workspace opened as `C:\` surfaces as `/c:/`; the trailing
+        // slash must not defeat the `startsWith`/`===` containment guard.
+        await expect(service.collectTemplateDirs("/c:/proj", "/c:/", ".camunda")).resolves.toEqual([
+            "/c:/proj/.camunda/element-templates",
+            "/c:/.camunda/element-templates",
+        ]);
+    });
+
     it("guards against an infinite loop at the filesystem root", async () => {
         const { service, vsWorkspace } = createService();
         vsWorkspace.readDirectory.mockResolvedValue([]);

--- a/libs/modeler-core/src/shared/service/ArtifactService.ts
+++ b/libs/modeler-core/src/shared/service/ArtifactService.ts
@@ -67,7 +67,12 @@ export class ArtifactService {
         const dirs: string[] = [];
         let current = documentDir;
 
-        while (current === workspaceRoot || current.startsWith(workspaceRoot + "/")) {
+        // Strip a trailing slash so a drive-root workspace (`/c:/`) still matches:
+        // otherwise the guard tests `startsWith("/c://")` and the `===` check never
+        // hits, since the `posix.dirname` walk yields `/c:`, never `/c:/`.
+        const root = this.stripTrailingSlash(workspaceRoot);
+
+        while (current === root || current.startsWith(root + "/")) {
             const targetDir = posix.join(current, configFolder, subFolder);
             try {
                 await this.vsWorkspace.readDirectory(targetDir);
@@ -78,7 +83,7 @@ export class ArtifactService {
                 }
             }
 
-            if (current === workspaceRoot) {
+            if (current === root) {
                 break;
             }
 
@@ -93,6 +98,15 @@ export class ArtifactService {
         }
 
         return dirs;
+    }
+
+    /**
+     * Drops a single trailing slash unless the path is the filesystem root
+     * itself (`/`). Normalizes a drive-root workspace (`/c:/`) so it compares
+     * against the `posix.dirname` walk, which never re-introduces the slash.
+     */
+    private stripTrailingSlash(path: string): string {
+        return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
     }
 
     async getArtifactPaths(documentDir: string): Promise<[string[], string]> {


### PR DESCRIPTION
**Issue**

Closes: #1204 — with a template in `.camunda/element-templates`, the element-template button never appears on a service task, but only on Windows + VS Code.

**Description**

On Windows, VS Code emits a lowercase drive letter for document/file URIs (`/c:/…`) but preserves the as-opened casing (typically uppercase, `/C:/…`) for `WorkspaceFolder.uri`; since `uri.path` strings compare case-sensitively, the template/config walk found the document to be "outside" its own workspace root and collected zero directories. This canonicalizes paths at the VS Code host boundary — lowercasing the drive letter on everything the workspace adapter emits and parsing `file://`-form inputs with `Uri.parse` instead of the mangling `Uri.file`. The `Uri.parse` fix also revives the artifact/lint watchers, which passed a `file://` editorId that produced a non-matching `RelativePattern` base (live-reload was dead on all platforms), and a trailing-slash strip fixes a drive-root (`/c:/`) workspace edge case. `modeler-core` stays host-agnostic; `NodeWorkspace` (IntelliJ) is untouched.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created