### PR TITLE
fix(bpmn-webview): make element template search fuzzy and rank results

### DIFF
--- a/libs/element-template-chooser/package.json
+++ b/libs/element-template-chooser/package.json
@@ -3,9 +3,11 @@
     "version": "0.0.1",
     "private": true,
     "scripts": {
-        "build": "tsc --noEmit"
+        "build": "tsc --noEmit",
+        "test": "vitest run"
     },
     "dependencies": {
+        "minisearch": "7.2.0",
         "preact": "10.29.3"
     },
     "peerDependencies": {
@@ -13,6 +15,7 @@
     },
     "devDependencies": {
         "bpmn-js": "18.19.0",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "4.1.9"
     }
 }

--- a/libs/element-template-chooser/src/components/ChooserOverlay.tsx
+++ b/libs/element-template-chooser/src/components/ChooserOverlay.tsx
@@ -7,6 +7,7 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "preact/hooks";
 import type { ElementTemplate } from "../types";
 import { extractImplementationDetail } from "../types";
+import { TemplateSearchIndex } from "../search";
 import { TemplatePreview } from "./TemplatePreview";
 
 interface ChooserOverlayProps {
@@ -41,27 +42,17 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
         return Array.from(seen.entries()).map(([id, name]) => ({ id, name }));
     }, [templates]);
 
-    // Filter templates by search query and active category.
+    // Rebuild the search index only when the template set changes; querying it
+    // on every keystroke is cheap.
+    const searchIndex = useMemo(() => new TemplateSearchIndex(templates), [templates]);
+
+    // Rank templates by the search query, then narrow to the active category.
+    // Category filtering runs after ranking because it is UI state, not a
+    // text-relevance concern.
     const filtered = useMemo(() => {
-        const q = search.toLowerCase().trim();
-        return templates.filter((t) => {
-            if (activeCategory && t.category?.id !== activeCategory) {
-                return false;
-            }
-            if (!q) {
-                return true;
-            }
-            const haystack = [
-                t.name,
-                t.description ?? "",
-                t.category?.name ?? "",
-                ...(t.keywords ?? []),
-            ]
-                .join(" ")
-                .toLowerCase();
-            return haystack.includes(q);
-        });
-    }, [templates, search, activeCategory]);
+        const results = searchIndex.search(search);
+        return activeCategory ? results.filter((t) => t.category?.id === activeCategory) : results;
+    }, [searchIndex, search, activeCategory]);
 
     const selectedTemplate = useMemo(
         () => filtered.find((t) => t.id === selectedId) ?? null,
@@ -77,10 +68,15 @@ export function ChooserOverlay({ templates, onSelect, onCancel }: ChooserOverlay
 
     /**
      * Reset focus index when filter results change.
+     *
+     * Keyed on the memoized array identity, not its length: ranked search can
+     * reorder results without changing the count (typing one more character),
+     * which would otherwise leave the keyboard focus index pointing at a
+     * different template than the highlighted one.
      */
     useEffect(() => {
         setFocusIndex(-1);
-    }, [filtered.length]);
+    }, [filtered]);
 
     /**
      * Close on Escape key.

--- a/libs/element-template-chooser/src/search.spec.ts
+++ b/libs/element-template-chooser/src/search.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { TemplateSearchIndex } from "./search";
+import type { ElementTemplate } from "./types";
+
+/**
+ * Minimal template factory: fills the required `appliesTo`/`properties` fields
+ * so each fixture can focus on the searchable text under test.
+ */
+function template(
+    partial: Partial<ElementTemplate> & Pick<ElementTemplate, "id" | "name">,
+): ElementTemplate {
+    return {
+        appliesTo: ["bpmn:ServiceTask"],
+        properties: [],
+        ...partial,
+    };
+}
+
+// The issue's repro template: "resources" is edit-distance 1 from "Resourcen".
+const repro = template({
+    id: "ds-1",
+    name: "Datenquelle - Resourcen laden",
+    description: "Lädt Daten aus der Quelle",
+    category: { id: "cat-ds", name: "Datenquellen" },
+    keywords: ["database", "load"],
+});
+
+// Same word ("Zahlung") in the name → must outrank the description-only hit.
+const zahlungName = template({
+    id: "z-1",
+    name: "Zahlung ausführen",
+    description: "Startet einen Vorgang",
+    category: { id: "cat-pay", name: "Zahlungen" },
+});
+
+// "Zahlung" appears only in the description; "Sonstiges" only in the category.
+const zahlungDesc = template({
+    id: "z-2",
+    name: "Generischer Task",
+    description: "Verarbeitet eine Zahlung im Hintergrund",
+    category: { id: "cat-misc", name: "Sonstiges" },
+});
+
+// Umlaut name with every optional field absent.
+const pruefung = template({ id: "u-1", name: "Prüfung" });
+
+// Old joined-haystack code matched a query spanning the name→description gap.
+const adjacency = template({ id: "adj-1", name: "Alpha", description: "Bravo" });
+
+// Two templates sharing an id: the index must key on array position instead.
+const dupA = template({ id: "dup", name: "First Duplicate" });
+const dupB = template({ id: "dup", name: "Second Duplicate" });
+
+const templates: ElementTemplate[] = [
+    repro,
+    zahlungName,
+    zahlungDesc,
+    pruefung,
+    adjacency,
+    dupA,
+    dupB,
+];
+
+const index = new TemplateSearchIndex(templates);
+
+describe("TemplateSearchIndex", () => {
+    it("finds a template despite a single-character typo (issue #1231 repro)", () => {
+        expect(index.search("resources")).toContain(repro);
+    });
+
+    it("matches multi-word queries regardless of order", () => {
+        expect(index.search("laden resourcen")).toContain(repro);
+    });
+
+    it("matches on a prefix of an indexed term", () => {
+        expect(index.search("daten")).toContain(repro);
+    });
+
+    it("requires every term to match (AND semantics)", () => {
+        expect(index.search("resourcen zzzz")).toEqual([]);
+    });
+
+    it("searches the keywords field", () => {
+        expect(index.search("database")).toContain(repro);
+    });
+
+    it("searches the category-name field", () => {
+        // "sonstiges" appears only as zahlungDesc's category name.
+        expect(index.search("sonstiges")).toEqual([zahlungDesc]);
+    });
+
+    it("ranks a name match above a description-only match", () => {
+        const results = index.search("zahlung");
+        expect(results.indexOf(zahlungName)).toBeLessThan(results.indexOf(zahlungDesc));
+    });
+
+    it("returns all templates in original order for an empty or whitespace query", () => {
+        expect(index.search("")).toBe(templates);
+        expect(index.search("   ")).toBe(templates);
+    });
+
+    it("does not match a substring spanning two fields (old joined-haystack bug)", () => {
+        // "pha bra" spans the end of "Alpha" and the start of "Bravo"; the old
+        // `haystack.includes(q)` matched it, per-field search must not.
+        expect(index.search("pha bra")).toEqual([]);
+    });
+
+    it("folds diacritics so an ASCII query matches an umlaut term", () => {
+        expect(index.search("prufung")).toContain(pruefung);
+    });
+
+    it("does not throw when optional fields are absent", () => {
+        expect(() => index.search("prüfung")).not.toThrow();
+        expect(index.search("prüfung")).toContain(pruefung);
+    });
+
+    it("indexes templates that share an id without throwing", () => {
+        const results = index.search("duplicate");
+        expect(results).toContain(dupA);
+        expect(results).toContain(dupB);
+    });
+
+    it("returns the caller's original template objects (reference identity)", () => {
+        const [result] = index.search("resources");
+        expect(result).toBe(repro);
+    });
+});

--- a/libs/element-template-chooser/src/search.ts
+++ b/libs/element-template-chooser/src/search.ts
@@ -1,0 +1,88 @@
+/**
+ * Ranked fuzzy search over element templates for the chooser overlay.
+ *
+ * The old chooser filtered with a single whole-query substring test over a
+ * space-joined name/description/category/keywords string. That missed typos
+ * ("resources" vs the German "Resourcen"), was sensitive to word order and
+ * adjacency, and let one field's tail match the next field's head across the
+ * join. This module replaces it with MiniSearch: per-term AND matching, typo
+ * tolerance, prefix matching, and field-boosted relevance ranking.
+ */
+import MiniSearch from "minisearch";
+import type { ElementTemplate } from "./types";
+
+/**
+ * Lowercases and strips diacritics so a query like "resources" matches the
+ * German corpus term "Resourcen" and "prufung" matches "Prüfung".
+ *
+ * MiniSearch applies `processTerm` at both index and search time, so query
+ * terms fold identically to indexed terms. Overriding `processTerm` replaces
+ * MiniSearch's default lowercasing, so we must lowercase here explicitly.
+ */
+function normalizeTerm(term: string): string {
+    return term
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/\p{Diacritic}/gu, "");
+}
+
+/**
+ * Builds a searchable index over a fixed set of templates.
+ *
+ * Constructed once per template set (the chooser memoizes it) and queried on
+ * every keystroke. Ranking, typo tolerance, and prefix matching are configured
+ * here; category-chip filtering stays in the component because it is UI state,
+ * not a text-relevance concern.
+ */
+export class TemplateSearchIndex {
+    private readonly index: MiniSearch;
+
+    /**
+     * Original templates keyed by their array index, which is also the
+     * MiniSearch document id. MiniSearch returns only stored fields, so we map
+     * results back to the caller's objects to preserve reference identity that
+     * the component relies on (selection, keyboard focus).
+     */
+    private readonly templates: ElementTemplate[];
+
+    constructor(templates: ElementTemplate[]) {
+        this.templates = templates;
+        this.index = new MiniSearch({
+            // Flat, pre-mapped fields: MiniSearch cannot index nested objects
+            // (category.name) or arrays (keywords[]) directly.
+            fields: ["name", "keywords", "category", "description"],
+            processTerm: normalizeTerm,
+            searchOptions: {
+                combineWith: "AND", // every term must match; order-independent
+                fuzzy: 0.2, // "resources" → "resourcen" (edit distance 1)
+                prefix: true, // "daten" → "Datenquelle"
+                boost: { name: 5, keywords: 3, category: 2, description: 1 },
+            },
+        });
+        // Array index as document id: template ids are not guaranteed unique
+        // (MiniSearch throws on duplicate ids) and the index gives O(1) mapping
+        // back to the original object.
+        this.index.addAll(
+            templates.map((template, i) => ({
+                id: i,
+                name: template.name,
+                keywords: template.keywords?.join(" ") ?? "",
+                category: template.category?.name ?? "",
+                description: template.description ?? "",
+            })),
+        );
+    }
+
+    /**
+     * Returns templates ranked by relevance for the query.
+     *
+     * An empty or whitespace-only query returns all templates in their original
+     * authored order, preserving the chooser's default (unsearched) behavior.
+     */
+    search(query: string): ElementTemplate[] {
+        if (!query.trim()) {
+            return this.templates;
+        }
+        return this.index.search(query).map((result) => this.templates[result.id as number]);
+    }
+}

--- a/libs/element-template-chooser/vitest.config.ts
+++ b/libs/element-template-chooser/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        name: "element-template-chooser",
+        environment: "node",
+        include: ["src/**/*.{spec,test}.ts"],
+    },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
             "apps/modeler-bridge",
             "apps/bpmn-webview",
             "libs/bpmn-i18n",
+            "libs/element-template-chooser",
             "libs/modeler-core",
             "libs/shared",
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,8 +3619,10 @@ __metadata:
   resolution: "@miragon/bpmn-modeler-element-template-chooser@workspace:libs/element-template-chooser"
   dependencies:
     bpmn-js: "npm:18.19.0"
+    minisearch: "npm:7.2.0"
     preact: "npm:10.29.3"
     typescript: "npm:6.0.3"
+    vitest: "npm:4.1.9"
   peerDependencies:
     bpmn-js: 18.19.0
   languageName: unknown
@@ -16354,7 +16356,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minisearch@npm:^7.1.1":
+"minisearch@npm:7.2.0, minisearch@npm:^7.1.1":
   version: 7.2.0
   resolution: "minisearch@npm:7.2.0"
   checksum: 10c0/64efaf30ead2acb19eb8be49c78352c527812dd2927a0981c9d666339d5d206d132b83038d2bfa756f5161cae5d98f15b07cc7e7b7be6b8278d35d2ecdc2628c


### PR DESCRIPTION
**Issue**

Closes #1231

**Description**

Replaces the element template chooser's whole-query substring filter with ranked fuzzy search via MiniSearch, extracted into a pure, unit-tested `TemplateSearchIndex` module. This fixes three failure modes of the old joined-haystack filter: typos (`resources` now finds the German "Resourcen", edit distance 1), word order/adjacency sensitivity (multi-word queries match per-term with AND semantics, order-independent), and cross-field false matches (per-field indexing replaces the space-joined string). MiniSearch is configured with per-term AND, `fuzzy: 0.2`, prefix matching, field boosts (name 5 / keywords 3 / category 2 / description 1), and diacritics folding so an ASCII query matches the umlaut corpus; category-chip filtering stays in the component as UI state, applied after ranking. Verified with 13 new unit tests plus a manual Playwright pass against the live webview (issue repro, reversed word order, prefix, fuzzy-noise, chip+query, AND-empty, and empty-query cases). Match highlighting is intentionally deferred to keep this PR focused.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created