### PR TITLE
docs(intellij): switch install guide to jetbrains marketplace

### DIFF
--- a/apps/intellij-plugin/MARKETPLACE.md
+++ b/apps/intellij-plugin/MARKETPLACE.md
@@ -1,13 +1,10 @@
 # Publishing to the JetBrains Marketplace
 
-The plugin currently ships through a **custom plugin repository** served from
-GitHub Pages (`https://miragon.github.io/bpmn-modeler/updatePlugins.xml`). This
-document captures the one-time steps to also publish on the official
+This document captures the one-time steps to publish the plugin on the official
 [JetBrains Marketplace](https://plugins.jetbrains.com/) — these are the parts
 the code in this repo cannot do for you.
 
-Why bother publishing on the official Marketplace if the custom repository
-already works? Two reasons:
+Why publishing on the official Marketplace matters:
 
 1. **Discoverability.** Settings ▸ Plugins ▸ Marketplace search hits anyone
    with a fresh IDE; the custom repository does not.
@@ -74,10 +71,10 @@ Suggested blurb — keep it in sync with the README's *Troubleshooting* section:
 
 ## Automated publishing
 
-The release pipeline now publishes to the official Marketplace on every
-release, **in addition to** uploading to GitHub Releases and refreshing
-`docs/public/updatePlugins.xml` — the custom repository keeps running in
-parallel, unchanged.
+The release pipeline now publishes to the official Marketplace — the primary
+channel — on every release. It **also** uploads to GitHub Releases and refreshes
+`docs/public/updatePlugins.xml`: the custom repository keeps running in parallel,
+unchanged, as a **legacy/fallback channel**.
 
 - `build.gradle.kts` carries the `signing { }` and `publishing { }` blocks in
   the `intellijPlatform { }` configuration. Signing uses our own certificate so

--- a/docs/intellij/getting-started.md
+++ b/docs/intellij/getting-started.md
@@ -5,9 +5,9 @@ IntelliJ-based JetBrains IDEs ≥ 2024.2). It opens `.bpmn` files in a JCEF
 (embedded Chromium) editor that renders the same bpmn-js modeler used by the
 VS Code extension and the standalone app.
 
-The plugin is currently distributed **outside the JetBrains Marketplace**, via
-a *custom plugin repository* hosted on GitHub Pages. Install is a one-time setup
-plus the regular *Install Plugin* flow.
+The plugin is available on the official **JetBrains Marketplace**, so it
+installs through the regular *Marketplace* flow — no custom repository setup
+required.
 
 ## Requirements
 
@@ -22,21 +22,12 @@ binary for each supported platform.
 ## Install
 
 1. Open *Settings → Plugins*.
-2. Click the gear icon (⚙) next to *Installed* and choose *Manage Plugin
-   Repositories…*.
-3. Add the custom repository URL:
+2. Select the *Marketplace* tab.
+3. Search for **Miragon BPMN Modeler** and click *Install*.
+4. Restart the IDE when prompted.
 
-   ```
-   https://miragon.github.io/bpmn-modeler/updatePlugins.xml
-   ```
-
-4. Close the dialog. In the *Marketplace* tab, search for
-   **Miragon BPMN Modeler** and click *Install*.
-5. Restart the IDE when prompted.
-
-Updates are delivered through the same mechanism: the IDE polls the custom
-repository on its normal schedule and offers the new version under
-*Settings → Plugins → Updates*.
+Updates are delivered automatically: the IDE offers new versions from the
+Marketplace on its normal schedule under *Settings → Plugins → Updates*.
 
 ## Open a diagram
 

--- a/docs/vscode/contributing/release-process.md
+++ b/docs/vscode/contributing/release-process.md
@@ -127,9 +127,11 @@ hosts have shipped a given shared version and which are still lagging.
 ## Artefact distribution
 
 - **VS Code** → [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=miragon-gmbh.vs-code-bpmn-modeler).
-- **IntelliJ** → the plugin ZIP attaches to the `v<version>` release;
-  `docs/public/updatePlugins.xml` (served via GitHub Pages) points the IDE's
-  custom-repository updater at it.
+- **IntelliJ** → the [JetBrains Marketplace](https://plugins.jetbrains.com/) is
+  the primary channel. The plugin ZIP also attaches to the `v<version>` release
+  and `docs/public/updatePlugins.xml` (served via GitHub Pages) points the IDE's
+  custom-repository updater at it — a **legacy/fallback channel** that still
+  runs on every release but is no longer the recommended install path.
 - **Standalone** → DMG / NSIS installers + the `electron-updater` manifests
   (`latest-mac.yml` / `latest.yml`) attach to the `v<version>` release; the
   Homebrew Cask in [Miragon/homebrew-tap](https://github.com/Miragon/homebrew-tap)


### PR DESCRIPTION
Switches the IntelliJ install docs from the custom plugin repository to the official JetBrains Marketplace. The custom-repo / `updatePlugins.xml` machinery is kept and re-labelled as a **legacy/fallback channel** — no code or workflow changes, docs only.

## Changes

- **`docs/intellij/getting-started.md`** — Install section now describes the regular Marketplace flow (Settings → Plugins → Marketplace → search "Miragon BPMN Modeler" → Install → restart). Removed the "Manage Plugin Repositories" + custom-repo URL steps and the "distributed outside the JetBrains Marketplace" framing.
- **`apps/intellij-plugin/MARKETPLACE.md`** — Intro no longer leads with the custom repository; the "legacy/fallback channel" label now sits next to the machinery description in the automation section. Publishing steps unchanged.
- **`docs/vscode/contributing/release-process.md`** — IntelliJ artefact-distribution entry marks the Marketplace as primary and `updatePlugins.xml` as the legacy/fallback channel that still runs on every release.

## ⚠️ Merge condition

**Only merge once the plugin is public/unhidden in the JetBrains Marketplace** — i.e. a Marketplace search for "Miragon BPMN Modeler" actually returns it. The listing is currently hidden, so merging earlier would document a flow users can't yet complete.

## Checklist

- [ ] Plugin unhidden (public in JetBrains Marketplace)
- [ ] Branch rebased on `main`