### PR TITLE
fix(vscode-plugin): show search spinner inside the navigation selection list

### DIFF
--- a/.agent/skills/vscode-ux-guidelines/SKILL.md
+++ b/.agent/skills/vscode-ux-guidelines/SKILL.md
@@ -64,7 +64,7 @@ The status bar item is lazily created. Use the **right side** for transient stat
 
 ## Quick Picks
 
-`VsCodePicker` (`apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.ts`) owns every quick pick — e.g. `pickExecutionPlatform()` when the execution platform cannot be auto-detected from the BPMN XML, plus `pickEngineVersion`, `pickScriptLanguage`, `pickPayloadFile`, `pickReferencedModel`:
+`VsCodePicker` (`apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.ts`) owns every quick pick — e.g. `pickExecutionPlatform()` when the execution platform cannot be auto-detected from the BPMN XML, plus `pickEngineVersion`, `pickScriptLanguage`, `pickPayloadFile`, `searchAndPickReferencedModel`:
 
 ```typescript
 const result = await window.showQuickPick(items, {

--- a/apps/modeler-bridge/src/adapters.spec.ts
+++ b/apps/modeler-bridge/src/adapters.spec.ts
@@ -434,30 +434,6 @@ describe("RpcNotifier", () => {
             },
         ]);
     });
-
-    it("withProgress brackets the task and returns its result", async () => {
-        const { frames, rpc } = harness();
-        const result = await new RpcNotifier(rpc).withProgress("Work", async () => 42);
-
-        expect(result).toBe(42);
-        expect(frames.map((f) => f.method)).toEqual([
-            "notifier/progressStart",
-            "notifier/progressEnd",
-        ]);
-    });
-
-    it("withProgress still ends the spinner when the task throws", async () => {
-        const { frames, rpc } = harness();
-        const run = new RpcNotifier(rpc).withProgress("Work", async () => {
-            throw new Error("fail");
-        });
-
-        await expect(run).rejects.toThrow("fail");
-        expect(frames.map((f) => f.method)).toEqual([
-            "notifier/progressStart",
-            "notifier/progressEnd",
-        ]);
-    });
 });
 
 describe("RpcSecretStore", () => {
@@ -649,21 +625,73 @@ describe("RpcPicker", () => {
         await expect(pending).resolves.toBeNull();
     });
 
-    it("pickReferencedModel sorts by path and returns the chosen one", async () => {
+    it("searchAndPickReferencedModel brackets the search with progress, then picks from multiple matches", async () => {
         const { frames, picker, answerLast } = setup();
-        const pending = picker.pickReferencedModel(["/w/b.bpmn", "/w/a.bpmn"]);
-        expect(
-            last(frames).params.items.map((item: { description: string }) => item.description),
-        ).toEqual(["/w/a.bpmn", "/w/b.bpmn"]);
+        const pending = picker.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/w/b.bpmn", "/w/a.bpmn"],
+        }));
+        await flush();
+
+        // No busy list on the host, so the search keeps the status-bar spinner:
+        // progress brackets it, then the picker opens.
+        expect(frames.filter((f) => f.method.startsWith("notifier/progress"))).toEqual([
+            { method: "notifier/progressStart", params: { title: "Searching…" } },
+            { method: "notifier/progressEnd", params: { title: "Searching…" } },
+        ]);
+        const show = frames.find((f) => f.method === "picker/show");
+        expect(show.params.items.map((item: { description: string }) => item.description)).toEqual([
+            "/w/a.bpmn",
+            "/w/b.bpmn",
+        ]);
         await answerLast({ selected: [0] });
-        await expect(pending).resolves.toBe("/w/a.bpmn");
+        await expect(pending).resolves.toEqual({
+            outcome: { kind: "matches", paths: ["/w/b.bpmn", "/w/a.bpmn"] },
+            chosen: "/w/a.bpmn",
+        });
     });
 
-    it("pickReferencedModel returns undefined on dismissal", async () => {
+    it("searchAndPickReferencedModel skips the picker for a single match", async () => {
+        const { frames, picker } = setup();
+        const result = await picker.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/w/only.bpmn"],
+        }));
+        expect(result).toEqual({
+            outcome: { kind: "matches", paths: ["/w/only.bpmn"] },
+            chosen: undefined,
+        });
+        expect(frames.find((f) => f.method === "picker/show")).toBeUndefined();
+        expect(frames.map((f) => f.method)).toEqual([
+            "notifier/progressStart",
+            "notifier/progressEnd",
+        ]);
+    });
+
+    it("searchAndPickReferencedModel returns chosen=undefined when the list is dismissed", async () => {
         const { picker, answerLast } = setup();
-        const pending = picker.pickReferencedModel(["/w/a.bpmn"]);
+        const pending = picker.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/w/a.bpmn", "/w/b.bpmn"],
+        }));
+        await flush();
         await answerLast({ selected: null });
-        await expect(pending).resolves.toBeUndefined();
+        await expect(pending).resolves.toEqual({
+            outcome: { kind: "matches", paths: ["/w/a.bpmn", "/w/b.bpmn"] },
+            chosen: undefined,
+        });
+    });
+
+    it("searchAndPickReferencedModel still ends the spinner when the search throws", async () => {
+        const { frames, picker } = setup();
+        const run = picker.searchAndPickReferencedModel("Searching…", async () => {
+            throw new Error("scan failed");
+        });
+        await expect(run).rejects.toThrow("scan failed");
+        expect(frames.map((f) => f.method)).toEqual([
+            "notifier/progressStart",
+            "notifier/progressEnd",
+        ]);
     });
 
     it("pickScriptLanguage pins the current format first and returns it", async () => {

--- a/apps/modeler-bridge/src/adapters.ts
+++ b/apps/modeler-bridge/src/adapters.ts
@@ -380,20 +380,6 @@ export class RpcNotifier implements NotifierPort {
         });
     }
 
-    /**
-     * The progress task runs core-side (that is where the work is); the host
-     * only renders a spinner, so we bracket the local run with start/end
-     * notifications and `finally` guarantees the spinner clears even on throw.
-     */
-    async withProgress<T>(title: string, task: () => Promise<T>): Promise<T> {
-        this.rpc.notify(METHODS.notifierProgressStart, { title });
-        try {
-            return await task();
-        } finally {
-            this.rpc.notify(METHODS.notifierProgressEnd, { title });
-        }
-    }
-
     async openDocument(absolutePath: string): Promise<void> {
         this.rpc.notify(METHODS.notifierOpenDocument, { path: absolutePath });
     }
@@ -747,15 +733,33 @@ export class RpcPicker implements PickerPort {
         return selected === null ? undefined : formats[selected[0]];
     }
 
-    async pickReferencedModel(paths: string[]): Promise<string | undefined> {
+    async searchAndPickReferencedModel<R extends { kind: string; paths?: string[] }>(
+        placeholder: string,
+        search: () => Promise<R>,
+    ): Promise<{ outcome: R; chosen?: string }> {
+        // The host can't render a busy list, so it keeps its status-bar spinner:
+        // bracket the local search with the progress notifications, then open the
+        // native picker only for a multi-match.
+        this.rpc.notify(METHODS.notifierProgressStart, { title: placeholder });
+        let outcome: R;
+        try {
+            outcome = await search();
+        } finally {
+            this.rpc.notify(METHODS.notifierProgressEnd, { title: placeholder });
+        }
+
+        if (!outcome.paths || outcome.paths.length < 2) {
+            return { outcome, chosen: undefined };
+        }
+
         // Sort by path so nearby files surface first. The bridge has no VS Code
         // `asRelativePath`, so the absolute path is both the detail and sort key.
-        const sorted = [...paths].sort((a, b) => a.localeCompare(b));
+        const sorted = [...outcome.paths].sort((a, b) => a.localeCompare(b));
         const selected = await this.show({
             placeholder: "Select the referenced model to open",
             canPickMany: false,
             items: sorted.map((path) => ({ label: posix.basename(path), description: path })),
         });
-        return selected === null ? undefined : sorted[selected[0]];
+        return { outcome, chosen: selected === null ? undefined : sorted[selected[0]] };
     }
 }

--- a/apps/modeler-bridge/src/bridge.navigate.spec.ts
+++ b/apps/modeler-bridge/src/bridge.navigate.spec.ts
@@ -38,10 +38,10 @@ async function settle(): Promise<void> {
 
 /**
  * Waits for a frame matching `predicate` to land, or rejects after `timeoutMs`.
- * The navigation flow awaits `notifier.withProgress` → an async fs.glob → an
- * `await Promise.all` over per-file reads, so a single `settle()` isn't enough
- * turns to drain it; polling lets the test stay deterministic without coupling
- * to the number of microtasks the service happens to chain.
+ * The navigation flow awaits the picker's `searchAndPickReferencedModel` → an
+ * async fs.glob → an `await Promise.all` over per-file reads, so a single
+ * `settle()` isn't enough turns to drain it; polling lets the test stay
+ * deterministic without coupling to the number of microtasks the flow chains.
  */
 async function waitForFrame(
     frames: any[],

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.spec.ts
@@ -16,7 +16,6 @@ vi.mock("vscode", () => ({
             show: vi.fn(),
         }),
     },
-    ProgressLocation: { Window: 10 },
     Uri: { file: (path: string) => ({ scheme: "file", path, fsPath: path }) },
 }));
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
@@ -1,4 +1,4 @@
-import { commands, LogOutputChannel, ProgressLocation, Uri, window } from "vscode";
+import { commands, LogOutputChannel, Uri, window } from "vscode";
 
 import { NotifierPort } from "@miragon/bpmn-modeler-core";
 
@@ -66,18 +66,6 @@ export class VsCodeNotifier implements NotifierPort {
      */
     logError(error: string | Error): void {
         this.channel.error(error);
-    }
-
-    /**
-     * Runs `task` while showing a status-bar progress indicator titled
-     * `title`. Status-bar location (`ProgressLocation.Window`) is the only
-     * surface this adapter exposes — the modal/notification variants belong
-     * on a future Picker or modal helper if a caller ever needs them.
-     */
-    withProgress<T>(title: string, task: () => Promise<T>): Promise<T> {
-        return Promise.resolve(
-            window.withProgress({ location: ProgressLocation.Window, title }, task),
-        );
     }
 
     /**

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.spec.ts
@@ -3,12 +3,69 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const showQuickPickMock = vi.fn();
 const asRelativePathMock = vi.fn();
 
+interface FakeQuickPick {
+    busy: boolean;
+    items: { label: string; description: string; path: string }[];
+    placeholder: string | undefined;
+    selectedItems: { path: string }[];
+    show: ReturnType<typeof vi.fn>;
+    hide: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    onDidAccept: (cb: () => void) => void;
+    onDidHide: (cb: () => void) => void;
+    _accept?: () => void;
+    _hide?: () => void;
+}
+
+// `pickBehavior` scripts how the simulated user settles a revealed list, so
+// tests stay free of hand-timed accept/dismiss calls.
+let quickPicks: FakeQuickPick[] = [];
+let pickBehavior: { action: "accept"; index: number } | { action: "hide" } = {
+    action: "hide",
+};
+
+const createQuickPickMock = vi.fn((): FakeQuickPick => {
+    const qp: FakeQuickPick = {
+        busy: false,
+        items: [],
+        placeholder: undefined,
+        selectedItems: [],
+        show: vi.fn(),
+        hide: vi.fn(),
+        dispose: vi.fn(),
+        onDidAccept(cb) {
+            qp._accept = cb;
+        },
+        onDidHide(cb) {
+            qp._hide = cb;
+            // Both handlers are set now — settle on the next microtask.
+            queueMicrotask(() => {
+                if (pickBehavior.action === "accept") {
+                    qp.selectedItems = qp.items[pickBehavior.index]
+                        ? [qp.items[pickBehavior.index]]
+                        : [];
+                    qp._accept?.();
+                } else {
+                    qp._hide?.();
+                }
+            });
+        },
+    };
+    quickPicks.push(qp);
+    return qp;
+});
+
+function lastQuickPick(): FakeQuickPick {
+    return quickPicks[quickPicks.length - 1];
+}
+
 vi.mock("vscode", () => ({
     env: { clipboard: { readText: vi.fn(), writeText: vi.fn() } },
     window: {
         showInformationMessage: vi.fn(),
         showErrorMessage: vi.fn(),
         showQuickPick: (...args: unknown[]) => showQuickPickMock(...args),
+        createQuickPick: () => createQuickPickMock(),
         createOutputChannel: () => ({
             clear: vi.fn(),
             info: vi.fn(),
@@ -46,75 +103,133 @@ function stubWorkspace(findFilesResult: string[] = []): VsCodeWorkspace {
 
 beforeEach(() => {
     showQuickPickMock.mockReset();
+    createQuickPickMock.mockClear();
+    quickPicks = [];
+    pickBehavior = { action: "hide" };
     asRelativePathMock.mockReset();
     asRelativePathMock.mockImplementation((uri: { path: string }) => uri.path.replace(/^\//, ""));
+    vi.useRealTimers();
 });
 
-describe("VsCodePicker.pickReferencedModel", () => {
-    it("returns the chosen item's path", async () => {
-        showQuickPickMock.mockImplementation((items: { path: string }[]) =>
-            Promise.resolve(items[0]),
-        );
-
+describe("VsCodePicker.searchAndPickReferencedModel", () => {
+    it("returns the untouched outcome and the picked path for multiple matches", async () => {
+        pickBehavior = { action: "accept", index: 0 };
         const sut = new VsCodePicker(stubWorkspace());
+        const outcome = { kind: "matches", paths: ["/repo/src/z.bpmn", "/repo/lib/a.bpmn"] };
 
-        const result = await sut.pickReferencedModel(["/src/a.bpmn"]);
+        const result = await sut.searchAndPickReferencedModel("Searching…", async () => outcome);
 
-        expect(result).toBe("/src/a.bpmn");
+        // Outcome passes through untouched so the service can branch on it.
+        expect(result.outcome).toBe(outcome);
+        expect(result.chosen).toBe("/repo/lib/a.bpmn");
     });
 
-    it("returns undefined when the user dismisses the picker", async () => {
-        showQuickPickMock.mockResolvedValue(undefined);
-
+    it("reveals the list busy=false with sorted basename/relative items for multiple matches", async () => {
+        pickBehavior = { action: "accept", index: 0 };
         const sut = new VsCodePicker(stubWorkspace());
 
-        const result = await sut.pickReferencedModel(["/src/a.bpmn"]);
+        await sut.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/repo/src/z.bpmn", "/repo/lib/a.bpmn", "/repo/src/m.bpmn"],
+        }));
 
-        expect(result).toBeUndefined();
-    });
-
-    it("builds items with basename label + workspace-relative description", async () => {
-        showQuickPickMock.mockResolvedValue(undefined);
-
-        const sut = new VsCodePicker(stubWorkspace());
-        await sut.pickReferencedModel(["/repo/src/a.bpmn"]);
-
-        const items = showQuickPickMock.mock.calls[0][0] as {
-            label: string;
-            description: string;
-            path: string;
-        }[];
-        expect(items).toHaveLength(1);
-        expect(items[0].label).toBe("a.bpmn");
-        expect(items[0].description).toBe("repo/src/a.bpmn");
-        expect(items[0].path).toBe("/repo/src/a.bpmn");
-    });
-
-    it("sorts items by workspace-relative description", async () => {
-        showQuickPickMock.mockResolvedValue(undefined);
-        // Inputs in non-alphabetical order; expect the picker to receive
-        // them sorted by `description` so nearby files surface first.
-        const sut = new VsCodePicker(stubWorkspace());
-        await sut.pickReferencedModel(["/repo/src/z.bpmn", "/repo/lib/a.bpmn", "/repo/src/m.bpmn"]);
-
-        const items = showQuickPickMock.mock.calls[0][0] as { path: string }[];
-        expect(items.map((i) => i.path)).toEqual([
+        const qp = lastQuickPick();
+        expect(qp.show).toHaveBeenCalled();
+        expect(qp.busy).toBe(false);
+        expect(qp.placeholder).toBe("Select the referenced model to open");
+        // Sorted by workspace-relative description so nearby files surface first.
+        expect(qp.items.map((i) => i.path)).toEqual([
             "/repo/lib/a.bpmn",
             "/repo/src/m.bpmn",
             "/repo/src/z.bpmn",
         ]);
+        expect(qp.items[0].label).toBe("a.bpmn");
+        expect(qp.items[0].description).toBe("repo/lib/a.bpmn");
+        expect(qp.dispose).toHaveBeenCalled();
     });
 
-    it("passes the placeholder to the picker", async () => {
-        showQuickPickMock.mockResolvedValue(undefined);
-
+    it("returns chosen=undefined when the user dismisses the populated list", async () => {
+        pickBehavior = { action: "hide" };
         const sut = new VsCodePicker(stubWorkspace());
-        await sut.pickReferencedModel(["/a.bpmn"]);
 
-        const options = showQuickPickMock.mock.calls[0][1] as {
-            placeHolder: string;
-        };
-        expect(options.placeHolder).toBe("Select the referenced model to open");
+        const result = await sut.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/a.bpmn", "/b.bpmn"],
+        }));
+
+        expect(result.chosen).toBeUndefined();
+        expect(lastQuickPick().dispose).toHaveBeenCalled();
+    });
+
+    it("never reveals a list for a single match and leaves chosen undefined", async () => {
+        const sut = new VsCodePicker(stubWorkspace());
+
+        const result = await sut.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/a.bpmn"],
+        }));
+
+        const qp = lastQuickPick();
+        expect(result.chosen).toBeUndefined();
+        expect(qp.items).toEqual([]);
+        expect(qp.hide).toHaveBeenCalled();
+        expect(qp.dispose).toHaveBeenCalled();
+    });
+
+    it("never reveals a list for zero matches or a non-matches outcome", async () => {
+        const sut = new VsCodePicker(stubWorkspace());
+
+        const empty = await sut.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: [],
+        }));
+        const noScope = await sut.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "no-search-scope",
+        }));
+
+        expect(empty.chosen).toBeUndefined();
+        expect(noScope.chosen).toBeUndefined();
+    });
+
+    it("reveals a busy list only after the ~150 ms delay while the search runs", async () => {
+        vi.useFakeTimers();
+        let resolveSearch!: (r: { kind: string; paths: string[] }) => void;
+        const search = () =>
+            new Promise<{ kind: string; paths: string[] }>((res) => (resolveSearch = res));
+        const sut = new VsCodePicker(stubWorkspace());
+
+        const pending = sut.searchAndPickReferencedModel("Searching…", search);
+        const qp = lastQuickPick();
+
+        // Before the delay elapses the list stays hidden.
+        await vi.advanceTimersByTimeAsync(149);
+        expect(qp.show).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(qp.show).toHaveBeenCalled();
+        expect(qp.busy).toBe(true);
+        expect(qp.placeholder).toBe("Searching…");
+
+        // A single-match result then hides the spinner without populating items.
+        resolveSearch({ kind: "matches", paths: ["/a.bpmn"] });
+        await pending;
+        expect(qp.hide).toHaveBeenCalled();
+    });
+
+    it("does not flash the list when the search resolves before the reveal delay", async () => {
+        vi.useFakeTimers();
+        const sut = new VsCodePicker(stubWorkspace());
+
+        // Search resolves before the 150 ms timer, so the list never shows.
+        const result = await sut.searchAndPickReferencedModel("Searching…", async () => ({
+            kind: "matches",
+            paths: ["/a.bpmn"],
+        }));
+
+        const qp = lastQuickPick();
+        expect(qp.show).not.toHaveBeenCalled();
+        expect(qp.dispose).toHaveBeenCalled();
+        expect(result.chosen).toBeUndefined();
     });
 });
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodePicker.ts
@@ -170,22 +170,72 @@ export class VsCodePicker implements PickerPort {
     }
 
     /**
-     * Returns `undefined` (not throws) on cancel: the user is free to back
-     * out of a navigation prompt. Sorted by workspace-relative path so
-     * nearby files surface first.
+     * Puts the search spinner on the selection list itself rather than the
+     * status bar. Only a multi-match result opens the list to pick from; the
+     * service still owns the 0/1/error cases via the returned `outcome`.
+     *
+     * Cancel resolves to `undefined` (never throws) — backing out of a
+     * navigation prompt is expected. Sorted by workspace-relative path so nearby
+     * files surface first.
      */
-    async pickReferencedModel(paths: string[]): Promise<string | undefined> {
-        const items = paths
-            .map((path) => ({
-                label: posix.basename(path),
-                description: workspace.asRelativePath(Uri.file(path)),
-                path,
-            }))
-            .sort((a, b) => a.description.localeCompare(b.description));
+    async searchAndPickReferencedModel<R extends { kind: string; paths?: string[] }>(
+        placeholder: string,
+        search: () => Promise<R>,
+    ): Promise<{ outcome: R; chosen?: string }> {
+        const qp = window.createQuickPick<ReferencedModelItem>();
+        try {
+            // Defer the reveal so a fast search doesn't flash the list open and
+            // shut; slow searches still get the spinner.
+            let revealed = false;
+            const revealTimer = setTimeout(() => {
+                revealed = true;
+                qp.busy = true;
+                qp.placeholder = placeholder;
+                qp.show();
+            }, 150);
 
-        const picked = await window.showQuickPick(items, {
-            placeHolder: "Select the referenced model to open",
-        });
-        return picked?.path;
+            let outcome: R;
+            try {
+                outcome = await search();
+            } finally {
+                clearTimeout(revealTimer);
+            }
+
+            if (!outcome.paths || outcome.paths.length < 2) {
+                // Nothing to pick — hide (in case the reveal already fired) and
+                // hand the 0/1/error cases back to the service.
+                qp.hide();
+                return { outcome, chosen: undefined };
+            }
+
+            const items = outcome.paths
+                .map((path) => ({
+                    label: posix.basename(path),
+                    description: workspace.asRelativePath(Uri.file(path)),
+                    path,
+                }))
+                .sort((a, b) => a.description.localeCompare(b.description));
+
+            qp.items = items;
+            qp.placeholder = "Select the referenced model to open";
+            qp.busy = false;
+            if (!revealed) {
+                qp.show();
+            }
+
+            const chosen = await new Promise<string | undefined>((resolve) => {
+                qp.onDidAccept(() => resolve(qp.selectedItems[0]?.path));
+                // Escape/dismissal; a resolved promise ignores a later settle.
+                qp.onDidHide(() => resolve(undefined));
+            });
+
+            return { outcome, chosen };
+        } finally {
+            qp.dispose();
+        }
     }
+}
+
+interface ReferencedModelItem extends QuickPickItem {
+    readonly path: string;
 }

--- a/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.spec.ts
+++ b/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.spec.ts
@@ -13,11 +13,16 @@ function createService(result: LocateImplementationResult) {
         logInfo: vi.fn(),
         logWarning: vi.fn(),
         logError: vi.fn(),
-        withProgress: vi.fn(<T>(_title: string, task: () => Promise<T>): Promise<T> => task()),
         openDocument: vi.fn().mockResolvedValue(undefined),
     };
+    // Default stub runs the search and returns no pick; tests override `chosen`.
     const picker = {
-        pickReferencedModel: vi.fn(),
+        searchAndPickReferencedModel: vi.fn(
+            async (_placeholder: string, search: () => Promise<LocateImplementationResult>) => ({
+                outcome: await search(),
+                chosen: undefined as string | undefined,
+            }),
+        ),
     };
     const service = new ImplementationNavigationService(
         locator as never,
@@ -28,8 +33,8 @@ function createService(result: LocateImplementationResult) {
 }
 
 describe("ImplementationNavigationService.navigate", () => {
-    it("wraps the search in a status-bar progress indicator", async () => {
-        const { service, notifier } = createService({
+    it("runs the search behind the picker's busy list, passing its own thunk", async () => {
+        const { service, picker, locator } = createService({
             kind: "matches",
             paths: ["/src/MyDelegate.java"],
             readFailures: [],
@@ -37,10 +42,13 @@ describe("ImplementationNavigationService.navigate", () => {
 
         await service.navigate("com.example.MyDelegate", "javaClass");
 
-        expect(notifier.withProgress).toHaveBeenCalledTimes(1);
-        const [title] = notifier.withProgress.mock.calls[0];
-        expect(title).toContain("com.example.MyDelegate");
-        expect(title).toContain("class");
+        expect(picker.searchAndPickReferencedModel).toHaveBeenCalledTimes(1);
+        const [placeholder, search] = picker.searchAndPickReferencedModel.mock.calls[0];
+        expect(placeholder).toContain("com.example.MyDelegate");
+        expect(placeholder).toContain("class");
+        // Service hands over a thunk, not a resolved result.
+        expect(search).toBeTypeOf("function");
+        expect(locator.resolve).toHaveBeenCalled();
     });
 
     it("delegates to the locator with the same arguments", async () => {
@@ -56,7 +64,7 @@ describe("ImplementationNavigationService.navigate", () => {
     });
 
     it("opens the file directly when the locator returns a single match", async () => {
-        const { service, picker, notifier } = createService({
+        const { service, notifier } = createService({
             kind: "matches",
             paths: ["/src/MyDelegate.java"],
             readFailures: [],
@@ -64,7 +72,7 @@ describe("ImplementationNavigationService.navigate", () => {
 
         await service.navigate("com.example.MyDelegate", "javaClass");
 
-        expect(picker.pickReferencedModel).not.toHaveBeenCalled();
+        // Single match opens directly, without a pick.
         expect(notifier.openDocument).toHaveBeenCalledWith("/src/MyDelegate.java");
     });
 
@@ -74,11 +82,13 @@ describe("ImplementationNavigationService.navigate", () => {
             paths: ["/src/A.java", "/src/B.java"],
             readFailures: [],
         });
-        picker.pickReferencedModel.mockResolvedValue("/src/B.java");
+        picker.searchAndPickReferencedModel.mockImplementation(async (_placeholder, search) => ({
+            outcome: await search(),
+            chosen: "/src/B.java",
+        }));
 
         await service.navigate("t", "jobType");
 
-        expect(picker.pickReferencedModel).toHaveBeenCalledWith(["/src/A.java", "/src/B.java"]);
         expect(notifier.openDocument).toHaveBeenCalledWith("/src/B.java");
     });
 
@@ -88,7 +98,10 @@ describe("ImplementationNavigationService.navigate", () => {
             paths: ["/src/A.java", "/src/B.java"],
             readFailures: [],
         });
-        picker.pickReferencedModel.mockResolvedValue(undefined);
+        picker.searchAndPickReferencedModel.mockImplementation(async (_placeholder, search) => ({
+            outcome: await search(),
+            chosen: undefined,
+        }));
 
         await service.navigate("t", "jobType");
 

--- a/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.ts
+++ b/libs/modeler-core/src/codeLink/service/ImplementationNavigationService.ts
@@ -6,7 +6,7 @@ import { ImplementationLocator } from "./ImplementationLocator";
 // Maximum length of a reference echoed back into a user-facing notification.
 const REFERENCE_DISPLAY_LIMIT = 100;
 
-// Tighter cap for the status-bar progress label — it's space-constrained.
+// Tighter cap for the busy-list placeholder — it's space-constrained.
 const PROGRESS_LABEL_LIMIT = 40;
 
 // Human-readable labels for the progress / not-found messages, per kind.
@@ -42,9 +42,10 @@ export class ImplementationNavigationService {
     ): Promise<void> {
         const label = KIND_LABELS[kind];
         const display = truncate(reference, REFERENCE_DISPLAY_LIMIT);
-        // Only the search is wrapped — the QuickPick (multi-match) and
-        // openDocument are user-driven and must not keep a spinner visible.
-        const result = await this.notifier.withProgress(
+        // The picker shows the search spinner on the list itself; this service
+        // still owns the 0/1/error messaging. `picked` is set only on a
+        // multi-match pick.
+        const { outcome: result, chosen: picked } = await this.picker.searchAndPickReferencedModel(
             `Searching for ${label} "${truncate(reference, PROGRESS_LABEL_LIMIT)}"…`,
             () => this.locator.resolve(reference, kind, sourceDocumentPath),
         );
@@ -76,7 +77,7 @@ export class ImplementationNavigationService {
         } else if (result.paths.length === 1) {
             chosen = result.paths[0];
         } else {
-            chosen = await this.picker.pickReferencedModel(result.paths);
+            chosen = picked;
         }
 
         if (!chosen) {

--- a/libs/modeler-core/src/navigation/service/ModelNavigationService.spec.ts
+++ b/libs/modeler-core/src/navigation/service/ModelNavigationService.spec.ts
@@ -13,23 +13,30 @@ function createService(result: LocateResult) {
         logInfo: vi.fn(),
         logWarning: vi.fn(),
         logError: vi.fn(),
-        withProgress: vi.fn(<T>(_title: string, task: () => Promise<T>): Promise<T> => task()),
         openDocument: vi.fn().mockResolvedValue(undefined),
     };
+
     const picker = {
-        pickReferencedModel: vi.fn(),
+        searchAndPickReferencedModel: vi.fn(
+            async (_placeholder: string, search: () => Promise<LocateResult>) => ({
+                outcome: await search(),
+                chosen: undefined as string | undefined,
+            }),
+        ),
     };
+
     const service = new ModelNavigationService(
         locator as never,
         notifier as never,
         picker as never,
     );
+
     return { service, locator, notifier, picker };
 }
 
 describe("ModelNavigationService.navigate", () => {
-    it("wraps the search in a status-bar progress indicator", async () => {
-        const { service, notifier } = createService({
+    it("runs the search behind the picker's busy list, passing its own thunk", async () => {
+        const { service, picker, locator } = createService({
             kind: "matches",
             paths: ["/a.bpmn"],
             readFailures: [],
@@ -37,9 +44,11 @@ describe("ModelNavigationService.navigate", () => {
 
         await service.navigate("ProcessB", "process");
 
-        expect(notifier.withProgress).toHaveBeenCalledTimes(1);
-        const [title] = notifier.withProgress.mock.calls[0];
-        expect(title).toContain("ProcessB");
+        expect(picker.searchAndPickReferencedModel).toHaveBeenCalledTimes(1);
+        const [placeholder, search] = picker.searchAndPickReferencedModel.mock.calls[0];
+        expect(placeholder).toContain("ProcessB");
+        expect(search).toBeTypeOf("function");
+        expect(locator.findDeclaringFiles).toHaveBeenCalled();
     });
 
     it("delegates to the locator with the same arguments", async () => {
@@ -55,7 +64,7 @@ describe("ModelNavigationService.navigate", () => {
     });
 
     it("opens the file directly via openDocument when the locator returns a single match", async () => {
-        const { service, picker, notifier } = createService({
+        const { service, notifier } = createService({
             kind: "matches",
             paths: ["/a.bpmn"],
             readFailures: [],
@@ -63,7 +72,7 @@ describe("ModelNavigationService.navigate", () => {
 
         await service.navigate("ProcessB", "process");
 
-        expect(picker.pickReferencedModel).not.toHaveBeenCalled();
+        // Single match opens directly, without a pick.
         expect(notifier.openDocument).toHaveBeenCalledWith("/a.bpmn");
     });
 
@@ -73,11 +82,13 @@ describe("ModelNavigationService.navigate", () => {
             paths: ["/a.bpmn", "/b.bpmn"],
             readFailures: [],
         });
-        picker.pickReferencedModel.mockResolvedValue("/b.bpmn");
+        picker.searchAndPickReferencedModel.mockImplementation(async (_placeholder, search) => ({
+            outcome: await search(),
+            chosen: "/b.bpmn",
+        }));
 
         await service.navigate("Shared", "process");
 
-        expect(picker.pickReferencedModel).toHaveBeenCalledWith(["/a.bpmn", "/b.bpmn"]);
         expect(notifier.openDocument).toHaveBeenCalledWith("/b.bpmn");
     });
 
@@ -87,7 +98,10 @@ describe("ModelNavigationService.navigate", () => {
             paths: ["/a.bpmn", "/b.bpmn"],
             readFailures: [],
         });
-        picker.pickReferencedModel.mockResolvedValue(undefined);
+        picker.searchAndPickReferencedModel.mockImplementation(async (_placeholder, search) => ({
+            outcome: await search(),
+            chosen: undefined,
+        }));
 
         await service.navigate("Shared", "process");
 

--- a/libs/modeler-core/src/navigation/service/ModelNavigationService.ts
+++ b/libs/modeler-core/src/navigation/service/ModelNavigationService.ts
@@ -5,7 +5,7 @@ import { ReferencedModelLocator } from "./ReferencedModelLocator";
 // Maximum length of a reference id echoed back into a user-facing notification.
 const REFERENCE_ID_DISPLAY_LIMIT = 100;
 
-// Tighter cap for the status-bar progress label — it's space-constrained.
+// Tighter cap for the busy-list placeholder — it's space-constrained.
 const PROGRESS_LABEL_LIMIT = 40;
 
 /**
@@ -30,9 +30,10 @@ export class ModelNavigationService {
         sourceDocumentPath?: string,
     ): Promise<void> {
         const display = truncate(referenceId, REFERENCE_ID_DISPLAY_LIMIT);
-        // Only the search itself is wrapped — the QuickPick (multi-match) and
-        // openDocument are user-driven and must not keep a spinner visible.
-        const result = await this.notifier.withProgress(
+        // The picker shows the search spinner on the list itself; this service
+        // still owns the 0/1/error messaging. `picked` is set only on a
+        // multi-match pick.
+        const { outcome: result, chosen: picked } = await this.picker.searchAndPickReferencedModel(
             `Searching for ${kind} "${truncate(referenceId, PROGRESS_LABEL_LIMIT)}"…`,
             () => this.locator.findDeclaringFiles(referenceId, kind, sourceDocumentPath),
         );
@@ -64,7 +65,7 @@ export class ModelNavigationService {
         } else if (result.paths.length === 1) {
             chosen = result.paths[0];
         } else {
-            chosen = await this.picker.pickReferencedModel(result.paths);
+            chosen = picked;
         }
 
         if (!chosen) {

--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -49,8 +49,6 @@ export interface NotifierPort extends LoggerPort {
     /** Logs `error`, then surfaces a toast pairing `context` with the error message. */
     notifyError(context: string, error: Error): void;
     openLoggingConsole(): void;
-    /** Runs `task` under a status-bar progress indicator titled `title`. */
-    withProgress<T>(title: string, task: () => Promise<T>): Promise<T>;
     /** Opens the file at `absolutePath` in its registered editor. */
     openDocument(absolutePath: string): Promise<void>;
 }
@@ -78,8 +76,21 @@ export interface PickerPort {
     pickPayloadFile(paths: string[]): Promise<{ filePath: string; label: string } | null>;
     /** @returns the picked `scriptFormat`, or `undefined` on dismissal. */
     pickScriptLanguage(currentFormat: string): Promise<string | undefined>;
-    /** @returns the chosen model path, or `undefined` on dismissal. */
-    pickReferencedModel(paths: string[]): Promise<string | undefined>;
+    /**
+     * Runs `search` behind a busy selection list so the spinner sits where the
+     * user is looking, not only in the status bar. Only a multi-match result
+     * reveals the list to pick from; the untouched `outcome` comes back either
+     * way, so the caller keeps its own 0/1/error branching and messages.
+     *
+     * The constraint carries `kind` (not just `paths?`) because an all-optional
+     * shape is a "weak type" no locate-result union can be assigned to.
+     *
+     * @returns `{ outcome, chosen }` — `chosen` set only on a multi-match pick.
+     */
+    searchAndPickReferencedModel<R extends { kind: string; paths?: string[] }>(
+        placeholder: string,
+        search: () => Promise<R>,
+    ): Promise<{ outcome: R; chosen?: string }>;
 }
 
 /**


### PR DESCRIPTION
## What

Moves the search feedback for the two "navigate away" flows — Call Activity / Business Rule Task → model, and code-link "Go to Implementation" → source — from the **status bar** into the **selection list itself**. The QuickPick now opens in a busy/spinner state while the workspace scan runs, then populates, so the loading indicator sits where the user is looking.

## How

- **New port method** `PickerPort.searchAndPickReferencedModel(placeholder, search)` replaces `pickReferencedModel`. It owns the busy-list UI **and** the search invocation but returns the raw `outcome`, so the two `modeler-core` services keep their own `0 / 1 / N / no-search-scope / all-unreadable / readFailures` branching and every user-facing message string unchanged (hexagonal boundary preserved).
- **`VsCodePicker`** switches to `window.createQuickPick`. A **~150 ms delayed reveal** (cancelled if the search resolves first) keeps fast single-match searches flash-free; slow multi-match searches show busy → populated seamlessly.
- **`RpcPicker`** (IntelliJ bridge) runs the search locally, bracketed by the existing `progressStart/End` notifications so IntelliJ keeps its status-bar spinner, then opens the native picker only for ≥2 matches.
- Removes the now-unused `NotifierPort.withProgress` and its `VsCodeNotifier` / `RpcNotifier` implementations.

## Notes / trade-off

The in-list spinner is inherent to the feature: a search slower than 150 ms that resolves to 0 or 1 result will briefly show "Searching…" then close the list before the info/error message. This is an accepted, low-harm trade-off (searches are typically well under 150 ms).

## Tests

- Rewrote the two service specs, `VsCodePicker.spec.ts` (new `createQuickPick` fake + fake-timer assertions on the 150 ms reveal), and the bridge `adapters.spec.ts`; verified `bridge.navigate.spec.ts` end-to-end path.
- `yarn build`, `yarn test` (922 passed), `yarn lint` (0 errors), `yarn format:check` all green.

> Branch is named `issue-1224-v1`, but issue #1224 is unrelated (Command Palette). This PR is intentionally **not** linked to it.
