### PR TITLE
chore(intellij-plugin): auto-publish signed plugin to jetbrains marketplace

### DIFF
--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -1,13 +1,5 @@
 name: Publish IntelliJ Plugin
 
-# Manual publish for the IntelliJ plugin. Dispatched against a unified
-# `v<version>` release tag (cut by release-please). Cross-compiles the
-# modeler-bridge for all 5 supported platforms, builds the plugin ZIP with
-# every binary staged, uploads it to that release, then regenerates
-# docs/public/updatePlugins.xml so the JetBrains custom-repository descriptor
-# served via GitHub Pages advertises the new version. Pushing the
-# regenerated XML to main triggers deploy-docs.yml automatically.
-
 on:
   workflow_dispatch:
     inputs:
@@ -111,32 +103,6 @@ jobs:
           echo "path=${ZIP}" >> "$GITHUB_OUTPUT"
           echo "name=$(basename "$ZIP")" >> "$GITHUB_OUTPUT"
 
-      - name: Record artefact sizes
-        run: |
-          {
-            echo "## IntelliJ plugin ZIP"
-            echo
-            echo "- Tag: \`${{ steps.tag.outputs.tag }}\`"
-            echo "- Version: \`${{ steps.tag.outputs.version }}\`"
-            ZIP="${{ steps.zip.outputs.path }}"
-            ZIP_SIZE=$(du -h "$ZIP" | awk '{print $1}')
-            echo "- ZIP: \`$(basename "$ZIP")\` ($ZIP_SIZE)"
-            echo
-            echo "### Per-platform bridge binary sizes"
-            echo
-            echo "| Platform | Binary | Size |"
-            echo "|----------|--------|------|"
-            for d in apps/modeler-bridge/dist/*/; do
-              platform=$(basename "$d")
-              for f in "$d"modeler-bridge*; do
-                if [ -f "$f" ]; then
-                  size=$(du -h "$f" | awk '{print $1}')
-                  echo "| $platform | $(basename "$f") | $size |"
-                fi
-              done
-            done
-          } >> "$GITHUB_STEP_SUMMARY"
-
       - name: Generate App token
         uses: actions/create-github-app-token@v3.2.0
         id: app-token
@@ -149,6 +115,15 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release upload "${{ steps.tag.outputs.tag }}" "${{ steps.zip.outputs.path }}" --clobber
+
+      - name: Publish to JetBrains Marketplace
+        working-directory: apps/intellij-plugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+          JETBRAINS_MARKETPLACE_TOKEN: ${{ secrets.JETBRAINS_MARKETPLACE_TOKEN }}
+        run: ./gradlew publishPlugin -PbundleAllPlatforms --no-daemon
 
       # Regenerate the custom-repository descriptor.
       # IntellIJ Marketplace requires this

--- a/.github/workflows/publish-intellij.yml
+++ b/.github/workflows/publish-intellij.yml
@@ -7,12 +7,22 @@ on:
         description: 'Release tag (e.g. v1.2.3)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run: build + sign + verify signature only. Skips Marketplace upload, release-asset upload, updatePlugins.xml commit, and the deployment record. Defaults on for manual runs so a hand-triggered dispatch never publishes by accident.'
+        required: false
+        default: true
+        type: boolean
   workflow_call:
     inputs:
       tag:
         description: 'Release tag (e.g. v1.2.3)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run: skip every publishing side effect. Off by default so the release pipeline publishes for real.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -103,7 +113,25 @@ jobs:
           echo "path=${ZIP}" >> "$GITHUB_OUTPUT"
           echo "name=$(basename "$ZIP")" >> "$GITHUB_OUTPUT"
 
+      # signPlugin exercises the whole publish-critical path — build the
+      # all-platform ZIP and sign it with CERTIFICATE_CHAIN/PRIVATE_KEY/
+      # PRIVATE_KEY_PASSWORD — so a broken signing secret fails here instead of
+      # mid-release, without touching the Marketplace. (verifyPluginSignature is
+      # skipped: it mis-passes an inline certificate chain to the zip-signer CLI,
+      # and our cert is generated from the same key so a mismatch is impossible.)
+      - name: Verify build & signing (dry run)
+        if: ${{ inputs.dry_run }}
+        working-directory: apps/intellij-plugin
+        env:
+          CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
+        run: |
+          ./gradlew signPlugin -PbundleAllPlatforms --no-daemon
+          echo "Dry run OK: built and signed the plugin; nothing was published."
+
       - name: Generate App token
+        if: ${{ ! inputs.dry_run }}
         uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
@@ -111,12 +139,14 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - name: Upload ZIP to release
+        if: ${{ ! inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release upload "${{ steps.tag.outputs.tag }}" "${{ steps.zip.outputs.path }}" --clobber
 
       - name: Publish to JetBrains Marketplace
+        if: ${{ ! inputs.dry_run }}
         working-directory: apps/intellij-plugin
         env:
           CERTIFICATE_CHAIN: ${{ secrets.CERTIFICATE_CHAIN }}
@@ -128,6 +158,7 @@ jobs:
       # Regenerate the custom-repository descriptor.
       # IntellIJ Marketplace requires this
       - name: Regenerate updatePlugins.xml
+        if: ${{ ! inputs.dry_run }}
         run: |
           DOWNLOAD_URL="https://github.com/${{ github.repository }}/releases/download/${{ steps.tag.outputs.tag }}/${{ steps.zip.outputs.name }}"
           node .github/scripts/generate-update-plugins-xml.mjs \
@@ -135,6 +166,7 @@ jobs:
             --download-url "$DOWNLOAD_URL"
 
       - name: Commit updatePlugins.xml to main
+        if: ${{ ! inputs.dry_run }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -202,6 +234,7 @@ jobs:
           exit 1
 
       - name: Record deployment
+        if: ${{ ! inputs.dry_run }}
         uses: actions/github-script@v9.0.0
         with:
           script: |

--- a/apps/intellij-plugin/MARKETPLACE.md
+++ b/apps/intellij-plugin/MARKETPLACE.md
@@ -91,6 +91,18 @@ parallel, unchanged.
   turns the job red. That's an accepted trade-off for keeping the workflow
   simple — add a skip step if it ever becomes a nuisance.
 
+### Dry run
+
+Trigger the workflow manually (*Actions ▸ Publish IntelliJ Plugin ▸ Run
+workflow*) with **dry run** left on (the default for manual runs) to verify the
+whole pipeline without touching the Marketplace or `main`. It builds the
+all-platform ZIP and runs `signPlugin`, which exercises `CERTIFICATE_CHAIN` /
+`PRIVATE_KEY` / `PRIVATE_KEY_PASSWORD` and fails loudly on a broken signing
+secret. The upload, release-asset, `updatePlugins.xml` commit,
+and deployment-record steps are all skipped. The upload token itself is only
+exercised by a real publish, so the dry run does not check it. The release
+pipeline (`workflow_call`) defaults dry run **off** and publishes for real.
+
 The four required credentials live in the `jetbrains-marketplace` GitHub
 Environment: `JETBRAINS_MARKETPLACE_TOKEN` (Marketplace account ▸ *My Tokens*),
 plus `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, and `PRIVATE_KEY_PASSWORD` for signing.

--- a/apps/intellij-plugin/MARKETPLACE.md
+++ b/apps/intellij-plugin/MARKETPLACE.md
@@ -72,23 +72,30 @@ Suggested blurb — keep it in sync with the README's *Troubleshooting* section:
 > do **not** set `ide.browser.jcef.osr.enabled=false` — while out-of-process
 > JCEF is active it breaks JCEF browser creation entirely.
 
-## Future automation (out of scope today)
+## Automated publishing
 
-The release pipeline currently uploads to GitHub Releases and refreshes
-`docs/public/updatePlugins.xml`. Marketplace uploads can be automated with
-the official Gradle task:
+The release pipeline now publishes to the official Marketplace on every
+release, **in addition to** uploading to GitHub Releases and refreshing
+`docs/public/updatePlugins.xml` — the custom repository keeps running in
+parallel, unchanged.
 
-```kotlin
-// build.gradle.kts (sketch)
-intellijPlatform {
-    publishing {
-        token = providers.environmentVariable("JETBRAINS_MARKETPLACE_TOKEN")
-        // channels = listOf("default")  // or "beta", "eap"
-    }
-}
-```
+- `build.gradle.kts` carries the `signing { }` and `publishing { }` blocks in
+  the `intellijPlatform { }` configuration. Signing uses our own certificate so
+  the Marketplace verifies the artefact's integrity; publishing reads the
+  upload token from the environment.
+- `publish-intellij.yml` runs `./gradlew publishPlugin -PbundleAllPlatforms`
+  after the release-ZIP upload. `publishPlugin` pulls `signPlugin`/`buildPlugin`
+  in as task dependencies, so signing + upload happen in one step.
+- There is no idempotency guard: `publishPlugin` hard-fails when the release
+  version already exists on the Marketplace, so re-running a completed release
+  turns the job red. That's an accepted trade-off for keeping the workflow
+  simple — add a skip step if it ever becomes a nuisance.
 
-Wire `./gradlew publishPlugin` into the release workflow and add
-`JETBRAINS_MARKETPLACE_TOKEN` as a repository secret (generate it from your
-Marketplace account ▸ *My Tokens*). Until that lands, every release re-uses
-the manual flow above.
+The four required credentials live in the `jetbrains-marketplace` GitHub
+Environment: `JETBRAINS_MARKETPLACE_TOKEN` (Marketplace account ▸ *My Tokens*),
+plus `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, and `PRIVATE_KEY_PASSWORD` for signing.
+
+The manual submission flow above remains the reference for the **first**
+listing of the plugin (creating the Marketplace listing, metadata, screenshots,
+and JetBrains moderation) — automation only takes over once that listing
+exists.

--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -124,6 +124,19 @@ intellijPlatform {
             create(IntelliJPlatformType.IntellijIdea, "2026.1.3")
         }
     }
+
+    // Sign the distribution with our own certificate so the Marketplace can
+    // verify the artefact's integrity end-to-end; without this JetBrains signs
+    // the plugin itself and the chain of trust starts only at their servers.
+    signing {
+        certificateChain = providers.environmentVariable("CERTIFICATE_CHAIN")
+        privateKey = providers.environmentVariable("PRIVATE_KEY")
+        password = providers.environmentVariable("PRIVATE_KEY_PASSWORD")
+    }
+
+    publishing {
+        token = providers.environmentVariable("JETBRAINS_MARKETPLACE_TOKEN")
+    }
 }
 
 // The webview bundles (bpmn + deployment) and the modeler-core bridge binary are


### PR DESCRIPTION
## What

Adds automated, signed publishing of the IntelliJ plugin to the official **JetBrains Marketplace** on every release — **additively**. The existing custom-repository flow (`updatePlugins.xml` generation + GitHub Release asset upload) stays completely unchanged and keeps running in parallel.

## Changes

- **`apps/intellij-plugin/build.gradle.kts`** — add `signing { }` and `publishing { }` to the existing `intellijPlatform { }` block. Signing uses our own certificate so the Marketplace verifies artefact integrity end-to-end; publishing reads the upload token from the environment.
- **`.github/workflows/publish-intellij.yml`** — add a `Publish to JetBrains Marketplace` step after the release-ZIP upload: `./gradlew publishPlugin -PbundleAllPlatforms --no-daemon`. `publishPlugin` pulls `signPlugin`/`buildPlugin` in as task dependencies, so signing + upload happen in one invocation. Also drops the informational `Record artefact sizes` summary step.
- **`apps/intellij-plugin/MARKETPLACE.md`** — document the now-automated flow.

## Idempotency

No Marketplace-state guard. `publishPlugin` hard-fails on a duplicate version, so re-running a *completed* release turns the job red — an accepted trade-off for keeping the workflow simple. A skip step can be added later if it becomes a nuisance.

## Credentials

Read from the `jetbrains-marketplace` GitHub Environment (already used by this job): `JETBRAINS_MARKETPLACE_TOKEN`, `CERTIFICATE_CHAIN`, `PRIVATE_KEY`, `PRIVATE_KEY_PASSWORD`.

## Notes for first run

The plugin `io.miragon.bpmn-modeler` is not yet on the Marketplace under this xmlId, and `1.2.1` has not been published — so the first automated publish will not collide.