### PR TITLE
feat(logging): improve output channel logging

### DIFF
--- a/apps/bpmn-webview/src/app/diff/DiffMode.ts
+++ b/apps/bpmn-webview/src/app/diff/DiffMode.ts
@@ -3,6 +3,7 @@ import {
     Command,
     CursorChangedCommand,
     DiffReadyCommand,
+    LogErrorCommand,
     Query,
     SwapCompareSidesCommand,
     SyncCursorQuery,
@@ -104,6 +105,10 @@ export class DiffMode {
             await this.viewer.importXML(content);
         } catch (error) {
             console.error("DiffViewer import failed", error);
+            const e = error instanceof Error ? error : new Error(String(error));
+            this.host.postMessage(
+                new LogErrorCommand(`DiffViewer import failed: ${e.message}`, e.stack),
+            );
             return;
         }
         this.host.postMessage(new DiffReadyCommand());

--- a/apps/bpmn-webview/src/app/host.ts
+++ b/apps/bpmn-webview/src/app/host.ts
@@ -10,8 +10,10 @@ import {
     DiffCounts,
     DiffSide,
     ElementTemplatesQuery,
+    LogDebugCommand,
     LogErrorCommand,
     LogInfoCommand,
+    LogWarningCommand,
     PropertiesPanelStateQuery,
     Query,
     sortIdsByOrder,
@@ -213,8 +215,16 @@ class MockHost extends MockHostApi<StateType, MessageType> {
                 );
                 break;
             }
+            case message.type === "LogDebugCommand": {
+                console.debug((message as LogDebugCommand).message);
+                break;
+            }
             case message.type === "LogInfoCommand": {
                 console.info((message as LogInfoCommand).message);
+                break;
+            }
+            case message.type === "LogWarningCommand": {
+                console.warn((message as LogWarningCommand).message);
                 break;
             }
             case message.type === "LogErrorCommand": {

--- a/apps/bpmn-webview/src/app/modeler.ts
+++ b/apps/bpmn-webview/src/app/modeler.ts
@@ -68,6 +68,11 @@ export class BpmnModeler {
 
     private _selection: SelectionManager | undefined;
 
+    // Optional host sink for non-fatal warnings (element-not-found, missing
+    // inline script). Kept as an injected callback rather than a host import so
+    // the modeler stays constructible in tests and the standalone dev browser.
+    private onWarningSink?: (message: string) => void;
+
     /**
      * Access the viewport manager after {@link create}.
      *
@@ -359,7 +364,7 @@ export class BpmnModeler {
         const modeling = modeler.get<any>("modeling");
         const element = elementRegistry.get(elementId);
         if (!element) {
-            console.warn(`Element not found: ${elementId}`);
+            this.warn(`Element not found: ${elementId}`);
             return;
         }
 
@@ -378,7 +383,7 @@ export class BpmnModeler {
             kind === "execution-listener" ? "camunda:ExecutionListener" : "camunda:TaskListener";
         const listener = findListenerAt(element.businessObject, listenerType, listenerIndex);
         if (!listener || !listener.script) {
-            console.warn(`${listenerType} #${listenerIndex} on ${elementId} has no inline script`);
+            this.warn(`${listenerType} #${listenerIndex} on ${elementId} has no inline script`);
             return;
         }
         modeling.updateModdleProperties(element, listener.script, {
@@ -409,7 +414,7 @@ export class BpmnModeler {
         const modeling = modeler.get<any>("modeling");
         const element = elementRegistry.get(elementId);
         if (!element) {
-            console.warn(`Element not found: ${elementId}`);
+            this.warn(`Element not found: ${elementId}`);
             return;
         }
 
@@ -424,7 +429,7 @@ export class BpmnModeler {
             kind === "execution-listener" ? "camunda:ExecutionListener" : "camunda:TaskListener";
         const listener = findListenerAt(element.businessObject, listenerType, listenerIndex);
         if (!listener || !listener.script) {
-            console.warn(`${listenerType} #${listenerIndex} on ${elementId} has no inline script`);
+            this.warn(`${listenerType} #${listenerIndex} on ${elementId} has no inline script`);
             return;
         }
         modeling.updateModdleProperties(element, listener.script, {
@@ -450,6 +455,15 @@ export class BpmnModeler {
     }
 
     /**
+     * Registers a sink for non-fatal warnings so the host can forward them to the
+     * output channel. Without it these only reached the webview console, invisible
+     * in a bug report.
+     */
+    onWarning(sink: (message: string) => void): void {
+        this.onWarningSink = sink;
+    }
+
+    /**
      * Hands the host's per-activity implementation-resolution map to the
      * code-link DI service, which caches it and refreshes the context pad so the
      * "Go to implementation" entry hides for tasks whose implementation does not
@@ -459,6 +473,15 @@ export class BpmnModeler {
      */
     applyImplementationStatus(resolved: Record<string, boolean>): void {
         this.getService<CodeLinkMapClient>("codeLinkMapClient").applyStatus(resolved);
+    }
+
+    /**
+     * Emits a non-fatal warning to the console (preserved for dev/tests) and, if
+     * a host sink is wired via {@link onWarning}, forwards it to the channel.
+     */
+    private warn(message: string): void {
+        console.warn(message);
+        this.onWarningSink?.(message);
     }
 
     /**

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -340,6 +340,9 @@ async function initializeModeler(
 
     try {
         bpmnModeler.create(engine, extraModules);
+        // Forward the modeler's non-fatal warnings (element-not-found, missing
+        // inline script) to the output channel — they were console-only before.
+        bpmnModeler.onWarning((warning) => host.postMessage(new LogWarningCommand(warning)));
         bpmnModeler.onCommandStackChanged(sendXmlChanges);
         await openXml(bpmn);
     } catch (error: any) {
@@ -379,9 +382,19 @@ async function openXml(bpmn?: string): Promise<void> {
  * changes, then triggers an align-to-origin pass if the setting is enabled.
  */
 async function sendXmlChanges(): Promise<void> {
-    const bpmn = await bpmnModeler.exportDiagram();
-    host.postMessage(new SyncDocumentCommand(bpmn));
-    bpmnModeler.alignElementsToOrigin();
+    // A rejection here only reaches the global unhandledrejection hook (diagram-js
+    // discards the returned promise) as a context-free line — catch it so the
+    // failure is named and deterministic on the channel.
+    try {
+        const bpmn = await bpmnModeler.exportDiagram();
+        host.postMessage(new SyncDocumentCommand(bpmn));
+        bpmnModeler.alignElementsToOrigin();
+    } catch (error) {
+        const e = error instanceof Error ? error : new Error(String(error));
+        host.postMessage(
+            new LogErrorCommand(`Failed to sync diagram changes: ${e.message}`, e.stack),
+        );
+    }
 }
 
 /**

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -23,7 +23,7 @@ import {
     ImplementationStatusQuery,
     LanguageQuery,
     LogErrorCommand,
-    LogInfoCommand,
+    LogWarningCommand,
     NoModelerError,
     OpenScriptEditorCommand,
     PropertiesPanelStateQuery,
@@ -56,6 +56,24 @@ import type { LintConfigService } from "./app/bpmnlint";
 import { WebviewStateManager } from "./app/state";
 
 const host = getHostApi();
+
+// Global safety net for throws the per-message try/catch in onReceiveMessage
+// can't reach — bpmn-js event-bus callbacks (e.g. onCommandStackChanged) run
+// outside it, so an error there would otherwise vanish into the webview console
+// and never reach the output channel. Registered eagerly so it covers failures
+// during the initial modeler bootstrap too.
+window.addEventListener("error", (event: ErrorEvent) => {
+    host.postMessage(new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack));
+});
+window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason: unknown = event.reason;
+    host.postMessage(
+        new LogErrorCommand(
+            `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
+            reason instanceof Error ? reason.stack : undefined,
+        ),
+    );
+});
 
 /**
  * Singleton modeler instance shared across all message handlers.
@@ -260,6 +278,18 @@ window.onload = async function () {
     // Phase 1: restore viewport (canvas exists after openXml)
     stateManager.restoreViewport();
 
+    // Surface templates bpmn-js rejects (invalid schema, bad `appliesTo`, …).
+    // Subscribed *before* GetElementTemplatesCommand so the errors fired while
+    // the loader validates the reply are observed. It's a warning, not an error:
+    // bpmn-js skips an invalid template non-fatally, and its message already
+    // carries the offending template's id/name.
+    bpmnModeler.onElementTemplatesErrors((errors) => {
+        for (const error of errors ?? []) {
+            const message = error instanceof Error ? error.message : String(error);
+            host.postMessage(new LogWarningCommand(`Element template rejected: ${message}`));
+        }
+    });
+
     // Request templates + settings + panel state, wait for all to apply
     host.postMessage(new GetElementTemplatesCommand());
     host.postMessage(new GetBpmnModelerSettingCommand());
@@ -339,8 +369,8 @@ async function openXml(bpmn?: string): Promise<void> {
     }
 
     if (result.warnings.length > 0) {
-        const warnings = `with following warnings: ${formatErrors(result.warnings)}`;
-        host.postMessage(new LogInfoCommand(warnings));
+        const warnings = `Diagram opened with following warnings: ${formatErrors(result.warnings)}`;
+        host.postMessage(new LogWarningCommand(warnings));
     }
 }
 
@@ -381,7 +411,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
         case queryOrCommand.type === "ElementTemplatesQuery": {
             try {
                 const elementTemplates = (message.data as ElementTemplatesQuery).elementTemplates;
-                console.log("Received element templates: ", elementTemplates);
+                console.debug("Received element templates: ", elementTemplates);
                 bpmnModeler.setElementTemplates(elementTemplates);
                 elementTemplatesResolver.done(message.data as ElementTemplatesQuery);
             } catch (error: any) {
@@ -397,7 +427,7 @@ async function onReceiveMessage(message: MessageEvent<Query | Command>): Promise
                     .apply(query.config);
 
                 for (const warning of warnings) {
-                    host.postMessage(new LogInfoCommand(warning));
+                    host.postMessage(new LogWarningCommand(warning));
                 }
             } catch (error: any) {
                 host.postMessage(new LogErrorCommand(errorPrefix + error.message));

--- a/apps/deployment-webview/src/app/form.ts
+++ b/apps/deployment-webview/src/app/form.ts
@@ -6,6 +6,7 @@ import {
     DeploymentFormDefaults,
     DeploymentResultQuery,
     Engine,
+    LogInfoCommand,
     Query,
     RequestAdditionalFilesCommand,
     RequestStoredCredentialsCommand,
@@ -332,6 +333,14 @@ export class DeploymentForm {
                 this.statusBanner.className = "status-banner error";
                 this.statusBanner.textContent = err instanceof Error ? err.message : String(err);
                 this.statusBanner.style.display = "block";
+                // Breadcrumb, not a defect: the banner already tells the user. The
+                // channel line lets a bug report show the deploy was blocked by
+                // client-side validation before any request left the webview.
+                this.host.postMessage(
+                    new LogInfoCommand(
+                        `Deployment form validation failed: ${err instanceof Error ? err.message : String(err)}`,
+                    ),
+                );
             }
         });
     }

--- a/apps/deployment-webview/src/app/startInstanceForm.ts
+++ b/apps/deployment-webview/src/app/startInstanceForm.ts
@@ -2,6 +2,7 @@ import {
     AuthConfigPayload,
     Command,
     Engine,
+    LogInfoCommand,
     Query,
     RequestPayloadFilesCommand,
     StartInstanceCommand,
@@ -124,6 +125,13 @@ export class StartInstanceForm {
                 this.statusBanner.className = "status-banner error";
                 this.statusBanner.textContent = err instanceof Error ? err.message : String(err);
                 this.statusBanner.style.display = "block";
+                // Breadcrumb, not a defect: the banner already tells the user; the
+                // channel line records that start-instance was blocked client-side.
+                this.host.postMessage(
+                    new LogInfoCommand(
+                        `Start-instance form validation failed: ${err instanceof Error ? err.message : String(err)}`,
+                    ),
+                );
             }
         });
     }

--- a/apps/deployment-webview/src/main.ts
+++ b/apps/deployment-webview/src/main.ts
@@ -5,6 +5,7 @@ import {
     Command,
     DeploymentResultQuery,
     FormDefaultsQuery,
+    LogErrorCommand,
     ProcessDefinitionKeyQuery,
     Query,
     RequestFormDefaultsCommand,
@@ -19,6 +20,23 @@ import { StartInstanceForm } from "./app/startInstanceForm";
 import { getHostApi } from "./app/host";
 
 const host = getHostApi();
+
+// Global safety net: the deployment webview had no error forwarding at all, so a
+// throw in a DOM callback or a rejected promise vanished into the webview console
+// and never reached the output channel. Mirrors the bpmn-webview hooks; registered
+// eagerly so failures during form bootstrap are covered too.
+window.addEventListener("error", (event: ErrorEvent) => {
+    host.postMessage(new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack));
+});
+window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason: unknown = event.reason;
+    host.postMessage(
+        new LogErrorCommand(
+            `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
+            reason instanceof Error ? reason.stack : undefined,
+        ),
+    );
+});
 
 /**
  * Entry point: initialises the deployment and start-instance forms once the
@@ -44,6 +62,10 @@ window.onload = function () {
         );
     } catch (err) {
         console.error("[DeploymentWebview] Failed to initialise forms:", err);
+        const e = err instanceof Error ? err : new Error(String(err));
+        host.postMessage(
+            new LogErrorCommand(`Failed to initialise deployment forms: ${e.message}`, e.stack),
+        );
         return;
     }
 

--- a/apps/dmn-webview/src/app/host.ts
+++ b/apps/dmn-webview/src/app/host.ts
@@ -2,6 +2,10 @@ import {
     Command,
     DmnFileQuery,
     DmnModelerSettingQuery,
+    LogDebugCommand,
+    LogErrorCommand,
+    LogInfoCommand,
+    LogWarningCommand,
     PropertiesPanelStateQuery,
     Query,
     HostApi,
@@ -93,6 +97,26 @@ class MockHost extends MockHostApi<StateType, MessageType> {
             }
             case message.type === "SetPropertiesPanelStateCommand": {
                 // No host to persist to in standalone browser runs.
+                break;
+            }
+            // The webview forwards log entries to the host; in a standalone
+            // browser run there's no host, so mirror them onto the dev console.
+            // Cases are required because the base MockHost throws on unknown
+            // types — and the global error listeners now emit LogErrorCommand.
+            case message.type === "LogDebugCommand": {
+                console.debug((message as LogDebugCommand).message);
+                break;
+            }
+            case message.type === "LogInfoCommand": {
+                console.info((message as LogInfoCommand).message);
+                break;
+            }
+            case message.type === "LogWarningCommand": {
+                console.warn((message as LogWarningCommand).message);
+                break;
+            }
+            case message.type === "LogErrorCommand": {
+                console.error((message as LogErrorCommand).message);
                 break;
             }
             default: {

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -159,8 +159,18 @@ async function openXML(dmn: string | undefined) {
 }
 
 async function sendChanges() {
-    const dmn = await exportDiagram();
-    host.postMessage(new SyncDocumentCommand(dmn));
+    // A rejection here only reaches the global unhandledrejection hook (the
+    // dmn-js event bus discards the returned promise) as a context-free line —
+    // catch it so the failure is named and deterministic on the channel.
+    try {
+        const dmn = await exportDiagram();
+        host.postMessage(new SyncDocumentCommand(dmn));
+    } catch (error) {
+        const e = error instanceof Error ? error : new Error(String(error));
+        host.postMessage(
+            new LogErrorCommand(`Failed to sync diagram changes: ${e.message}`, e.stack),
+        );
+    }
 }
 
 async function onReceiveMessage(message: MessageEvent<Query | Command>) {

--- a/apps/dmn-webview/src/main.ts
+++ b/apps/dmn-webview/src/main.ts
@@ -17,7 +17,7 @@ import {
     initResizer,
     initTheme,
     LogErrorCommand,
-    LogInfoCommand,
+    LogWarningCommand,
     NoModelerError,
     PropertiesPanelStateQuery,
     Query,
@@ -37,6 +37,22 @@ import {
 } from "./app";
 
 const host = getHostApi();
+
+// Global safety net for throws outside the per-message try/catch below — dmn-js
+// event-bus callbacks run outside it, so an error there would otherwise vanish
+// into the webview console instead of reaching the output channel.
+window.addEventListener("error", (event: ErrorEvent) => {
+    host.postMessage(new LogErrorCommand(`Unhandled error: ${event.message}`, event.error?.stack));
+});
+window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason: unknown = event.reason;
+    host.postMessage(
+        new LogErrorCommand(
+            `Unhandled promise rejection: ${reason instanceof Error ? reason.message : String(reason)}`,
+            reason instanceof Error ? reason.stack : undefined,
+        ),
+    );
+});
 
 const stateManager = new WebviewStateManager(host);
 
@@ -138,7 +154,7 @@ async function openXML(dmn: string | undefined) {
         );
         const message = `Diagram was opened with following warnings: ${formatErrors(warnings)}
             `;
-        host.postMessage(new LogInfoCommand(message));
+        host.postMessage(new LogWarningCommand(message));
     }
 }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/HostNotifications.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/HostNotifications.kt
@@ -36,6 +36,7 @@ class HostNotifications(private val project: Project) {
         when (level) {
             "error" -> log.warn(text)
             "warn" -> log.warn(text)
+            "debug" -> log.debug(text)
             else -> log.info(text)
         }
     }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/DeploymentRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/DeploymentRouter.kt
@@ -74,7 +74,11 @@ internal class DeploymentRouter(private val deps: BridgeDeps) {
             try {
                 JsonParser.parseString(rawMessage)
             } catch (e: Exception) {
-                log.warn("Discarding malformed deployment message: $rawMessage", e)
+                // The body is withheld: deployment form messages carry the user's
+                // plaintext password / clientSecret, and unlike the core→host
+                // frames there is no method marker to key redaction on — the whole
+                // raw message is the auth payload. The parse exception is enough.
+                log.warn("Discarding malformed deployment message (body withheld: may contain credentials)", e)
                 return
             }
         deps.channel.notify("deployment/webviewMessage", linkedMapOf("message" to parsed))

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannel.kt
@@ -122,7 +122,9 @@ internal class RpcChannel(
             try {
                 gson.fromJson(line, JsonObject::class.java)
             } catch (e: Exception) {
-                log.warn("Discarding malformed core message: $line", e)
+                // `method` is unreadable here (the line failed to parse), so
+                // redactFrameForLog falls back to a substring probe.
+                log.warn("Discarding malformed core message: ${redactFrameForLog(line, method = null)}", e)
                 return
             }
         // The host issues no requests to the core, so a frame without `method`
@@ -141,7 +143,7 @@ internal class RpcChannel(
         try {
             dispatch(method, params, id)
         } catch (e: Exception) {
-            log.warn("Failed to handle core message ($method): $line", e)
+            log.warn("Failed to handle core message ($method): ${redactFrameForLog(line, method)}", e)
             id?.let { replyError(it, e.message ?: "host handler failed") }
         }
     }
@@ -196,4 +198,29 @@ internal class RpcChannel(
     private companion object {
         const val OUTBOUND_CAPACITY = 512
     }
+}
+
+// JSON-RPC namespaces whose frames can carry plaintext credentials: the password
+// / clientSecret live in `secretStore/*` params, and the deployment form relays
+// the same secrets (and the core echoes stored ones back to prefill the form)
+// under `deployment/*`. Their bodies must never reach idea.log. Kept in sync with
+// `SecretStoreRouter` and `DeploymentRouter`.
+internal val CREDENTIAL_METHOD_PREFIXES = listOf("secretStore/", "deployment/")
+internal const val REDACTED_FRAME = "<redacted: credential-bearing frame>"
+
+/**
+ * Strips the body of a credential-bearing frame before it is logged. When the
+ * [method] is known (a parsed frame that then threw during dispatch) we match the
+ * credential namespaces exactly; for an unparseable line ([method] == null) we
+ * fall back to a substring probe so a corrupted secret frame still can't leak its
+ * plaintext. Other frames pass through unredacted for debuggability.
+ */
+internal fun redactFrameForLog(line: String, method: String?): String {
+    val sensitive =
+        if (method != null) {
+            CREDENTIAL_METHOD_PREFIXES.any { method.startsWith(it) }
+        } else {
+            CREDENTIAL_METHOD_PREFIXES.any { line.contains(it) }
+        }
+    return if (sensitive) REDACTED_FRAME else line
 }

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -22,6 +22,17 @@
                 leaving the IDE.</li>
         </ul>
 
+        <h4>Troubleshooting</h4>
+        <p>If a diagram fails to open or an action misbehaves, the plugin surfaces
+        errors as IDE notifications and records the full detail in the IDE log.
+        Open it via <b>Help | Show Log in Finder / Explorer</b> (or bundle it with
+        <b>Help | Collect Logs and Diagnostic Data</b>).</p>
+        <p>When filing a bug, capture more detail first: open
+        <b>Help | Diagnostic Tools | Debug Log Settings…</b>, add
+        <code>io.miragon</code>, reproduce the problem, then attach the log.
+        Deployment passwords and client secrets are stored in the IDE's password
+        safe and are redacted from the log, so it is safe to attach.</p>
+
         <p>For the complete feature list and documentation, visit
            <a href="https://miragon.github.io/bpmn-modeler/">miragon.github.io/bpmn-modeler</a>.</p>
         <p><b>Source &amp; issues:</b>

--- a/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannelTest.kt
+++ b/apps/intellij-plugin/src/test/kotlin/io/miragon/intellij/bpmn/bridge/RpcChannelTest.kt
@@ -4,6 +4,7 @@ import com.google.gson.Gson
 import com.google.gson.JsonObject
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -129,6 +130,57 @@ class RpcChannelTest {
         val okReply = parse(fake.nextFrame())
         assertEquals(9, okReply.get("id").asInt)
         assertEquals("ok", okReply.get("result").asString)
+    }
+
+    /**
+     * A `secretStore` frame whose handler throws (e.g. a failing PasswordSafe
+     * call) must never have its plaintext credential reach the log. The redaction
+     * runs before `log.warn`, so we assert the property on [redactFrameForLog]
+     * directly rather than scraping the process-global no-op logger.
+     */
+    @Test
+    fun `redaction strips credentials from a failing secretStore frame`() {
+        val frame = """{"method":"secretStore/saveBasicAuth","params":{"username":"admin","password":"hunter2"},"id":3}"""
+
+        val redacted = redactFrameForLog(frame, method = "secretStore/saveBasicAuth")
+
+        assertEquals(REDACTED_FRAME, redacted)
+        assertFalse(redacted.contains("hunter2"), "the plaintext password must not survive redaction")
+    }
+
+    /**
+     * Credentials also ride `deployment` frames: the form relays them and the
+     * core echoes stored ones back to prefill the form. A failing prefill dispatch
+     * must not leak the echoed password.
+     */
+    @Test
+    fun `redaction strips credentials from a failing deployment frame`() {
+        val frame = """{"method":"deployment/postMessage","params":{"message":{"auth":{"password":"hunter2"}}}}"""
+
+        val redacted = redactFrameForLog(frame, method = "deployment/postMessage")
+
+        assertEquals(REDACTED_FRAME, redacted)
+        assertFalse(redacted.contains("hunter2"), "the echoed password must not survive redaction")
+    }
+
+    /** An unparseable line that still mentions a credential namespace is redacted via the substring fallback. */
+    @Test
+    fun `redaction covers a malformed credential line with no parsed method`() {
+        val corrupt = """{"method":"secretStore/saveOAuth2","params":{"clientSecret":"s3cr3t"},"""
+
+        val redacted = redactFrameForLog(corrupt, method = null)
+
+        assertEquals(REDACTED_FRAME, redacted)
+        assertFalse(redacted.contains("s3cr3t"), "a corrupted secret frame must not leak either")
+    }
+
+    /** Non-credential frames pass through unredacted so ordinary failures stay debuggable. */
+    @Test
+    fun `redaction leaves non-credential frames intact`() {
+        val frame = """{"method":"document/save","params":{"editorId":"x"},"id":1}"""
+
+        assertEquals(frame, redactFrameForLog(frame, method = "document/save"))
+        assertEquals(frame, redactFrameForLog(frame, method = null))
     }
 
     /**

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -386,6 +386,12 @@ describe("RpcNotifier", () => {
             params: { message: "boom" },
         });
 
+        notifier.logDebug("trace");
+        expect(last(frames)).toEqual({
+            method: "notifier/log",
+            params: { level: "debug", message: "trace" },
+        });
+
         notifier.logWarning("careful");
         expect(last(frames)).toEqual({
             method: "notifier/log",
@@ -396,6 +402,14 @@ describe("RpcNotifier", () => {
         expect(last(frames)).toEqual({
             method: "notifier/log",
             params: { level: "error", message: "bad" },
+        });
+
+        // A bare string (e.g. a webview-forwarded stack) is forwarded verbatim,
+        // not re-wrapped in an Error.
+        notifier.logError("[webview] raw stack");
+        expect(last(frames)).toEqual({
+            method: "notifier/log",
+            params: { level: "error", message: "[webview] raw stack" },
         });
 
         notifier.openLoggingConsole();

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -392,6 +392,12 @@ describe("RpcNotifier", () => {
             params: { level: "debug", message: "trace" },
         });
 
+        notifier.logInfo("step");
+        expect(last(frames)).toEqual({
+            method: "notifier/log",
+            params: { level: "info", message: "step" },
+        });
+
         notifier.logWarning("careful");
         expect(last(frames)).toEqual({
             method: "notifier/log",

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -360,6 +360,10 @@ export class RpcNotifier implements NotifierPort {
         this.rpc.notify(METHODS.notifierOpenConsole, {});
     }
 
+    logDebug(message: string): void {
+        this.rpc.notify(METHODS.notifierLog, { level: "debug", message });
+    }
+
     logInfo(message: string): void {
         this.rpc.notify(METHODS.notifierLog, { level: "info", message });
     }
@@ -368,8 +372,12 @@ export class RpcNotifier implements NotifierPort {
         this.rpc.notify(METHODS.notifierLog, { level: "warn", message });
     }
 
-    logError(error: Error): void {
-        this.rpc.notify(METHODS.notifierLog, { level: "error", message: error.message });
+    /** A bare `string` (e.g. a webview stack) is forwarded verbatim, not re-wrapped. */
+    logError(error: string | Error): void {
+        this.rpc.notify(METHODS.notifierLog, {
+            level: "error",
+            message: error instanceof Error ? error.message : error,
+        });
     }
 
     /**

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -1,5 +1,5 @@
 import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
-import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
+import { BpmnModelerService, registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
 
 import { RpcEditorHandle } from "../adapters";
 import { METHODS } from "../protocol/descriptor";
@@ -44,7 +44,7 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
     deps.router
         .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
             if (await bpmnService.display(editorId)) {
-                deps.notifier.logInfo("BPMN modeler is ready");
+                deps.notifier.logDebug("BPMN modeler is ready");
             }
         })
         .on("SyncDocumentCommand", async (message: Command, editorId: string) => {
@@ -57,6 +57,9 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
         .on("GetPropertiesPanelStateCommand", (_m: Command, editorId: string) => {
             deps.store.postMessage(editorId, query("PropertiesPanelStateQuery", { visible: true }));
         });
+
+    // Route the webview's Log*Commands into `idea.log` via the notifier/log RPC.
+    registerWebviewLogHandlers(deps.router, deps.notifier);
 
     deps.rpc.on(METHODS.sessionRegister, async (params: RegisterParams) => {
         // Seed settings before any discovery so `getConfigFolder()` is correct on

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -1,3 +1,5 @@
+import { basename } from "node:path";
+
 import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
 import { BpmnModelerService, registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
 
@@ -59,7 +61,16 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
         });
 
     // Route the webview's Log*Commands into `idea.log` via the notifier/log RPC.
-    registerWebviewLogHandlers(deps.router, deps.notifier);
+    // Tag each line with the diagram's basename so a warning is correlatable when
+    // several editors are open; getFilePath throws for an unknown editorId.
+    const resolveSource = (editorId: string): string | undefined => {
+        try {
+            return basename(deps.documentPort.getFilePath(editorId));
+        } catch {
+            return undefined;
+        }
+    };
+    registerWebviewLogHandlers(deps.router, deps.notifier, resolveSource);
 
     deps.rpc.on(METHODS.sessionRegister, async (params: RegisterParams) => {
         // Seed settings before any discovery so `getConfigFolder()` is correct on
@@ -78,8 +89,13 @@ export function register(deps: BridgeSharedDeps, sessionHooks: SessionHooks[]): 
         // messages through the store into the router, and arm the echo-prevention
         // session.
         deps.store.register(handle);
+        // The bridge (unlike VS Code's ModelerEditorController) doesn't wrap the
+        // dispatch, so a rejected handler — now that commit 2 makes handlers return
+        // their service promise — would surface as a Node unhandled rejection.
         deps.store.subscribeToMessageEvent(params.editorId, (message, editorId) =>
-            deps.router.dispatch(message, editorId),
+            deps.router.dispatch(message, editorId).catch((error) => {
+                deps.notifier.logError(error instanceof Error ? error : new Error(String(error)));
+            }),
         );
         bpmnService.registerSession(params.editorId);
 

--- a/apps/modeler-bridge/src/composition/sharedDeps.ts
+++ b/apps/modeler-bridge/src/composition/sharedDeps.ts
@@ -63,7 +63,7 @@ export function buildSharedDeps(
     // onOpenCountChanged is the VS Code setContext hook; irrelevant out-of-process.
     const store = new EditorSessionStore(() => {});
 
-    const artifactSvc = new ArtifactService(nodeWorkspace, settings);
+    const artifactSvc = new ArtifactService(nodeWorkspace, settings, notifier);
 
     // One router shared across features: each feature registers its own
     // webview-message surface on it. The core enforces one handler per type, so

--- a/apps/modeler-bridge/src/protocol/types.ts
+++ b/apps/modeler-bridge/src/protocol/types.ts
@@ -216,7 +216,7 @@ export interface NotifierOpenDocumentParams {
 
 /** `notifier/log` — a leveled line to the IDE log/console. */
 export interface NotifierLogParams {
-    level: "info" | "warn" | "error";
+    level: "debug" | "info" | "warn" | "error";
     message: string;
 }
 

--- a/apps/vscode-plugin/README.md
+++ b/apps/vscode-plugin/README.md
@@ -89,7 +89,13 @@ template, or the webview misbehaves, raise the level to see the full trace:
 run **Developer: Set Log Level…**, pick *bpmn.modeler*, and choose **Debug**.
 Debug adds the per-message transport trace, the element-template discovery scan
 (which config folder was searched and what was found), and any warnings or
-errors the webview forwards (prefixed with `[webview]`).
+errors the webview forwards (prefixed with `[webview:<file>]`).
+
+**Filing a bug?** Set the log level to **Debug**, reproduce the problem, then
+copy the whole `bpmn.modeler` channel into the report — the Info-level
+breadcrumbs (editor opened/closed, deployment started/result, SVG export) plus
+the Debug transport trace let us reconstruct the exact steps that led to the
+failure. Credentials are never logged, so the channel is safe to paste.
 
 ## Support and feedback
 

--- a/apps/vscode-plugin/README.md
+++ b/apps/vscode-plugin/README.md
@@ -78,6 +78,19 @@ Search for "BPMN Modeler" in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`
 | BPMN Modeler: Toggle Standard Text Editor | `Ctrl+Shift+E` | Open the XML text editor next to the BPMN modeler                |
 | BPMN Modeler: Display Logging Information |                | Open a console showing modeler log output                        |
 
+## Troubleshooting
+
+The modeler logs to the **`bpmn.modeler`** output channel. Open it via the
+Output panel (View → Output → select *bpmn.modeler*) or the command **BPMN
+Modeler: Display Logging Information** (`bpmn-modeler.openLoggingConsole`).
+
+By default the channel shows `Info` and above. When a diagram, element
+template, or the webview misbehaves, raise the level to see the full trace:
+run **Developer: Set Log Level…**, pick *bpmn.modeler*, and choose **Debug**.
+Debug adds the per-message transport trace, the element-template discovery scan
+(which config folder was searched and what was found), and any warnings or
+errors the webview forwards (prefixed with `[webview]`).
+
 ## Support and feedback
 
 - Documentation: <https://miragon.github.io/bpmn-modeler/>

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -1,3 +1,5 @@
+import { basename } from "node:path";
+
 import { ExtensionContext } from "vscode";
 
 import { PropertiesPanelStateRepository } from "../modeler/bpmn/infrastructure/PropertiesPanelStateRepository";
@@ -194,16 +196,28 @@ export function register(
             ),
         )
         .on("SyncActivitiesCommand", syncActivitiesHandler(codeLink.codeLinkMap));
+    // Tags forwarded webview log lines with the diagram's basename so a warning
+    // can be correlated to a file when several editors are open. getFilePath
+    // throws for an editorId the store no longer tracks; a bare `[webview]` tag
+    // is better than dropping the line.
+    const resolveSource = (editorId: string): string | undefined => {
+        try {
+            return basename(deps.vsDocument.getFilePath(editorId));
+        } catch {
+            return undefined;
+        }
+    };
+
     // Route the webview's own Log*Commands into the output channel; without this
     // the router drops them as unknown types and webview diagnostics never surface.
-    registerWebviewLogHandlers(bpmnMessageRouter, deps.notifier);
+    registerWebviewLogHandlers(bpmnMessageRouter, deps.notifier, resolveSource);
     const dmnMessageRouter = new WebviewMessageRouter()
         .on("GetDmnFileCommand", getDmnFileHandler(dmnService, deps.notifier))
         .on("GetDmnModelerSettingCommand", getDmnModelerSettingHandler(dmnSettingsBroadcaster))
         .on("GetPropertiesPanelStateCommand", getPropertiesPanelStateHandler(dmnPanelSvc))
         .on("SetPropertiesPanelStateCommand", setPropertiesPanelStateHandler(dmnPanelSvc))
         .on("SyncDocumentCommand", syncDmnDocumentHandler(dmnService));
-    registerWebviewLogHandlers(dmnMessageRouter, deps.notifier);
+    registerWebviewLogHandlers(dmnMessageRouter, deps.notifier, resolveSource);
 
     new ModelerEditorController(deps.editorStore, deps.notifier, {
         viewType: BPMN_VIEW_TYPE,

--- a/apps/vscode-plugin/src/composition/editorFeature.ts
+++ b/apps/vscode-plugin/src/composition/editorFeature.ts
@@ -2,6 +2,7 @@ import { ExtensionContext } from "vscode";
 
 import { PropertiesPanelStateRepository } from "../modeler/bpmn/infrastructure/PropertiesPanelStateRepository";
 import { WebviewMessageRouter } from "@miragon/bpmn-modeler-core";
+import { registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
 import { BpmnModelerService } from "@miragon/bpmn-modeler-core";
 import { BpmnClipboardMediator } from "@miragon/bpmn-modeler-core";
 import { BpmnElementTemplatesService } from "@miragon/bpmn-modeler-core";
@@ -193,12 +194,16 @@ export function register(
             ),
         )
         .on("SyncActivitiesCommand", syncActivitiesHandler(codeLink.codeLinkMap));
+    // Route the webview's own Log*Commands into the output channel; without this
+    // the router drops them as unknown types and webview diagnostics never surface.
+    registerWebviewLogHandlers(bpmnMessageRouter, deps.notifier);
     const dmnMessageRouter = new WebviewMessageRouter()
         .on("GetDmnFileCommand", getDmnFileHandler(dmnService, deps.notifier))
         .on("GetDmnModelerSettingCommand", getDmnModelerSettingHandler(dmnSettingsBroadcaster))
         .on("GetPropertiesPanelStateCommand", getPropertiesPanelStateHandler(dmnPanelSvc))
         .on("SetPropertiesPanelStateCommand", setPropertiesPanelStateHandler(dmnPanelSvc))
         .on("SyncDocumentCommand", syncDmnDocumentHandler(dmnService));
+    registerWebviewLogHandlers(dmnMessageRouter, deps.notifier);
 
     new ModelerEditorController(deps.editorStore, deps.notifier, {
         viewType: BPMN_VIEW_TYPE,

--- a/apps/vscode-plugin/src/composition/sharedDeps.ts
+++ b/apps/vscode-plugin/src/composition/sharedDeps.ts
@@ -47,6 +47,9 @@ export function buildSharedDeps(context: ExtensionContext): SharedDeps {
 
     const vsWorkspace = new VsCodeWorkspace();
     const vsSettings = new VsCodeSettings();
+    // Hoisted so it can seed ArtifactService's optional logger for the
+    // element-template discovery diagnostics.
+    const notifier = new VsCodeNotifier();
 
     return {
         editorStore,
@@ -54,10 +57,10 @@ export function buildSharedDeps(context: ExtensionContext): SharedDeps {
         vsWorkspace,
         vsSettings,
         statusBar: new VsCodeStatusBar(),
-        notifier: new VsCodeNotifier(),
+        notifier,
         picker: new VsCodePicker(vsWorkspace),
         clipboard: new VsCodeClipboard(),
         textEditor: new VsCodeTextEditor(),
-        artifactSvc: new ArtifactService(vsWorkspace, vsSettings),
+        artifactSvc: new ArtifactService(vsWorkspace, vsSettings, notifier),
     };
 }

--- a/apps/vscode-plugin/src/deployment/controller/DeploymentController.spec.ts
+++ b/apps/vscode-plugin/src/deployment/controller/DeploymentController.spec.ts
@@ -60,6 +60,7 @@ function createController() {
     const notifier = {
         showInfo: vi.fn(),
         showError: vi.fn(),
+        logDebug: vi.fn(),
         logInfo: vi.fn(),
         logError: vi.fn(),
     };

--- a/apps/vscode-plugin/src/diff/controller/BpmnDiffController.ts
+++ b/apps/vscode-plugin/src/diff/controller/BpmnDiffController.ts
@@ -15,7 +15,12 @@ import {
     ViewportChangedCommand,
 } from "@miragon/bpmn-modeler-shared";
 
-import { DiffPaneHandle, DiffSession, basenameOfUriString } from "@miragon/bpmn-modeler-core";
+import {
+    DiffPaneHandle,
+    DiffSession,
+    basenameOfUriString,
+    routeWebviewLogCommand,
+} from "@miragon/bpmn-modeler-core";
 import { bootstrapWebview } from "../../shared/infrastructure/bootstrapWebview";
 import { DiffPaneStore } from "@miragon/bpmn-modeler-core";
 import { VsCodeNotifier } from "../../shared/infrastructure/VsCodeNotifier";
@@ -152,7 +157,13 @@ export class BpmnDiffController {
         // `GetBpmnFileCommand` as soon as the webview's scripts run.
         const handle = new WebviewPaneHandle(panel, document);
 
-        panel.webview.onDidReceiveMessage((message: Command) => this.onMessage(handle, message));
+        panel.webview.onDidReceiveMessage((message: Command) =>
+            this.onMessage(handle, message).catch((error) => {
+                // VS Code's emitter doesn't await this listener, so a rejected
+                // handler would surface as an unhandled rejection — log instead.
+                this.notifier.logError(error instanceof Error ? error : new Error(String(error)));
+            }),
+        );
         panel.onDidDispose(() => this.disposePane(handle));
 
         const session = this.store.findByUri(handle.uri);
@@ -255,6 +266,12 @@ export class BpmnDiffController {
     }
 
     private async onMessage(handle: DiffPaneHandle, message: Command): Promise<void> {
+        // Diff panes reuse bpmn-webview, whose global error hooks post
+        // Log*Commands. The switch below doesn't know them, so route them onto
+        // the channel first (tagged with the pane's file) or they're dropped.
+        if (routeWebviewLogCommand(this.notifier, message, basenameOfUriString(handle.uri))) {
+            return;
+        }
         switch (message.type) {
             case "GetBpmnFileCommand":
                 await this.diffService.sendViewerFile(handle);

--- a/apps/vscode-plugin/src/main.ts
+++ b/apps/vscode-plugin/src/main.ts
@@ -1,5 +1,6 @@
 import { env, ExtensionContext, Uri, window } from "vscode";
 
+import { LoggerPort } from "@miragon/bpmn-modeler-core";
 import { setContext } from "./shared/infrastructure/extensionContext";
 import { buildSharedDeps } from "./composition/sharedDeps";
 import * as diffFeature from "./composition/diffFeature";
@@ -23,11 +24,11 @@ import * as deploymentFeature from "./composition/deploymentFeature";
  * returned.
  */
 export function activate(context: ExtensionContext): void {
-    notifyIfNewRelease(context);
-
     setContext(context);
 
     const deps = buildSharedDeps(context);
+    // Below buildSharedDeps so the release check can log through the notifier.
+    notifyIfNewRelease(context, deps.notifier);
     const { diffController } = diffFeature.register(context, deps);
     const { scriptTaskSvc, scriptVariableStore, scriptManifestParticipant } =
         scriptFeature.register(context, deps);
@@ -47,7 +48,7 @@ export function activate(context: ExtensionContext): void {
 const RELEASES_BASE = "https://github.com/Miragon/bpmn-modeler/releases/tag";
 const LAST_NOTIFIED_KEY = "lastNotifiedVersion";
 
-function notifyIfNewRelease(context: ExtensionContext): void {
+function notifyIfNewRelease(context: ExtensionContext, logger: LoggerPort): void {
     const current: string = context.extension.packageJSON.version;
     const last = context.globalState.get<string>(LAST_NOTIFIED_KEY);
 
@@ -56,7 +57,11 @@ function notifyIfNewRelease(context: ExtensionContext): void {
     }
 
     // Persist before showing so a crash/dismiss never re-triggers the prompt.
-    context.globalState.update(LAST_NOTIFIED_KEY, current);
+    // A rejected update means the prompt may repeat next launch — log it rather
+    // than let the write float away silently.
+    Promise.resolve(context.globalState.update(LAST_NOTIFIED_KEY, current)).catch((error) => {
+        logger.logError(error instanceof Error ? error : new Error(String(error)));
+    });
 
     window
         .showInformationMessage(
@@ -65,7 +70,11 @@ function notifyIfNewRelease(context: ExtensionContext): void {
         )
         .then((selection) => {
             if (selection === "View Release Notes") {
-                env.openExternal(Uri.parse(`${RELEASES_BASE}/v${current}`));
+                return env.openExternal(Uri.parse(`${RELEASES_BASE}/v${current}`));
             }
+            return undefined;
+        })
+        .then(undefined, (error) => {
+            logger.logError(error instanceof Error ? error : new Error(String(error)));
         });
 }

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.spec.ts
@@ -59,7 +59,7 @@ function createController() {
         }),
     };
     const vsDocument = { getFilePath: vi.fn().mockReturnValue("/work/diagram.bpmn") };
-    const notifier = { openLoggingConsole: vi.fn(), logError: vi.fn() };
+    const notifier = { openLoggingConsole: vi.fn(), logError: vi.fn(), logInfo: vi.fn() };
     const textEditor = { toggle: vi.fn().mockResolvedValue(true) };
     const bpmnService = { changeEngineVersion: vi.fn().mockResolvedValue(true) };
     const migrationSvc = { migrateAllDiagrams: vi.fn().mockResolvedValue(true) };
@@ -250,18 +250,36 @@ describe("CommandController.writeToClipboard", () => {
 });
 
 describe("CommandController.writeToFile", () => {
-    it("writes the svg to a sibling .svg file, rewriting the .bpmn extension", () => {
-        const { controller, captured, vsDocument } = createController();
+    it("writes the svg to a sibling .svg file and logs the export path", async () => {
+        const { controller, captured, vsDocument, notifier } = createController();
         vsDocument.getFilePath.mockReturnValue("/work/diagram.bpmn");
         controller.writeToFile();
 
         captured.onMessage?.(svgReply("<svg/>"));
+        // The write + info log run on a microtask chain; flush before asserting.
+        await Promise.resolve();
+        await Promise.resolve();
 
         expect(uriFileMock).toHaveBeenCalledWith("/work/diagram.svg");
         const [uriArg, bufferArg] = fsWriteFileMock.mock.calls[0];
         expect((uriArg as { path: string }).path).toBe("/work/diagram.svg");
         expect(Buffer.isBuffer(bufferArg)).toBe(true);
         expect((bufferArg as Buffer).toString()).toBe("<svg/>");
+        expect(notifier.logInfo).toHaveBeenCalledWith("Diagram SVG exported to /work/diagram.svg");
+    });
+
+    it("logs an error when the file write rejects", async () => {
+        const { controller, captured, notifier } = createController();
+        const failure = new Error("EACCES");
+        fsWriteFileMock.mockRejectedValueOnce(failure);
+        controller.writeToFile();
+
+        captured.onMessage?.(svgReply("<svg/>"));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(notifier.logError).toHaveBeenCalledWith(failure);
+        expect(notifier.logInfo).not.toHaveBeenCalled();
     });
 
     it("does not write a file when the svg payload is empty", () => {
@@ -271,5 +289,26 @@ describe("CommandController.writeToFile", () => {
         captured.onMessage?.(svgReply(""));
 
         expect(fsWriteFileMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("CommandController command error surfacing", () => {
+    it("logs and rethrows when changeLanguage's config update rejects", async () => {
+        const { controller, notifier } = createController();
+        showQuickPickMock.mockResolvedValue({ label: "English", description: "en" });
+        const failure = new Error("update denied");
+        configUpdateMock.mockRejectedValueOnce(failure);
+
+        await expect(controller.changeLanguage()).rejects.toThrow(failure);
+        expect(notifier.logError).toHaveBeenCalledWith(failure);
+    });
+
+    it("logs and rethrows when changeEngineVersion rejects", async () => {
+        const { controller, bpmnService, notifier } = createController();
+        const failure = new Error("engine change failed");
+        bpmnService.changeEngineVersion.mockRejectedValueOnce(failure);
+
+        await expect(controller.changeEngineVersion()).rejects.toThrow(failure);
+        expect(notifier.logError).toHaveBeenCalledWith(failure);
     });
 });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/CommandController.ts
@@ -104,8 +104,9 @@ export class CommandController {
      * Delegates to {@link BpmnModelerService.changeEngineVersion}.
      */
     changeEngineVersion(): Promise<boolean> {
-        const activeId = this.editorStore.getActiveEditorId();
-        return this.bpmnService.changeEngineVersion(activeId);
+        return this.logAndRethrow(() =>
+            this.bpmnService.changeEngineVersion(this.editorStore.getActiveEditorId()),
+        );
     }
 
     /**
@@ -114,7 +115,7 @@ export class CommandController {
      * Delegates to {@link BpmnMigrationService.migrateAllDiagrams}.
      */
     migrateAllDiagrams(): Promise<boolean> {
-        return this.migrationSvc.migrateAllDiagrams();
+        return this.logAndRethrow(() => this.migrationSvc.migrateAllDiagrams());
     }
 
     /**
@@ -123,26 +124,46 @@ export class CommandController {
      * Shows a QuickPick with all supported languages and sends the selected
      * locale to the active webview via {@link BpmnModelerService.setLanguage}.
      */
-    async changeLanguage(): Promise<void> {
-        const items = supportedLanguages.map((lang) => ({
-            label: lang.label,
-            description: lang.locale,
-        }));
+    changeLanguage(): Promise<void> {
+        return this.logAndRethrow(async () => {
+            const items = supportedLanguages.map((lang) => ({
+                label: lang.label,
+                description: lang.locale,
+            }));
 
-        const picked = await window.showQuickPick(items, {
-            placeHolder: "Select the modeler language",
+            const picked = await window.showQuickPick(items, {
+                placeHolder: "Select the modeler language",
+            });
+
+            if (!picked) {
+                return;
+            }
+
+            // Language is a personal UI preference rather than a project-scoped
+            // setting — writing at Global (User) level avoids pinning one
+            // collaborator's choice to a shared workspace settings file.
+            await workspace
+                .getConfiguration("miragon.bpmnModeler")
+                .update("language", picked.description, ConfigurationTarget.Global);
+            // Breadcrumb: a language switch changes UI strings across the modeler,
+            // so record it to explain later "why is the panel in German?" reports.
+            this.notifier.logInfo(`Modeler language changed to ${picked.description}`);
         });
+    }
 
-        if (!picked) {
-            return;
+    /**
+     * Runs an async command body, logging any rejection to the output channel
+     * before rethrowing. Without the log a rejected config update (e.g. the
+     * language write) never reaches the channel; the rethrow preserves VS Code's
+     * own command-failed surfacing so the user still sees the error.
+     */
+    private async logAndRethrow<T>(run: () => Promise<T>): Promise<T> {
+        try {
+            return await run();
+        } catch (error) {
+            this.notifier.logError(error instanceof Error ? error : new Error(String(error)));
+            throw error;
         }
-
-        // Language is a personal UI preference rather than a project-scoped
-        // setting — writing at Global (User) level avoids pinning one
-        // collaborator's choice to a shared workspace settings file.
-        await workspace
-            .getConfiguration("miragon.bpmnModeler")
-            .update("language", picked.description, ConfigurationTarget.Global);
     }
 
     /**
@@ -166,11 +187,12 @@ export class CommandController {
      * prevent listener accumulation.
      */
     writeToFile(): void {
-        this.requestSvg((svg) => {
+        this.requestSvg(async (svg) => {
             const filePath = this.vsDocument
                 .getFilePath(this.editorStore.getActiveEditorId())
                 .replace(/\.bpmn$/, ".svg");
-            workspace.fs.writeFile(Uri.file(filePath), Buffer.from(svg));
+            await workspace.fs.writeFile(Uri.file(filePath), Buffer.from(svg));
+            this.notifier.logInfo(`Diagram SVG exported to ${filePath}`);
         });
     }
 
@@ -178,9 +200,12 @@ export class CommandController {
      * Sends a `GetDiagramAsSVGCommand` to the active webview and subscribes
      * to the response.  Disposes any previously active SVG subscription first.
      *
-     * @param onSvg Callback invoked with the SVG string once received.
+     * @param onSvg Callback invoked with the SVG string once received. Its
+     *   result is awaited so a rejected async sink (a failed `workspace.fs`
+     *   file write, a denied clipboard write) reaches the channel instead of
+     *   floating away as an unhandled rejection.
      */
-    private requestSvg(onSvg: (svg: string) => void): void {
+    private requestSvg(onSvg: (svg: string) => void | Promise<void>): void {
         const activeId = this.editorStore.getActiveEditorId();
 
         this.editorStore.postMessage(activeId, new GetDiagramAsSVGCommand()).catch((error) => {
@@ -195,7 +220,11 @@ export class CommandController {
                 if (message.type === "GetDiagramAsSVGCommand") {
                     const cmd = message as GetDiagramAsSVGCommand;
                     if (cmd.svg && cmd.svg.length > 0) {
-                        onSvg(cmd.svg);
+                        Promise.resolve(onSvg(cmd.svg)).catch((error) => {
+                            this.notifier.logError(
+                                error instanceof Error ? error : new Error(String(error)),
+                            );
+                        });
                     }
                     // Dispose after receiving the response.
                     this.svgSubscription?.dispose();

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.spec.ts
@@ -42,7 +42,7 @@ function createService() {
     } as unknown as BpmnModelerService;
 }
 
-const notifier = { logInfo: vi.fn() } as unknown as VsCodeNotifier;
+const notifier = { logDebug: vi.fn() } as unknown as VsCodeNotifier;
 
 describe("BpmnRenderParticipant", () => {
     it("registers the modeler session on resolve", () => {

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/BpmnRenderParticipant.ts
@@ -26,7 +26,7 @@ export class BpmnRenderParticipant implements EditorSessionParticipant {
                 event.documentPath().endsWith(".bpmn") &&
                 session.editorId === event.documentUriString()
             ) {
-                this.notifier.logInfo("OnDidChangeTextDocument -> display");
+                this.notifier.logDebug("OnDidChangeTextDocument -> display");
                 this.bpmnService.display(session.editorId);
             }
         });

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -44,21 +44,21 @@ beforeEach(() => {
 describe("getBpmnFileHandler", () => {
     it("logs readiness only when the diagram actually rendered", async () => {
         const bpmnService = { display: vi.fn().mockResolvedValue(true) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getBpmnFileHandler(bpmnService as never, notifier as never)(ANY, EDITOR);
 
         expect(bpmnService.display).toHaveBeenCalledWith(EDITOR);
-        expect(notifier.logInfo).toHaveBeenCalledOnce();
+        expect(notifier.logDebug).toHaveBeenCalledOnce();
     });
 
     it("does not log when rendering was skipped", async () => {
         const bpmnService = { display: vi.fn().mockResolvedValue(false) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getBpmnFileHandler(bpmnService as never, notifier as never)(ANY, EDITOR);
 
-        expect(notifier.logInfo).not.toHaveBeenCalled();
+        expect(notifier.logDebug).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.spec.ts
@@ -19,6 +19,7 @@ import {
 
 import {
     getBpmnFileHandler,
+    getBpmnlintConfigHandler,
     getBpmnModelerSettingHandler,
     getClipboardHandler,
     getElementTemplatesHandler,
@@ -183,6 +184,41 @@ describe("openScriptEditorHandler", () => {
         );
 
         expect(variableStore.setExtracted).toHaveBeenCalledWith(EDITOR, variables);
+    });
+});
+
+describe("Pattern B: a rejecting service promise propagates through the handler", () => {
+    // The router awaits each handler and ModelerEditorController's dispatch catch
+    // logs a rejection — but only if the handler actually returns/awaits the
+    // service promise instead of dropping it on the floor.
+    const boom = new Error("service failed");
+
+    it("getElementTemplatesHandler rejects when setElementTemplates rejects", async () => {
+        const svc = { setElementTemplates: vi.fn().mockRejectedValue(boom) };
+        await expect(getElementTemplatesHandler(svc as never)(ANY, EDITOR)).rejects.toThrow(boom);
+    });
+
+    it("getBpmnlintConfigHandler rejects when setBpmnlintConfig rejects", async () => {
+        const svc = { setBpmnlintConfig: vi.fn().mockRejectedValue(boom) };
+        await expect(getBpmnlintConfigHandler(svc as never)(ANY, EDITOR)).rejects.toThrow(boom);
+    });
+
+    it("resyncScriptTasksHandler rejects when resyncOpenDocuments rejects", async () => {
+        const svc = { resyncOpenDocuments: vi.fn().mockRejectedValue(boom) };
+        await expect(resyncScriptTasksHandler(svc as never)(ANY, EDITOR)).rejects.toThrow(boom);
+    });
+
+    it("getBpmnModelerSettingHandler rejects when setSettings rejects, still setting language", async () => {
+        const broadcaster = {
+            setSettings: vi.fn().mockRejectedValue(boom),
+            setLanguage: vi.fn(),
+        };
+
+        await expect(
+            getBpmnModelerSettingHandler(broadcaster as never)(ANY, EDITOR),
+        ).rejects.toThrow(boom);
+        // Language is posted before settings is awaited, so it still fires.
+        expect(broadcaster.setLanguage).toHaveBeenCalledWith(EDITOR);
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -49,8 +49,10 @@ export function getBpmnFileHandler(
 export function getElementTemplatesHandler(
     templatesSvc: BpmnElementTemplatesService,
 ): MessageHandler {
-    return (_message: Command, editorId: string) => {
-        templatesSvc.setElementTemplates(editorId);
+    // Await (not fire-and-forget) so a rejection propagates to the router's
+    // dispatch catch (ModelerEditorController) instead of floating off unlogged.
+    return async (_message: Command, editorId: string) => {
+        await templatesSvc.setElementTemplates(editorId);
     };
 }
 
@@ -58,8 +60,8 @@ export function getElementTemplatesHandler(
  * `GetBpmnlintConfigCommand` → discover and push the nearest `.bpmnlintrc`.
  */
 export function getBpmnlintConfigHandler(lintSvc: BpmnLintConfigService): MessageHandler {
-    return (_message: Command, editorId: string) => {
-        lintSvc.setBpmnlintConfig(editorId);
+    return async (_message: Command, editorId: string) => {
+        await lintSvc.setBpmnlintConfig(editorId);
     };
 }
 
@@ -73,17 +75,19 @@ export function getBpmnlintConfigHandler(lintSvc: BpmnLintConfigService): Messag
 export function getBpmnModelerSettingHandler(
     settingsBroadcaster: BpmnSettingsBroadcaster,
 ): MessageHandler {
-    return (_message: Command, editorId: string) => {
-        settingsBroadcaster.setSettings(editorId);
+    // Preserve the original settings-then-language post order (settingsPromise is
+    // started first), but await settings so its rejection reaches the router's
+    // dispatch catch. setLanguage owns its own error handling and stays floating.
+    return async (_message: Command, editorId: string) => {
+        const settingsPromise = settingsBroadcaster.setSettings(editorId);
         settingsBroadcaster.setLanguage(editorId);
+        await settingsPromise;
     };
 }
 
 /** Second handler for `GetBpmnModelerSettingCommand`: reload scripts edited while hidden. */
 export function resyncScriptTasksHandler(scriptTaskSvc: ScriptTaskService): MessageHandler {
-    return (_message: Command, editorId: string) => {
-        scriptTaskSvc.resyncOpenDocuments(editorId);
-    };
+    return (_message: Command, editorId: string) => scriptTaskSvc.resyncOpenDocuments(editorId);
 }
 
 /** `GetPropertiesPanelStateCommand` → send the persisted panel visibility. */

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts
@@ -40,7 +40,7 @@ export function getBpmnFileHandler(
 ): MessageHandler {
     return async (_message: Command, editorId: string) => {
         if (await bpmnService.display(editorId)) {
-            notifier.logInfo("Bpmn modeler is ready");
+            notifier.logDebug("Bpmn modeler is ready");
         }
     };
 }

--- a/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.spec.ts
@@ -41,7 +41,7 @@ function createService() {
     } as unknown as DmnModelerService;
 }
 
-const notifier = { logInfo: vi.fn() } as unknown as VsCodeNotifier;
+const notifier = { logDebug: vi.fn() } as unknown as VsCodeNotifier;
 
 describe("DmnRenderParticipant", () => {
     it("registers the modeler session on resolve", () => {

--- a/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/editor-participants/DmnRenderParticipant.ts
@@ -25,7 +25,7 @@ export class DmnRenderParticipant implements EditorSessionParticipant {
                 event.documentPath().endsWith(".dmn") &&
                 session.editorId === event.documentUriString()
             ) {
-                this.notifier.logInfo("OnDidChangeTextDocument -> display");
+                this.notifier.logDebug("OnDidChangeTextDocument -> display");
                 this.dmnService.display(session.editorId);
             }
         });

--- a/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.spec.ts
@@ -50,6 +50,15 @@ describe("getDmnModelerSettingHandler", () => {
 
         expect(settingsBroadcaster.setSettings).toHaveBeenCalledWith(EDITOR);
     });
+
+    it("rejects when setSettings rejects so the router's dispatch catch logs it", async () => {
+        const boom = new Error("settings failed");
+        const settingsBroadcaster = { setSettings: vi.fn().mockRejectedValue(boom) };
+
+        await expect(
+            getDmnModelerSettingHandler(settingsBroadcaster as never)(ANY, EDITOR),
+        ).rejects.toThrow(boom);
+    });
 });
 
 describe("syncDmnDocumentHandler", () => {

--- a/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.spec.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.spec.ts
@@ -24,21 +24,21 @@ beforeEach(() => {
 describe("getDmnFileHandler", () => {
     it("logs readiness only when the diagram actually rendered", async () => {
         const dmnService = { display: vi.fn().mockResolvedValue(true) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getDmnFileHandler(dmnService as never, notifier as never)(ANY, EDITOR);
 
         expect(dmnService.display).toHaveBeenCalledWith(EDITOR);
-        expect(notifier.logInfo).toHaveBeenCalledOnce();
+        expect(notifier.logDebug).toHaveBeenCalledOnce();
     });
 
     it("does not log when rendering was skipped", async () => {
         const dmnService = { display: vi.fn().mockResolvedValue(false) };
-        const notifier = { logInfo: vi.fn() };
+        const notifier = { logDebug: vi.fn() };
 
         await getDmnFileHandler(dmnService as never, notifier as never)(ANY, EDITOR);
 
-        expect(notifier.logInfo).not.toHaveBeenCalled();
+        expect(notifier.logDebug).not.toHaveBeenCalled();
     });
 });
 

--- a/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.ts
@@ -34,7 +34,9 @@ export function syncDmnDocumentHandler(dmnService: DmnModelerService): MessageHa
 export function getDmnModelerSettingHandler(
     settingsBroadcaster: DmnSettingsBroadcaster,
 ): MessageHandler {
-    return (_message: Command, editorId: string) => {
-        settingsBroadcaster.setSettings(editorId);
+    // Await so a rejection propagates to the router's dispatch catch instead of
+    // floating off unlogged.
+    return async (_message: Command, editorId: string) => {
+        await settingsBroadcaster.setSettings(editorId);
     };
 }

--- a/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.ts
+++ b/apps/vscode-plugin/src/modeler/dmn/controller/webview-handlers/dmnMessageHandlers.ts
@@ -18,7 +18,7 @@ export function getDmnFileHandler(
 ): MessageHandler {
     return async (_message: Command, editorId: string) => {
         if (await dmnService.display(editorId)) {
-            notifier.logInfo("Dmn modeler is ready");
+            notifier.logDebug("Dmn modeler is ready");
         }
     };
 }

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.spec.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.spec.ts
@@ -46,6 +46,7 @@ function createFakeStore() {
 
 function createNotifier() {
     return {
+        logDebug: vi.fn(),
         logInfo: vi.fn(),
         logError: vi.fn(),
         showError: vi.fn(),

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
@@ -10,7 +10,7 @@ import {
 import { Command } from "@miragon/bpmn-modeler-shared";
 
 import { DocumentChangeEvent, EditorSubscription, SettingChange } from "@miragon/bpmn-modeler-core";
-import { EditorSessionStore } from "@miragon/bpmn-modeler-core";
+import { basenameOfUriString, EditorSessionStore } from "@miragon/bpmn-modeler-core";
 import { VsCodeEditorHandle } from "../../shared/infrastructure/VsCodeEditorHandle";
 import { VsCodeNotifier } from "../../shared/infrastructure/VsCodeNotifier";
 import { WebviewMessageRouter } from "@miragon/bpmn-modeler-core";
@@ -99,6 +99,11 @@ export class ModelerEditorController implements CustomTextEditorProvider {
                     this.options.initialPanelVisible?.(),
                 ),
             );
+            // Reproduction breadcrumb: the open/close pair frames a session in the
+            // channel so a bug report reads as a sequence of user steps.
+            this.notifier.logInfo(
+                `Editor opened: ${basenameOfUriString(editorId)} (${this.options.viewType})`,
+            );
 
             const context = new EditorSessionContextImpl(this.editorStore, editorId, webviewPanel);
 
@@ -119,7 +124,12 @@ export class ModelerEditorController implements CustomTextEditorProvider {
             // it a single call, after the store's own bookkeeping. Wired before
             // the loop (the callbacks are read lazily) so an immediate close
             // during a participant's await is still cleaned up.
-            this.editorStore.subscribeToDisposeEvent(editorId, () => context.runDisposeCallbacks());
+            this.editorStore.subscribeToDisposeEvent(editorId, () => {
+                this.notifier.logInfo(
+                    `Editor closed: ${basenameOfUriString(editorId)} (${this.options.viewType})`,
+                );
+                context.runDisposeCallbacks();
+            });
 
             // Isolate each participant: a throw in one must not skip the rest.
             // ElementTemplatesParticipant awaits a workspace-root lookup that

--- a/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
+++ b/apps/vscode-plugin/src/modeler/editor-session/ModelerEditorController.ts
@@ -150,10 +150,12 @@ export class ModelerEditorController implements CustomTextEditorProvider {
      */
     private subscribeToMessageEvent(editorId: string): void {
         this.editorStore.subscribeToMessageEvent(editorId, async (message: Command, id: string) => {
-            this.notifier.logInfo(`Message received -> ${message.type}`);
+            // Per-message transport tracing: useful when diagnosing a stuck
+            // webview handshake, but far too frequent for the default level.
+            this.notifier.logDebug(`Message received -> ${message.type}`);
             try {
                 await this.options.messageRouter.dispatch(message, id);
-                this.notifier.logInfo(`Message processed -> ${message.type}`);
+                this.notifier.logDebug(`Message processed -> ${message.type}`);
             } catch (error) {
                 // VS Code's event emitter does not await this async listener, so
                 // a rejected dispatch would otherwise surface as an unhandled

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts
@@ -89,7 +89,15 @@ export class ScriptTaskService {
      */
     register(context: ExtensionContext): void {
         context.subscriptions.push(
-            workspace.onDidChangeTextDocument((event) => this.onVirtualDocumentChanged(event)),
+            workspace.onDidChangeTextDocument((event) =>
+                // VS Code doesn't await this async listener, so a rejection would
+                // otherwise surface as an unhandled promise rejection.
+                this.onVirtualDocumentChanged(event).catch((error) => {
+                    this.notifier.logError(
+                        error instanceof Error ? error : new Error(String(error)),
+                    );
+                }),
+            ),
             window.tabGroups.onDidChangeTabs((event) => this.onTabsChanged(event)),
         );
     }

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
@@ -3,21 +3,26 @@ import { commands, LogOutputChannel, ProgressLocation, Uri, window } from "vscod
 import { NotifierPort } from "@miragon/bpmn-modeler-core";
 
 const LOG_CHANNEL_ID = "bpmn.modeler";
-const LOG_PREFIX = `[${LOG_CHANNEL_ID}] `;
 
 /**
  * Adapter for user-facing messages and diagnostic logging.
  *
- * Owns a single VS Code log output channel and the toast notification
+ * Owns a single VS Code {@link LogOutputChannel} and the toast notification
  * API so services and controllers can surface information to the user
  * without importing from `vscode` directly.
+ *
+ * The channel is created with `{ log: true }`, so VS Code supplies the level
+ * filtering (Output panel gear / *Developer: Set Log Level…*), per-line
+ * timestamps, and persistence to the extension log file. The channel-name
+ * prefix each line used to carry is therefore redundant — the channel already
+ * identifies itself — and the ctor no longer `clear()`s, so the previous
+ * session's trail survives a reload.
  */
 export class VsCodeNotifier implements NotifierPort {
     private readonly channel: LogOutputChannel;
 
     constructor() {
         this.channel = window.createOutputChannel(LOG_CHANNEL_ID, { log: true });
-        this.channel.clear();
     }
 
     showInfo(message: string): void {
@@ -43,16 +48,24 @@ export class VsCodeNotifier implements NotifierPort {
         this.channel.show(true);
     }
 
+    logDebug(message: string): void {
+        this.channel.debug(message);
+    }
+
     logInfo(message: string): void {
-        this.channel.info(LOG_PREFIX + message);
+        this.channel.info(message);
     }
 
     logWarning(message: string): void {
-        this.channel.warn(LOG_PREFIX + message);
+        this.channel.warn(message);
     }
 
-    logError(error: Error): void {
-        this.channel.error(LOG_PREFIX, error);
+    /**
+     * A `string` is passed through untouched so a webview-forwarded stack prints
+     * verbatim; an `Error` keeps VS Code's own formatting (message + stack).
+     */
+    logError(error: string | Error): void {
+        this.channel.error(error);
     }
 
     /**

--- a/libs/modeler-core/src/codeLink/service/CodeLinkMapService.spec.ts
+++ b/libs/modeler-core/src/codeLink/service/CodeLinkMapService.spec.ts
@@ -76,7 +76,12 @@ function createService(
         getPersistCodeLinkMap: vi.fn(() => opts.persist ?? false),
         getConfigFolder: vi.fn(() => ".camunda"),
     };
-    const notifier = { logInfo: vi.fn(), logWarning: vi.fn() };
+    const notifier = {
+        logDebug: vi.fn(),
+        logInfo: vi.fn(),
+        logWarning: vi.fn(),
+        logError: vi.fn(),
+    };
 
     const service = new CodeLinkMapService(
         editorStore as never,
@@ -530,7 +535,8 @@ describe("CodeLinkMapService — lifecycle", () => {
         await expect(
             service.syncActivities("editor1", [entry("A", "jobType", "a")]),
         ).resolves.toBeUndefined();
-        expect(notifier.logInfo).toHaveBeenCalledWith(
+        // A skipped push leaves the context pad briefly stale → warn, not info.
+        expect(notifier.logWarning).toHaveBeenCalledWith(
             expect.stringContaining("status push skipped"),
         );
     });

--- a/libs/modeler-core/src/codeLink/service/CodeLinkMapService.ts
+++ b/libs/modeler-core/src/codeLink/service/CodeLinkMapService.ts
@@ -341,8 +341,12 @@ export class CodeLinkMapService {
             let content: string;
             try {
                 content = await this.vsWorkspace.readFile(path);
-            } catch {
+            } catch (error) {
                 // Linked file gone or unreadable → drop it; re-resolution decides.
+                // Debug: a source file disappearing mid-session is routine churn.
+                this.notifier.logDebug(
+                    `[code-link] linked file unreadable, dropping ${path}: ${(error as Error).message}`,
+                );
                 continue;
             }
             if (fileMatchesEntry(entry.kind, entry.reference, path, content)) {
@@ -360,9 +364,12 @@ export class CodeLinkMapService {
         try {
             await this.editorStore.postMessage(editorId, new ImplementationStatusQuery(resolved));
         } catch (error) {
-            // Expected when the editor is hidden (no retainContextWhenHidden):
-            // the webview re-syncs on reload, so a dropped push is harmless.
-            this.notifier.logInfo(`[code-link] status push skipped: ${(error as Error).message}`);
+            // Usually the editor being hidden (no retainContextWhenHidden): the
+            // webview re-syncs on reload, so the drop is recoverable — but it does
+            // mean the context pad is briefly stale, so warn rather than whisper.
+            this.notifier.logWarning(
+                `[code-link] status push skipped: ${(error as Error).message}`,
+            );
         }
     }
 
@@ -449,8 +456,14 @@ export class CodeLinkMapService {
         let raw: string;
         try {
             raw = await this.vsWorkspace.readFile(artifactPath);
-        } catch {
-            return; // No prior artifact — cold open, the diff resolves everything.
+        } catch (error) {
+            // No prior artifact — cold open, the diff resolves everything. Debug
+            // level: the first open of any diagram hits this, so it must not add
+            // channel noise, but the path helps when persistence is misconfigured.
+            this.notifier.logDebug(
+                `[code-link] no warm cache at ${artifactPath}: ${(error as Error).message}`,
+            );
+            return;
         }
         const json = parseMapJson(raw);
         if (!json) {

--- a/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.spec.ts
+++ b/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.spec.ts
@@ -4,6 +4,10 @@ import {
     AdditionalFilesQuery,
     DeploymentResultQuery,
     FormDefaultsQuery,
+    LogDebugCommand,
+    LogErrorCommand,
+    LogInfoCommand,
+    LogWarningCommand,
     ProcessDefinitionKeyQuery,
     SelectedPayloadFileQuery,
     StartInstanceResultQuery,
@@ -50,6 +54,7 @@ function createDispatcher() {
         showError: vi.fn(),
         logDebug: vi.fn(),
         logInfo: vi.fn(),
+        logWarning: vi.fn(),
         logError: vi.fn(),
     };
 
@@ -224,6 +229,64 @@ describe("DeploymentMessageDispatcher deploy result handling", () => {
     });
 });
 
+describe("DeploymentMessageDispatcher deploy breadcrumbs", () => {
+    /** Every string passed to any notifier log method across the whole call. */
+    function allLoggedText(c: ReturnType<typeof createDispatcher>): string {
+        return [
+            ...c.notifier.logDebug.mock.calls,
+            ...c.notifier.logInfo.mock.calls,
+            ...c.notifier.logWarning.mock.calls,
+            ...c.notifier.logError.mock.calls,
+        ]
+            .map((args) => String(args[0]))
+            .join("\n");
+    }
+
+    it("logs a start breadcrumb with the trusted basename, engine, and endpoint host", async () => {
+        const c = createDispatcher();
+        c.deploymentService.deploy.mockResolvedValue(new DeploymentResult(true, "ok"));
+
+        await deploy(c, { authType: "none" });
+
+        expect(c.notifier.logInfo).toHaveBeenCalledWith(
+            "Deployment started: order-process.bpmn -> c7 @ localhost:8080",
+        );
+    });
+
+    it("logs a warning breadcrumb when the deployment fails", async () => {
+        const c = createDispatcher();
+        c.deploymentService.deploy.mockResolvedValue(new DeploymentResult(false, "rejected"));
+
+        await deploy(c, { authType: "none" });
+
+        expect(c.notifier.logWarning).toHaveBeenCalledWith("Deployment failed: rejected");
+    });
+
+    it("never writes the basic-auth password to any log line", async () => {
+        const c = createDispatcher();
+        c.deploymentService.deploy.mockResolvedValue(new DeploymentResult(true, "ok"));
+
+        await deploy(c, { authType: "basic", username: "admin", password: "s3cret" });
+
+        expect(allLoggedText(c)).not.toContain("s3cret");
+    });
+
+    it("never writes an oauth2 client secret to any log line", async () => {
+        const c = createDispatcher();
+        c.startInstanceService.startInstance.mockResolvedValue(new StartInstanceResult(true, "ok"));
+
+        await startInstance(c, {
+            authType: "oauth2",
+            clientId: "cid",
+            clientSecret: "s3cret",
+            tokenEndpoint: "https://idp/token",
+            audience: "zeebe-api",
+        });
+
+        expect(allLoggedText(c)).not.toContain("s3cret");
+    });
+});
+
 describe("DeploymentMessageDispatcher start-instance auth construction", () => {
     it("builds a BasicAuth from a basic payload", async () => {
         const c = createDispatcher();
@@ -341,9 +404,13 @@ describe("DeploymentMessageDispatcher.sendFormDefaults", () => {
         c.dispatcher.sendFormDefaults();
 
         expect(postedQuery(c.post, ProcessDefinitionKeyQuery).processDefinitionKey).toBe("");
+        // A parseable diagram whose key can't be read is a degradation → warn.
+        expect(c.notifier.logWarning).toHaveBeenCalledWith(
+            expect.stringContaining("Process-definition key extraction failed"),
+        );
     });
 
-    it("falls back to empty defaults when there is no active editor", () => {
+    it("falls back to empty defaults (and only debug-logs) when there is no active editor", () => {
         const c = createDispatcher();
         c.editorStore.getActiveEditorId.mockImplementation(() => {
             throw new Error("no active editor");
@@ -351,6 +418,11 @@ describe("DeploymentMessageDispatcher.sendFormDefaults", () => {
 
         c.dispatcher.sendFormDefaults();
 
+        // No active editor is the expected steady state — debug, not warn.
+        expect(c.notifier.logDebug).toHaveBeenCalledWith(
+            expect.stringContaining("No active editor for deployment form defaults"),
+        );
+        expect(c.notifier.logWarning).not.toHaveBeenCalled();
         const defaults = postedQuery(c.post, FormDefaultsQuery).defaults;
         expect(defaults.deploymentName).toBe("");
         expect(defaults.engine).toBe("c7");
@@ -483,5 +555,44 @@ describe("DeploymentMessageDispatcher.handle routing", () => {
         } as StartInstanceCommand);
 
         expect(c.startInstanceService.startInstance).toHaveBeenCalledOnce();
+    });
+});
+
+describe("DeploymentMessageDispatcher.handle webview-log routing", () => {
+    it("routes each Log* level onto the notifier with a [webview:deployment] tag", async () => {
+        const c = createDispatcher();
+
+        await c.dispatcher.handle(new LogDebugCommand("d"));
+        await c.dispatcher.handle(new LogInfoCommand("i"));
+        await c.dispatcher.handle(new LogWarningCommand("w"));
+        await c.dispatcher.handle(new LogErrorCommand("boom", "at foo"));
+
+        expect(c.notifier.logInfo).toHaveBeenCalledWith("[webview:deployment] i");
+        expect(c.notifier.logWarning).toHaveBeenCalledWith("[webview:deployment] w");
+        expect(c.notifier.logError).toHaveBeenCalledWith("[webview:deployment] boom\nat foo");
+    });
+
+    it("does not enter the command switch for a Log* command", async () => {
+        const c = createDispatcher();
+
+        await c.dispatcher.handle(new LogInfoCommand("i"));
+
+        // The switch's per-message debug breadcrumb is skipped for log traffic
+        // so forwarded lines aren't double-logged.
+        expect(c.notifier.logDebug).not.toHaveBeenCalledWith(
+            "Deployment message received -> LogInfoCommand",
+        );
+        expect(c.deploymentService.getFormDefaults).not.toHaveBeenCalled();
+    });
+
+    it("still no-ops on an unknown, non-log command type", async () => {
+        const c = createDispatcher();
+
+        await c.dispatcher.handle({ type: "TotallyUnknownCommand" } as Command);
+
+        expect(c.post).not.toHaveBeenCalled();
+        expect(c.notifier.logDebug).toHaveBeenCalledWith(
+            "Deployment message received -> TotallyUnknownCommand",
+        );
     });
 });

--- a/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.spec.ts
+++ b/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.spec.ts
@@ -48,6 +48,7 @@ function createDispatcher() {
     const notifier = {
         showInfo: vi.fn(),
         showError: vi.fn(),
+        logDebug: vi.fn(),
         logInfo: vi.fn(),
         logError: vi.fn(),
     };

--- a/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.ts
+++ b/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.ts
@@ -16,6 +16,7 @@ import { BasicAuth, DeploymentConfigBuilder, NoAuth, OAuth2Auth } from "../domai
 import { InvalidDeploymentConfigError } from "../../shared/domain/errors";
 import { DocumentPort, NotifierPort } from "../../shared/domain/hostPorts";
 import { EditorSessionStore } from "../../shared/infrastructure/EditorSessionStore";
+import { routeWebviewLogCommand } from "../../shared/infrastructure/webviewLogHandlers";
 import { DeploymentService } from "./DeploymentService";
 import { StartInstanceService } from "./StartInstanceService";
 
@@ -56,6 +57,12 @@ export class DeploymentMessageDispatcher {
      * ignored — the protocol is closed and a stray discriminant is not an error.
      */
     async handle(message: Command): Promise<void> {
+        // The deployment webview forwards its own diagnostics as Log*Commands.
+        // This dispatcher owns a raw switch (it bypasses WebviewMessageRouter),
+        // so route them here or the switch below drops them as unknown types.
+        if (routeWebviewLogCommand(this.notifier, message, "deployment")) {
+            return;
+        }
         this.notifier.logDebug(`Deployment message received -> ${message.type}`);
         switch (message.type) {
             case "RequestFormDefaultsCommand":
@@ -97,12 +104,21 @@ export class DeploymentMessageDispatcher {
             try {
                 const key = this.startInstanceService.getProcessDefinitionKey(activeEditorId);
                 this.post(new ProcessDefinitionKeyQuery(key));
-            } catch {
-                // Process key extraction failed — send empty key.
+            } catch (error) {
+                // A parseable diagram with an unreadable/absent process key is a
+                // real degradation of the Start Instance tab — warn, then fall
+                // back to an empty key so the form still renders.
+                this.notifier.logWarning(
+                    `Process-definition key extraction failed: ${(error as Error).message}`,
+                );
                 this.post(new ProcessDefinitionKeyQuery(""));
             }
-        } catch {
-            // No active editor — send empty defaults.
+        } catch (error) {
+            // No active editor is the expected steady state when no diagram is
+            // focused — a debug breadcrumb, not a warning.
+            this.notifier.logDebug(
+                `No active editor for deployment form defaults: ${(error as Error).message}`,
+            );
             this.post(
                 new FormDefaultsQuery({
                     deploymentName: "",
@@ -190,6 +206,11 @@ export class DeploymentMessageDispatcher {
         try {
             const auth = this.buildAuth(configPayload.auth);
 
+            // Breadcrumb. Host[:port] only — never the full URL or auth payload.
+            this.notifier.logInfo(
+                `Instance start requested: ${configPayload.processDefinitionKey} @ ${this.endpointHost(configPayload.endpoint)}`,
+            );
+
             const result = await this.startInstanceService.startInstance(
                 configPayload.processDefinitionKey,
                 configPayload.endpoint,
@@ -199,8 +220,10 @@ export class DeploymentMessageDispatcher {
             );
 
             if (result.success) {
+                this.notifier.logInfo(`Instance start succeeded: ${result.message}`);
                 this.notifier.showInfo(result.message);
             } else {
+                this.notifier.logWarning(`Instance start failed: ${result.message}`);
                 this.notifier.showError(result.message);
             }
 
@@ -244,11 +267,19 @@ export class DeploymentMessageDispatcher {
                 .withAuth(auth)
                 .build();
 
+            // Breadcrumb. Only host[:port] is logged (never the full URL, which can
+            // carry credentials, and never the auth payload) — see endpointHost.
+            this.notifier.logInfo(
+                `Deployment started: ${this.fileBasename(mainFilePath)} -> ${configPayload.engine} @ ${this.endpointHost(configPayload.endpoint)}`,
+            );
+
             const result = await this.deploymentService.deploy(config);
 
             if (result.success) {
+                this.notifier.logInfo(`Deployment succeeded: ${result.message}`);
                 this.notifier.showInfo(result.message);
             } else {
+                this.notifier.logWarning(`Deployment failed: ${result.message}`);
                 this.notifier.showError(result.message);
             }
 
@@ -265,6 +296,24 @@ export class DeploymentMessageDispatcher {
             this.notifier.showError(message);
             this.post(new DeploymentResultQuery(false, message));
         }
+    }
+
+    /**
+     * Host[:port] of `endpoint` for a breadcrumb — never the path, query, or
+     * userinfo. `URL.host` deliberately excludes any `user:pass@` prefix, so a
+     * credentialled endpoint can't leak into the channel.
+     */
+    private endpointHost(endpoint: string): string {
+        try {
+            return new URL(endpoint).host || "unknown-host";
+        } catch {
+            return "unknown-host";
+        }
+    }
+
+    /** Basename for logging; separator-agnostic so Windows paths don't leak a full path. */
+    private fileBasename(filePath: string): string {
+        return filePath.split(/[\\/]/).pop() || filePath;
     }
 
     /** Maps the webview's auth payload to the domain auth value object. */

--- a/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.ts
+++ b/libs/modeler-core/src/deployment/service/DeploymentMessageDispatcher.ts
@@ -56,7 +56,7 @@ export class DeploymentMessageDispatcher {
      * ignored — the protocol is closed and a stray discriminant is not an error.
      */
     async handle(message: Command): Promise<void> {
-        this.notifier.logInfo(`Deployment message received -> ${message.type}`);
+        this.notifier.logDebug(`Deployment message received -> ${message.type}`);
         switch (message.type) {
             case "RequestFormDefaultsCommand":
                 this.sendFormDefaults();

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./shared/service/ArtifactService";
 export * from "./shared/service/BpmnLintConfigLocator";
 export * from "./shared/infrastructure/EditorSessionStore";
 export * from "./shared/infrastructure/WebviewMessageRouter";
+export * from "./shared/infrastructure/webviewLogHandlers";
 export * from "./shared/infrastructure/helpers";
 
 // ── modeler ─────────────────────────────────────────────────────────────────

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.spec.ts
@@ -28,7 +28,12 @@ function createService() {
         showElementTemplatesReady: vi.fn(),
         hideElementTemplatesStatus: vi.fn(),
     };
-    const notifier = { notifyError: vi.fn(), logError: vi.fn(), logInfo: vi.fn() };
+    const notifier = {
+        notifyError: vi.fn(),
+        logError: vi.fn(),
+        logInfo: vi.fn(),
+        logDebug: vi.fn(),
+    };
 
     const service = new BpmnElementTemplatesService(
         editorStore as never,

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnElementTemplatesService.ts
@@ -27,6 +27,11 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
             const documentDir = posix.dirname(this.vsDocument.getFilePath(editorId));
 
             const [artifacts] = await this.artifactSvc.getArtifactPaths(documentDir);
+            this.notifier.logDebug(
+                artifacts.length > 0
+                    ? `Element-template files resolved: ${artifacts.join(", ")}`
+                    : "No element-template files resolved.",
+            );
 
             const parsed = await Promise.all(
                 artifacts.map(async (a) => {
@@ -51,7 +56,13 @@ export class BpmnElementTemplatesService implements ArtifactChangeTarget {
             if (await this.editorStore.postMessage(editorId, new ElementTemplatesQuery(sorted))) {
                 this.statusBar.showElementTemplatesReady(sorted.length);
                 if (artifacts.length > 0) {
-                    this.notifier.logInfo(`${artifacts.length} element templates are set.`);
+                    // Report templates loaded vs. files scanned separately — a
+                    // file can hold several templates, so conflating the two (the
+                    // old message reported the file count as the template count)
+                    // misled anyone cross-checking the status-bar count.
+                    this.notifier.logInfo(
+                        `${sorted.length} element template(s) loaded from ${artifacts.length} file(s).`,
+                    );
                 }
                 return true;
             } else {

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -23,7 +23,7 @@ function createService() {
         showBpmnlintNoConfig: vi.fn(),
         hideBpmnlintStatus: vi.fn(),
     };
-    const notifier = { logError: vi.fn() };
+    const notifier = { logError: vi.fn(), logInfo: vi.fn(), logDebug: vi.fn() };
 
     const service = new BpmnLintConfigService(
         editorStore as never,
@@ -42,7 +42,7 @@ beforeEach(() => {
 
 describe("BpmnLintConfigService.setBpmnlintConfig", () => {
     it("posts the parsed config and shows the active status when a config is found", async () => {
-        const { service, editorStore, locator, statusBar } = createService();
+        const { service, editorStore, locator, statusBar, notifier } = createService();
         locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
         locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
 
@@ -53,13 +53,17 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(locator.findNearestConfig).toHaveBeenCalledWith("file:///work");
         expect(statusBar.showBpmnlintActive).toHaveBeenCalledWith("/work/.bpmnlintrc");
         expect(statusBar.showBpmnlintNoConfig).not.toHaveBeenCalled();
+        // Reproduction breadcrumb names the applied config path.
+        expect(notifier.logInfo).toHaveBeenCalledWith(
+            "bpmnlint config applied from /work/.bpmnlintrc",
+        );
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintConfigQuery;
         expect(msg.type).toBe("BpmnlintConfigQuery");
         expect(msg.config).toEqual({ extends: "bpmnlint:recommended" });
     });
 
-    it("posts null and shows the no-config status when nothing is found", async () => {
-        const { service, editorStore, locator, statusBar } = createService();
+    it("posts null and shows the no-config status (debug-only) when nothing is found", async () => {
+        const { service, editorStore, locator, statusBar, notifier } = createService();
         locator.findNearestConfig.mockResolvedValue(undefined);
 
         const result = await service.setBpmnlintConfig(EDITOR);
@@ -67,6 +71,9 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(result).toBe(true);
         expect(locator.readConfig).not.toHaveBeenCalled();
         expect(statusBar.showBpmnlintNoConfig).toHaveBeenCalledOnce();
+        // The no-config case fires on every editor open → debug, not info.
+        expect(notifier.logDebug).toHaveBeenCalledWith("No .bpmnlintrc found; linting inactive");
+        expect(notifier.logInfo).not.toHaveBeenCalled();
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintConfigQuery;
         expect(msg.config).toBeNull();
     });

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.spec.ts
@@ -23,7 +23,12 @@ function createService() {
         showBpmnlintNoConfig: vi.fn(),
         hideBpmnlintStatus: vi.fn(),
     };
-    const notifier = { logError: vi.fn(), logInfo: vi.fn(), logDebug: vi.fn() };
+    const notifier = {
+        logError: vi.fn(),
+        logInfo: vi.fn(),
+        logDebug: vi.fn(),
+        logWarning: vi.fn(),
+    };
 
     const service = new BpmnLintConfigService(
         editorStore as never,
@@ -104,5 +109,25 @@ describe("BpmnLintConfigService.setBpmnlintConfig", () => {
         expect(statusBar.showBpmnlintNoConfig).toHaveBeenCalledOnce();
         const msg = editorStore.postMessage.mock.calls[0][1] as BpmnlintConfigQuery;
         expect(msg.config).toBeNull();
+    });
+
+    it("swallows a hidden-panel post rejection as a warning without misreporting it as a read failure", async () => {
+        const { service, editorStore, locator, notifier } = createService();
+        locator.findNearestConfig.mockResolvedValue("/work/.bpmnlintrc");
+        locator.readConfig.mockResolvedValue(JSON.stringify({ extends: "bpmnlint:recommended" }));
+        // The watcher fires while the diagram panel is hidden, so the post rejects.
+        editorStore.postMessage.mockRejectedValue(new Error("The active editor is hidden."));
+
+        const result = await service.setBpmnlintConfig(EDITOR);
+
+        // Recoverable transport drop: resolves false, never throws.
+        expect(result).toBe(false);
+        expect(notifier.logWarning).toHaveBeenCalledWith(
+            "[bpmnlint] config push skipped: The active editor is hidden.",
+        );
+        // The read succeeded — the transport failure must not be logged as one.
+        expect(notifier.logError).not.toHaveBeenCalled();
+        // The sole post means no second rejecting fallback push.
+        expect(editorStore.postMessage).toHaveBeenCalledOnce();
     });
 });

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -45,7 +45,16 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
                     this.statusBar.showBpmnlintNoConfig();
                 }
             }
-            return this.editorStore.postMessage(editorId, new BpmnlintConfigQuery(config));
+            // Reproduction breadcrumb. `applied` at info; the no-config case fires
+            // on every editor open, so it stays debug to keep the trail legible.
+            if (path) {
+                this.notifier.logInfo(`bpmnlint config applied from ${path}`);
+            } else {
+                this.notifier.logDebug("No .bpmnlintrc found; linting inactive");
+            }
+            // `return await` (not a bare `return`) so a rejected post is caught
+            // by this block's own handler rather than escaping to the caller.
+            return await this.editorStore.postMessage(editorId, new BpmnlintConfigQuery(config));
         } catch (error) {
             // A malformed .bpmnlintrc must not crash the editor — warn, fall back
             // to the no-config state, and tell the webview to deactivate linting.

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnLintConfigService.ts
@@ -32,6 +32,26 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
     ) {}
 
     async setBpmnlintConfig(editorId: string, reflectInStatusBar = true): Promise<boolean> {
+        const config = await this.resolveConfig(editorId, reflectInStatusBar);
+        return this.pushConfig(editorId, config);
+    }
+
+    /**
+     * Resolves the effective config for an editor: walks to the nearest
+     * `.bpmnlintrc`, parses it, and reflects presence in the status bar.
+     *
+     * A missing/malformed file must not crash the editor, so a read/parse
+     * failure degrades to the no-config state here. This handler is scoped to
+     * the filesystem work *only* — transport is pushed apart in
+     * {@link pushConfig} — because {@link EditorSessionStore.postMessage}
+     * rejects with "The active editor is hidden." when the panel is hidden,
+     * the exact state the `.bpmnlintrc` watcher fires in, and that recoverable
+     * drop must not be misreported as a read failure.
+     */
+    private async resolveConfig(
+        editorId: string,
+        reflectInStatusBar: boolean,
+    ): Promise<Record<string, unknown> | null> {
         try {
             const dir = posix.dirname(this.vsDocument.getFilePath(editorId));
             const path = await this.locator.findNearestConfig(dir);
@@ -52,9 +72,7 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
             } else {
                 this.notifier.logDebug("No .bpmnlintrc found; linting inactive");
             }
-            // `return await` (not a bare `return`) so a rejected post is caught
-            // by this block's own handler rather than escaping to the caller.
-            return await this.editorStore.postMessage(editorId, new BpmnlintConfigQuery(config));
+            return config;
         } catch (error) {
             // A malformed .bpmnlintrc must not crash the editor — warn, fall back
             // to the no-config state, and tell the webview to deactivate linting.
@@ -64,7 +82,28 @@ export class BpmnLintConfigService implements BpmnlintChangeTarget {
             if (reflectInStatusBar) {
                 this.statusBar.showBpmnlintNoConfig();
             }
-            return this.editorStore.postMessage(editorId, new BpmnlintConfigQuery(null));
+            return null;
+        }
+    }
+
+    /**
+     * Posts the resolved config to the webview, the sole config transport.
+     *
+     * A hidden panel (no `retainContextWhenHidden`) makes `postMessage` reject;
+     * the webview re-syncs on reload, so the drop is recoverable. Swallowing it
+     * here — at warning level, mirroring `CodeLinkMapService.pushStatus` — keeps
+     * fire-and-forget callers from leaking an unhandled rejection, and being the
+     * only post means a drop can't trigger a second rejecting fallback push.
+     */
+    private async pushConfig(
+        editorId: string,
+        config: Record<string, unknown> | null,
+    ): Promise<boolean> {
+        try {
+            return await this.editorStore.postMessage(editorId, new BpmnlintConfigQuery(config));
+        } catch (error) {
+            this.notifier.logWarning(`[bpmnlint] config push skipped: ${(error as Error).message}`);
+            return false;
         }
     }
 }

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnSettingsBroadcaster.spec.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnSettingsBroadcaster.spec.ts
@@ -155,4 +155,17 @@ describe("BpmnSettingsBroadcaster.subscribe", () => {
         expect(setSettings).not.toHaveBeenCalled();
         expect(setLanguage).not.toHaveBeenCalled();
     });
+
+    it("guards a rejecting setSettings so the change listener never leaks a rejection", async () => {
+        const { broadcaster, editorStore, notifier } = createBroadcaster();
+        vi.spyOn(broadcaster, "setSettings").mockRejectedValue(new Error("post failed"));
+
+        broadcaster.subscribe(EDITOR);
+        fireSettingChange(editorStore, ["miragon.bpmnModeler.colorTheme"]);
+        // The `.catch` guard runs on a later microtask; flush before asserting.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(notifier.logError).toHaveBeenCalledOnce();
+    });
 });

--- a/libs/modeler-core/src/modeler/bpmn/service/BpmnSettingsBroadcaster.ts
+++ b/libs/modeler-core/src/modeler/bpmn/service/BpmnSettingsBroadcaster.ts
@@ -77,7 +77,14 @@ export class BpmnSettingsBroadcaster {
                 event.affectsConfiguration("miragon.bpmnModeler.colorTheme") ||
                 event.affectsConfiguration("miragon.bpmnModeler.favouriteBpmnElements")
             ) {
-                this.setSettings(id);
+                // The change listener has no caller to await it, so guard the
+                // floating promise even though setSettings already logs its own
+                // failures — a future refactor mustn't turn this into a leak.
+                this.setSettings(id).catch((error) => {
+                    this.notifier.logError(
+                        error instanceof Error ? error : new Error(String(error)),
+                    );
+                });
             }
             if (event.affectsConfiguration("miragon.bpmnModeler.language")) {
                 this.setLanguage(id);

--- a/libs/modeler-core/src/modeler/dmn/service/DmnSettingsBroadcaster.spec.ts
+++ b/libs/modeler-core/src/modeler/dmn/service/DmnSettingsBroadcaster.spec.ts
@@ -103,4 +103,16 @@ describe("DmnSettingsBroadcaster.subscribe", () => {
 
         expect(setSettings).not.toHaveBeenCalled();
     });
+
+    it("guards a rejecting setSettings so the change listener never leaks a rejection", async () => {
+        const { broadcaster, editorStore, notifier } = createBroadcaster();
+        vi.spyOn(broadcaster, "setSettings").mockRejectedValue(new Error("post failed"));
+
+        broadcaster.subscribe(EDITOR);
+        fireSettingChange(editorStore, ["miragon.bpmnModeler.colorTheme"]);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(notifier.logError).toHaveBeenCalledOnce();
+    });
 });

--- a/libs/modeler-core/src/modeler/dmn/service/DmnSettingsBroadcaster.ts
+++ b/libs/modeler-core/src/modeler/dmn/service/DmnSettingsBroadcaster.ts
@@ -50,7 +50,13 @@ export class DmnSettingsBroadcaster {
     subscribe(editorId: string): void {
         this.editorStore.subscribeToSettingChangeEvent(editorId, (event, id) => {
             if (event.affectsConfiguration("miragon.bpmnModeler.colorTheme")) {
-                this.setSettings(id);
+                // Guard the floating promise: the change listener has no caller
+                // to await it (setSettings already logs its own failures).
+                this.setSettings(id).catch((error) => {
+                    this.notifier.logError(
+                        error instanceof Error ? error : new Error(String(error)),
+                    );
+                });
             }
         });
     }

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -19,19 +19,36 @@ import { AuthTypePayload, Engine } from "@miragon/bpmn-modeler-shared";
 import { MigrationScope } from "../../migration/domain/MigrationPlan";
 
 /**
+ * Levelled diagnostic logging to the host's log surface (VS Code's
+ * `bpmn.modeler` output channel, IntelliJ's `idea.log`). Split out of
+ * {@link NotifierPort} so pure-logging callers — webview-log routing, artifact
+ * discovery diagnostics — depend only on logging, not the whole notifier.
+ *
+ * `logDebug` is the level for high-frequency transport/lifecycle noise the user
+ * only wants when diagnosing (raised via *Developer: Set Log Level…*). `logError`
+ * accepts a bare `string` so a webview-supplied stack prints verbatim; wrapping
+ * it in a host-side `Error` would replace the original throw site's stack.
+ */
+export interface LoggerPort {
+    logDebug(message: string): void;
+    logInfo(message: string): void;
+    logWarning(message: string): void;
+    logError(error: string | Error): void;
+}
+
+/**
  * User-facing messages and diagnostic logging. Keeps services free of
  * `window.show*Message` / output-channel wiring and centralises the
- * log-then-toast convention behind {@link notifyError}.
+ * log-then-toast convention behind {@link notifyError}. Extends
+ * {@link LoggerPort}, so every notifier is also a logger — injection sites that
+ * only need to log can narrow to `LoggerPort` without extra wiring.
  */
-export interface NotifierPort {
+export interface NotifierPort extends LoggerPort {
     showInfo(message: string): void;
     showError(message: string): void;
     /** Logs `error`, then surfaces a toast pairing `context` with the error message. */
     notifyError(context: string, error: Error): void;
     openLoggingConsole(): void;
-    logInfo(message: string): void;
-    logWarning(message: string): void;
-    logError(error: Error): void;
     /** Runs `task` under a status-bar progress indicator titled `title`. */
     withProgress<T>(title: string, task: () => Promise<T>): Promise<T>;
     /** Opens the file at `absolutePath` in its registered editor. */

--- a/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.spec.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    LogDebugCommand,
+    LogErrorCommand,
+    LogInfoCommand,
+    LogWarningCommand,
+} from "@miragon/bpmn-modeler-shared";
+
+import { LoggerPort } from "../domain/hostPorts";
+import { WebviewMessageRouter } from "./WebviewMessageRouter";
+import { registerWebviewLogHandlers } from "./webviewLogHandlers";
+
+const EDITOR = "file:///w/a.bpmn";
+
+/** Wires a router to a spy logger so tests can dispatch a command and read the call. */
+function setup() {
+    const logger = {
+        logDebug: vi.fn(),
+        logInfo: vi.fn(),
+        logWarning: vi.fn(),
+        logError: vi.fn(),
+    };
+    const router = new WebviewMessageRouter();
+    registerWebviewLogHandlers(router, logger as unknown as LoggerPort);
+    return { logger, router };
+}
+
+describe("registerWebviewLogHandlers", () => {
+    it("routes each level to its logger method with a [webview] prefix", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogDebugCommand("d"), EDITOR);
+        await router.dispatch(new LogInfoCommand("i"), EDITOR);
+        await router.dispatch(new LogWarningCommand("w"), EDITOR);
+        await router.dispatch(new LogErrorCommand("e"), EDITOR);
+
+        expect(logger.logDebug).toHaveBeenCalledWith("[webview] d");
+        expect(logger.logInfo).toHaveBeenCalledWith("[webview] i");
+        expect(logger.logWarning).toHaveBeenCalledWith("[webview] w");
+        expect(logger.logError).toHaveBeenCalledWith("[webview] e");
+    });
+
+    it("appends the stack to an error command when present", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogErrorCommand("boom", "at foo (x.js:1)"), EDITOR);
+
+        expect(logger.logError).toHaveBeenCalledWith("[webview] boom\nat foo (x.js:1)");
+    });
+
+    it("omits the stack when the error command carries none", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogErrorCommand("boom"), EDITOR);
+
+        expect(logger.logError).toHaveBeenCalledWith("[webview] boom");
+    });
+
+    it("does not cross-fire levels (a debug command logs only at debug)", async () => {
+        const { logger, router } = setup();
+
+        await router.dispatch(new LogDebugCommand("d"), EDITOR);
+
+        expect(logger.logInfo).not.toHaveBeenCalled();
+        expect(logger.logWarning).not.toHaveBeenCalled();
+        expect(logger.logError).not.toHaveBeenCalled();
+    });
+});

--- a/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.spec.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.spec.ts
@@ -9,20 +9,28 @@ import {
 
 import { LoggerPort } from "../domain/hostPorts";
 import { WebviewMessageRouter } from "./WebviewMessageRouter";
-import { registerWebviewLogHandlers } from "./webviewLogHandlers";
+import { registerWebviewLogHandlers, routeWebviewLogCommand } from "./webviewLogHandlers";
 
 const EDITOR = "file:///w/a.bpmn";
 
-/** Wires a router to a spy logger so tests can dispatch a command and read the call. */
-function setup() {
-    const logger = {
+/** A fresh spy logger with all four levels stubbed. */
+function spyLogger() {
+    return {
         logDebug: vi.fn(),
         logInfo: vi.fn(),
         logWarning: vi.fn(),
         logError: vi.fn(),
     };
+}
+
+/**
+ * Wires a router to a spy logger so tests can dispatch a command and read the
+ * call. `resolveSource` is passed through so tag-context behaviour is testable.
+ */
+function setup(resolveSource?: (editorId: string) => string | undefined) {
+    const logger = spyLogger();
     const router = new WebviewMessageRouter();
-    registerWebviewLogHandlers(router, logger as unknown as LoggerPort);
+    registerWebviewLogHandlers(router, logger as unknown as LoggerPort, resolveSource);
     return { logger, router };
 }
 
@@ -65,5 +73,76 @@ describe("registerWebviewLogHandlers", () => {
         expect(logger.logInfo).not.toHaveBeenCalled();
         expect(logger.logWarning).not.toHaveBeenCalled();
         expect(logger.logError).not.toHaveBeenCalled();
+    });
+
+    it("tags lines with the resolved source when a resolver is supplied", async () => {
+        const { logger, router } = setup(() => "a.bpmn");
+
+        await router.dispatch(new LogWarningCommand("w"), EDITOR);
+        await router.dispatch(new LogErrorCommand("boom", "at foo"), EDITOR);
+
+        expect(logger.logWarning).toHaveBeenCalledWith("[webview:a.bpmn] w");
+        expect(logger.logError).toHaveBeenCalledWith("[webview:a.bpmn] boom\nat foo");
+    });
+
+    it("falls back to the bare [webview] tag when the resolver returns undefined", async () => {
+        const { logger, router } = setup(() => undefined);
+
+        await router.dispatch(new LogInfoCommand("i"), EDITOR);
+
+        expect(logger.logInfo).toHaveBeenCalledWith("[webview] i");
+    });
+
+    it("passes the originating editorId to the resolver", async () => {
+        const resolveSource = vi.fn(() => "a.bpmn");
+        const { router } = setup(resolveSource);
+
+        await router.dispatch(new LogInfoCommand("i"), EDITOR);
+
+        expect(resolveSource).toHaveBeenCalledWith(EDITOR);
+    });
+});
+
+describe("routeWebviewLogCommand", () => {
+    it("returns true and logs for each Log* level", () => {
+        const logger = spyLogger();
+
+        expect(
+            routeWebviewLogCommand(logger as unknown as LoggerPort, new LogDebugCommand("d")),
+        ).toBe(true);
+        expect(
+            routeWebviewLogCommand(logger as unknown as LoggerPort, new LogInfoCommand("i")),
+        ).toBe(true);
+
+        expect(logger.logDebug).toHaveBeenCalledWith("[webview] d");
+        expect(logger.logInfo).toHaveBeenCalledWith("[webview] i");
+    });
+
+    it("returns false and logs nothing for a non-log command", () => {
+        const logger = spyLogger();
+
+        const handled = routeWebviewLogCommand(
+            logger as unknown as LoggerPort,
+            { type: "SyncDocumentCommand" } as never,
+            "deployment",
+        );
+
+        expect(handled).toBe(false);
+        expect(logger.logDebug).not.toHaveBeenCalled();
+        expect(logger.logInfo).not.toHaveBeenCalled();
+        expect(logger.logWarning).not.toHaveBeenCalled();
+        expect(logger.logError).not.toHaveBeenCalled();
+    });
+
+    it("tags with the given source and appends an error stack", () => {
+        const logger = spyLogger();
+
+        routeWebviewLogCommand(
+            logger as unknown as LoggerPort,
+            new LogErrorCommand("boom", "at foo (x.js:1)"),
+            "deployment",
+        );
+
+        expect(logger.logError).toHaveBeenCalledWith("[webview:deployment] boom\nat foo (x.js:1)");
     });
 });

--- a/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.ts
@@ -3,39 +3,72 @@ import { Command, LogMessageCommand } from "@miragon/bpmn-modeler-shared";
 import { LoggerPort } from "../domain/hostPorts";
 import { WebviewMessageRouter } from "./WebviewMessageRouter";
 
+/** Command types this module recognises, mapped to the logger method each drives. */
+const LOG_LEVELS = {
+    LogDebugCommand: "logDebug",
+    LogInfoCommand: "logInfo",
+    LogWarningCommand: "logWarning",
+    LogErrorCommand: "logError",
+} as const;
+
 /**
- * Routes the four webview `Log*Command`s onto the host's {@link LoggerPort}.
+ * Logs `command` onto `logger` iff it is one of the four webview `Log*Command`s,
+ * returning `true` when it handled it and `false` for any other type.
  *
  * The sandboxed webview cannot write to the output channel / `idea.log`, so it
- * forwards log entries as commands. Without these handlers the router treats an
- * unknown type as a no-op, so webview diagnostics are silently dropped — the
- * exact "webview errors never reach the output channel" gap issue #1210
- * describes. Shared by every host (VS Code + the IntelliJ bridge) so the two
- * transports can't drift.
+ * forwards log entries as commands. Callers that own a raw `switch` (the
+ * deployment dispatcher, the diff controller) use this to opt into the same
+ * routing the {@link WebviewMessageRouter} handlers get, without duplicating the
+ * formatter or the four-way level fan-out — so the two transports can't drift.
  *
- * Each line is tagged `[webview]` to mark its origin in a channel the host also
- * writes to directly; the error handler appends the command's textual `stack`
- * (an `Error` doesn't survive `postMessage`) so the original throw site prints.
+ * Each line is tagged `[webview:<source>]` (or `[webview]` when no source is
+ * known) to mark its origin in a channel the host also writes to directly; the
+ * `source` lets a reader correlate a line to a specific file/panel when several
+ * are open. The error handler appends the command's textual `stack` (an `Error`
+ * doesn't survive `postMessage`) so the original throw site prints.
  */
-export function registerWebviewLogHandlers(router: WebviewMessageRouter, logger: LoggerPort): void {
-    router
-        .on("LogDebugCommand", (message: Command) => {
-            logger.logDebug(prefix(message as LogMessageCommand));
-        })
-        .on("LogInfoCommand", (message: Command) => {
-            logger.logInfo(prefix(message as LogMessageCommand));
-        })
-        .on("LogWarningCommand", (message: Command) => {
-            logger.logWarning(prefix(message as LogMessageCommand));
-        })
-        .on("LogErrorCommand", (message: Command) => {
-            const command = message as LogMessageCommand;
-            const body = command.stack ? `${command.message}\n${command.stack}` : command.message;
-            logger.logError(`[webview] ${body}`);
-        });
+export function routeWebviewLogCommand(
+    logger: LoggerPort,
+    command: Command,
+    source?: string,
+): boolean {
+    const method = LOG_LEVELS[command.type as keyof typeof LOG_LEVELS];
+    if (!method) {
+        return false;
+    }
+
+    const tag = source ? `[webview:${source}]` : "[webview]";
+    const log = command as LogMessageCommand;
+
+    if (method === "logError") {
+        const body = log.stack ? `${log.message}\n${log.stack}` : log.message;
+        logger.logError(`${tag} ${body}`);
+    } else {
+        logger[method](`${tag} ${log.message}`);
+    }
+    return true;
 }
 
-/** Prefixes a log command's message with the webview-origin marker. */
-function prefix(command: LogMessageCommand): string {
-    return `[webview] ${command.message}`;
+/**
+ * Registers the four webview `Log*Command`s on `router`, routing each onto the
+ * host's {@link LoggerPort} via {@link routeWebviewLogCommand}.
+ *
+ * `resolveSource` turns the handler's `editorId` into a human-readable origin
+ * (typically the diagram's basename) so log lines are correlatable when several
+ * editors are open; when omitted or when it returns `undefined`, lines fall back
+ * to the bare `[webview]` tag.
+ */
+export function registerWebviewLogHandlers(
+    router: WebviewMessageRouter,
+    logger: LoggerPort,
+    resolveSource?: (editorId: string) => string | undefined,
+): void {
+    const handle: (message: Command, editorId: string) => void = (message, editorId) => {
+        routeWebviewLogCommand(logger, message, resolveSource?.(editorId));
+    };
+    router
+        .on("LogDebugCommand", handle)
+        .on("LogInfoCommand", handle)
+        .on("LogWarningCommand", handle)
+        .on("LogErrorCommand", handle);
 }

--- a/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.ts
+++ b/libs/modeler-core/src/shared/infrastructure/webviewLogHandlers.ts
@@ -1,0 +1,41 @@
+import { Command, LogMessageCommand } from "@miragon/bpmn-modeler-shared";
+
+import { LoggerPort } from "../domain/hostPorts";
+import { WebviewMessageRouter } from "./WebviewMessageRouter";
+
+/**
+ * Routes the four webview `Log*Command`s onto the host's {@link LoggerPort}.
+ *
+ * The sandboxed webview cannot write to the output channel / `idea.log`, so it
+ * forwards log entries as commands. Without these handlers the router treats an
+ * unknown type as a no-op, so webview diagnostics are silently dropped — the
+ * exact "webview errors never reach the output channel" gap issue #1210
+ * describes. Shared by every host (VS Code + the IntelliJ bridge) so the two
+ * transports can't drift.
+ *
+ * Each line is tagged `[webview]` to mark its origin in a channel the host also
+ * writes to directly; the error handler appends the command's textual `stack`
+ * (an `Error` doesn't survive `postMessage`) so the original throw site prints.
+ */
+export function registerWebviewLogHandlers(router: WebviewMessageRouter, logger: LoggerPort): void {
+    router
+        .on("LogDebugCommand", (message: Command) => {
+            logger.logDebug(prefix(message as LogMessageCommand));
+        })
+        .on("LogInfoCommand", (message: Command) => {
+            logger.logInfo(prefix(message as LogMessageCommand));
+        })
+        .on("LogWarningCommand", (message: Command) => {
+            logger.logWarning(prefix(message as LogMessageCommand));
+        })
+        .on("LogErrorCommand", (message: Command) => {
+            const command = message as LogMessageCommand;
+            const body = command.stack ? `${command.message}\n${command.stack}` : command.message;
+            logger.logError(`[webview] ${body}`);
+        });
+}
+
+/** Prefixes a log command's message with the webview-origin marker. */
+function prefix(command: LogMessageCommand): string {
+    return `[webview] ${command.message}`;
+}

--- a/libs/modeler-core/src/shared/service/ArtifactService.spec.ts
+++ b/libs/modeler-core/src/shared/service/ArtifactService.spec.ts
@@ -263,4 +263,32 @@ describe("ArtifactService.createWatcher", () => {
         expect(target.setElementTemplates).toHaveBeenCalledTimes(3);
         expect(target.setElementTemplates).toHaveBeenNthCalledWith(1, "/work/proc/order.bpmn");
     });
+
+    it("logs a rejected template refresh instead of leaking an unhandled rejection", async () => {
+        const { vsWorkspace, vsSettings } = createService();
+        vsWorkspace.getWorkspaceFolderForDocument.mockReturnValue("/work");
+        vsWorkspace.createWatcher.mockReturnValue({ dispose: vi.fn() });
+        const logger = {
+            logDebug: vi.fn(),
+            logInfo: vi.fn(),
+            logWarning: vi.fn(),
+            logError: vi.fn(),
+        };
+        const service = new ArtifactService(
+            vsWorkspace as never,
+            vsSettings as never,
+            logger as never,
+        );
+        const boom = new Error("templates dir unreadable");
+        const target = { setElementTemplates: vi.fn().mockRejectedValue(boom) };
+
+        await service.createWatcher("/work/proc/order.bpmn", target as never);
+        const handlers = vsWorkspace.createWatcher.mock.calls[0][2];
+        handlers.onChange("/work/.camunda/element-templates/x.json");
+        // The `.catch` guard runs on a later microtask; flush before asserting.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(logger.logError).toHaveBeenCalledWith(boom);
+    });
 });

--- a/libs/modeler-core/src/shared/service/ArtifactService.ts
+++ b/libs/modeler-core/src/shared/service/ArtifactService.ts
@@ -176,10 +176,18 @@ export class ArtifactService {
         const workspaceRoot = await this.getWorkspaceRoot(documentDir);
 
         const pattern = `**/${configFolder}/element-templates/**/*.json`;
+        // A watcher callback's rejection has no caller to await it, so a failed
+        // re-push (unreadable template dir, gone webview) would float away as an
+        // unhandled rejection instead of reaching the channel.
+        const repushTemplates = () => {
+            target.setElementTemplates(editorId).catch((error) => {
+                this.logger?.logError(error instanceof Error ? error : new Error(String(error)));
+            });
+        };
         const handle = this.vsWorkspace.createWatcher(workspaceRoot, pattern, {
-            onCreate: () => void target.setElementTemplates(editorId),
-            onChange: () => void target.setElementTemplates(editorId),
-            onDelete: () => void target.setElementTemplates(editorId),
+            onCreate: repushTemplates,
+            onChange: repushTemplates,
+            onDelete: repushTemplates,
         });
 
         return { disposables: [handle], errors: [] };

--- a/libs/modeler-core/src/shared/service/ArtifactService.ts
+++ b/libs/modeler-core/src/shared/service/ArtifactService.ts
@@ -1,7 +1,7 @@
 import { posix } from "path";
 
 import { DirectoryNotFound, NoWorkspaceFolderFoundError } from "../domain/errors";
-import { SettingsPort, WorkspacePort } from "../domain/hostPorts";
+import { LoggerPort, SettingsPort, WorkspacePort } from "../domain/hostPorts";
 
 /**
  * Implemented by {@link import("../../modeler/bpmn/service/BpmnElementTemplatesService").BpmnElementTemplatesService}
@@ -29,6 +29,10 @@ export class ArtifactService {
     constructor(
         private readonly vsWorkspace: WorkspacePort,
         private readonly vsSettings: SettingsPort,
+        // Optional so the two hosts (VS Code + bridge) can opt in without every
+        // ArtifactService call-site or test having to supply a logger. Used only
+        // for debug-level "why did nothing load?" diagnostics.
+        private readonly logger?: LoggerPort,
     ) {}
 
     /**
@@ -117,6 +121,22 @@ export class ArtifactService {
             workspaceRoot,
             configFolder,
         );
+
+        // Debug-level trail for the "no templates showed up" support case: the
+        // resolved config folder + root are the two inputs that most often
+        // explain an empty scan, and an explicit "no directory found" line names
+        // the range walked so the user knows where the modeler looked.
+        this.logger?.logDebug(
+            `Element-template scan: configFolder="${configFolder}", root="${workspaceRoot}", ` +
+                `documentDir="${documentDir}" → ${templateDirs.length} directory(ies)` +
+                (templateDirs.length > 0 ? `: ${templateDirs.join(", ")}` : ""),
+        );
+        if (templateDirs.length === 0) {
+            this.logger?.logDebug(
+                `No "${configFolder}/element-templates" directory found between ` +
+                    `${documentDir} and ${workspaceRoot}.`,
+            );
+        }
 
         const allPaths: string[] = [];
         for (const dir of templateDirs) {

--- a/libs/shared/src/lib/messages.ts
+++ b/libs/shared/src/lib/messages.ts
@@ -51,8 +51,10 @@ export class LogMessageCommand implements Command {
 
     /**
      * The originating error's stack, carried as text: a real `Error` doesn't
-     * survive `postMessage` (structured clone drops the stack), so the webview
-     * passes it as a string the host appends verbatim. Absent for non-error logs.
+     * survive `postMessage` here because VS Code JSON-serializes webview
+     * messages, and JSON flattens an `Error` to `{}` (dropping `message` and
+     * `stack` alike), so the webview passes it as a string the host appends
+     * verbatim. Absent for non-error logs.
      */
     public readonly stack?: string;
 

--- a/libs/shared/src/lib/messages.ts
+++ b/libs/shared/src/lib/messages.ts
@@ -8,7 +8,9 @@
  * Also contains cross-cutting concrete commands that are not specific to any one
  * modeler feature:
  * - {@link SyncDocumentCommand} — webview notifies the host to persist the current XML to disk
- * - {@link LogInfoCommand} / {@link LogErrorCommand} — webview forwards log entries to the host's output channel
+ * - {@link LogDebugCommand} / {@link LogInfoCommand} / {@link LogWarningCommand} /
+ *   {@link LogErrorCommand} — webview forwards a levelled log entry to the host's
+ *   output channel
  *
  * @see modeler.ts for the modeler-specific Query and Command implementations that
  * extend these base classes.
@@ -47,13 +49,29 @@ export class LogMessageCommand implements Command {
 
     public readonly message: string;
 
-    constructor(log: string) {
+    /**
+     * The originating error's stack, carried as text: a real `Error` doesn't
+     * survive `postMessage` (structured clone drops the stack), so the webview
+     * passes it as a string the host appends verbatim. Absent for non-error logs.
+     */
+    public readonly stack?: string;
+
+    constructor(log: string, stack?: string) {
         this.message = log;
+        this.stack = stack;
     }
+}
+
+export class LogDebugCommand extends LogMessageCommand {
+    public override readonly type: string = "LogDebugCommand";
 }
 
 export class LogInfoCommand extends LogMessageCommand {
     public override readonly type: string = "LogInfoCommand";
+}
+
+export class LogWarningCommand extends LogMessageCommand {
+    public override readonly type: string = "LogWarningCommand";
 }
 
 export class LogErrorCommand extends LogMessageCommand {


### PR DESCRIPTION
**Issue**

Closes: https://github.com/Miragon/bpmn-modeler/issues/1210

**Description**

The bpmn.modeler output channel was cluttered with per-message transport noise while real diagnostics never arrived: the host silently dropped the webview's Log*Commands and bpmn-js element-template validation errors were never surfaced.

- add a LoggerPort domain port with a debug level; VsCodeNotifier drops the redundant channel prefix and no longer clears the prior session's trail
- demote per-message transport/lifecycle lines to debug level
- add LogWarning/LogDebug commands and a textual stack payload
- route the webview's Log*Commands into the output channel (shared handler used by both the VS Code host and the IntelliJ bridge)
- surface uncaught webview errors and rejected element templates to the host
- debug-level diagnostics for element-template discovery
- document the channel and how to raise the level to Debug

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
