### PR TITLE
fix(vscode-plugin): open code-link implementation in a persistent tab (#1226)

### DIFF
--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executeCommandMock = vi.fn();
+
+vi.mock("vscode", () => ({
+    commands: {
+        executeCommand: (...args: unknown[]) => executeCommandMock(...args),
+    },
+    window: {
+        createOutputChannel: () => ({
+            clear: vi.fn(),
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            show: vi.fn(),
+        }),
+    },
+    ProgressLocation: { Window: 10 },
+    Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
+}));
+
+import { VsCodeNotifier } from "./VsCodeNotifier";
+
+beforeEach(() => {
+    executeCommandMock.mockReset();
+});
+
+describe("VsCodeNotifier.openDocument", () => {
+    it("opens the file as a persistent tab via `preview: false`", async () => {
+        const sut = new VsCodeNotifier();
+
+        await sut.openDocument("/repo/src/Worker.java");
+
+        expect(executeCommandMock).toHaveBeenCalledWith(
+            "vscode.open",
+            expect.objectContaining({ scheme: "file", path: "/repo/src/Worker.java" }),
+            { preview: false },
+        );
+    });
+});

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
@@ -86,6 +86,8 @@ export class VsCodeNotifier implements NotifierPort {
      * stay free of `commands` and `Uri`.
      */
     async openDocument(absolutePath: string): Promise<void> {
-        await commands.executeCommand("vscode.open", Uri.file(absolutePath));
+        await commands.executeCommand("vscode.open", Uri.file(absolutePath), {
+            preview: false,
+        });
     }
 }


### PR DESCRIPTION
## Summary

**"Go to Implementation"** (code-link) opened the source file in VS Code's reused **preview** tab, so it took over the active diagram view and the model appeared lost. This makes it match Call Activity navigation: the source now opens as its own **persistent new tab** in the same editor group, leaving the model open.

Fixes #1226.

## Change

`VsCodeNotifier.openDocument()` now passes `{ preview: false }` to `vscode.open`:

```ts
await commands.executeCommand("vscode.open", Uri.file(absolutePath), {
    preview: false,
});
```

- `openDocument` is the shared `NotifierPort` open path for both code-link and Call Activity navigation — confirmed via grep that those two navigation services are its only callers, so the change is intended for both.
- `{ preview: false }` is a no-op for the `.bpmn` custom-editor path, so Call Activity keeps its existing (correct) behavior.
- The IntelliJ `modeler-bridge` adapter has its own `openDocument` over RPC and is a separate host — out of scope, untouched.

## Tests

- New `VsCodeNotifier.spec.ts` asserts `vscode.open` is called with `{ preview: false }`.
- Existing `ImplementationNavigationService.spec.ts` / `ModelNavigationService.spec.ts` still pass.
- Prettier `format:check` clean.