### PR TITLE
fix(intellij-plugin): make Ctrl+Z/Ctrl+Y undo/redo work on the canvas

### DIFF
--- a/apps/bpmn-webview/src/app/hostEditorActions.spec.ts
+++ b/apps/bpmn-webview/src/app/hostEditorActions.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installHostEditorActions } from "./hostEditorActions";
+
+const trigger = vi.fn<(action: "undo" | "redo") => void>();
+
+beforeEach(() => {
+    trigger.mockReset();
+    document.body.innerHTML = "";
+    installHostEditorActions((action) => trigger(action));
+});
+
+afterEach(() => {
+    delete window.__modelerTriggerEditorAction;
+});
+
+describe("installHostEditorActions", () => {
+    it("runs undo when no text surface is focused", () => {
+        window.__modelerTriggerEditorAction!("undo");
+        expect(trigger).toHaveBeenCalledWith("undo");
+    });
+
+    it("runs redo when no text surface is focused", () => {
+        window.__modelerTriggerEditorAction!("redo");
+        expect(trigger).toHaveBeenCalledWith("redo");
+    });
+
+    it("skips while an input owns the caret so the diagram isn't clobbered", () => {
+        const input = document.createElement("input");
+        document.body.appendChild(input);
+        input.focus();
+
+        window.__modelerTriggerEditorAction!("undo");
+
+        expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it("skips while a contenteditable surface owns the caret", () => {
+        const editable = document.createElement("div");
+        editable.contentEditable = "true";
+        editable.tabIndex = 0;
+        document.body.appendChild(editable);
+        editable.focus();
+
+        window.__modelerTriggerEditorAction!("undo");
+
+        expect(trigger).not.toHaveBeenCalled();
+    });
+});

--- a/apps/bpmn-webview/src/app/hostEditorActions.ts
+++ b/apps/bpmn-webview/src/app/hostEditorActions.ts
@@ -1,0 +1,32 @@
+import { isTextEditingSurface } from "./propertiesPanelClipboard";
+
+/** bpmn-js editor actions a host may drive programmatically. */
+export type HostEditorAction = "undo" | "redo";
+
+declare global {
+    interface Window {
+        /**
+         * Lets a host run undo/redo when it can't deliver the keystroke to
+         * bpmn-js itself. The IntelliJ JCEF host swallows Ctrl+Z / Ctrl+Y at the
+         * IDE level before the canvas ever sees them, so it calls this instead.
+         */
+        __modelerTriggerEditorAction?: (action: HostEditorAction) => void;
+    }
+}
+
+/**
+ * Installs {@link Window.__modelerTriggerEditorAction}.
+ *
+ * Skips text-editing surfaces so a host-issued undo never clobbers the diagram's
+ * command stack while the caret sits in a property field — mirroring how a real
+ * Ctrl+Z would be owned by the focused input rather than the canvas.
+ *
+ * @param trigger Runs the bpmn-js editor action (typically
+ *   `editorActions.trigger(action)`).
+ */
+export function installHostEditorActions(trigger: (action: HostEditorAction) => void): void {
+    window.__modelerTriggerEditorAction = (action) => {
+        if (isTextEditingSurface(document.activeElement)) return;
+        trigger(action);
+    };
+}

--- a/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
+++ b/apps/bpmn-webview/src/app/propertiesPanelClipboard.ts
@@ -7,7 +7,7 @@
  * own their own selection, so the event must not reach bpmn-js's Keyboard
  * service.
  */
-function isTextEditingSurface(el: Element | null): boolean {
+export function isTextEditingSurface(el: Element | null): boolean {
     if (el instanceof HTMLInputElement) return true;
     if (el instanceof HTMLTextAreaElement) return true;
     if (el instanceof HTMLElement && el.contentEditable === "true") return true;

--- a/apps/bpmn-webview/src/main.ts
+++ b/apps/bpmn-webview/src/main.ts
@@ -53,6 +53,7 @@ import {
 } from "./app";
 import { DiffMode } from "./app/diff/DiffMode";
 import type { LintConfigService } from "./app/bpmnlint";
+import { installHostEditorActions } from "./app/hostEditorActions";
 import { WebviewStateManager } from "./app/state";
 
 const host = getHostApi();
@@ -340,6 +341,13 @@ async function initializeModeler(
 
     try {
         bpmnModeler.create(engine, extraModules);
+        // Lets the IntelliJ JCEF host drive undo/redo: it swallows Ctrl+Z/Ctrl+Y
+        // at the IDE level before bpmn-js sees them (works fine in VS Code/Theia).
+        installHostEditorActions((action) =>
+            bpmnModeler
+                .getService<{ trigger(action: string): void }>("editorActions")
+                .trigger(action),
+        );
         // Forward the modeler's non-fatal warnings (element-not-found, missing
         // inline script) to the output channel — they were console-only before.
         bpmnModeler.onWarning((warning) => host.postMessage(new LogWarningCommand(warning)));

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WarmBrowser.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WarmBrowser.kt
@@ -2,6 +2,8 @@ package io.miragon.intellij.bpmn
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
+import com.intellij.openapi.keymap.KeymapUtil
+import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.util.Disposer
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
@@ -67,6 +69,8 @@ class WarmBrowser : Disposable {
             }
         }
 
+        forwardUndoRedoToWebview()
+
         // Created before createImmediately() so its message router binds to the
         // render process; the handler delegates to the swappable forwarder.
         jsQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
@@ -119,6 +123,30 @@ class WarmBrowser : Disposable {
                 loaded
             }
         if (injectNow) injectSink(browser.cefBrowser)
+    }
+
+    /**
+     * Makes Ctrl+Z / Ctrl+Y reach bpmn-js. IntelliJ's global `$Undo`/`$Redo`
+     * actions consume the keystroke before it reaches this OSR browser, and a
+     * global keymap action can't be suppressed per-component — but a
+     * component-scoped action with the same shortcut wins over it while focus is
+     * here. Each forwards to the page's `__modelerTriggerEditorAction` hook,
+     * which runs the matching bpmn-js editor action (see the bpmn-webview's
+     * `hostEditorActions.ts`). The existing macOS `JcefShortcutProvider`
+     * unregister above never addressed the global action, so undo was broken on
+     * every platform.
+     */
+    private fun forwardUndoRedoToWebview() {
+        registerWebviewShortcut("\$Undo", "undo")
+        registerWebviewShortcut("\$Redo", "redo")
+    }
+
+    private fun registerWebviewShortcut(actionId: String, editorAction: String) {
+        val cef = browser.cefBrowser
+        val js = "window.__modelerTriggerEditorAction && window.__modelerTriggerEditorAction('$editorAction');"
+        val action = DumbAwareAction.create { cef.executeJavaScript(js, cef.url, 0) }
+        val shortcuts = KeymapUtil.getActiveKeymapShortcuts(actionId)
+        action.registerCustomShortcutSet(shortcuts, browser.component, this)
     }
 
     // inject("p") emits the JS that ships the string argument `p` back to the


### PR DESCRIPTION
## Problem

In the IntelliJ/JetBrains plugin, `Ctrl+Z` (`Cmd+Z` on macOS) does nothing on the BPMN canvas — undo/redo are dead. Works fine in the VS Code extension and the Standalone app. Fixes #1235.

## Root cause

The modeler runs in an off-screen (OSR) JCEF browser. IntelliJ's `IdeKeyEventDispatcher` matches the IDE's **global** `$Undo`/`$Redo` actions and **consumes** the keystroke before it reaches the browser / CEF / bpmn-js, so bpmn-js's `Keyboard`/`EditorActions` never fire. Copy/paste/select-all aren't blocked this way, which is why only undo/redo were reported broken.

The pre-existing macOS block in `WarmBrowser.kt` only unregisters a macOS-specific *component-level* hijack (`JBCefBrowser` registers `JcefShortcutProvider` actions `if (SystemInfo.isMac)`); it never touched the *global* action, so undo was broken on every platform.

## Fix

A global keymap action can't be suppressed per-component, but a **component-scoped** action with the same shortcut wins over the global one while focus is in the browser. So the host registers component-scoped `$Undo`/`$Redo` actions (bound via `KeymapUtil.getActiveKeymapShortcuts`, so custom keymaps are respected) that forward to a small, stable webview hook rather than encoding DOM/keyboard details in Kotlin:

- **`apps/bpmn-webview/src/app/hostEditorActions.ts`** (new) — exposes `window.__modelerTriggerEditorAction('undo'|'redo')`, which runs the real bpmn-js `editorActions.trigger(...)` (→ `commandStack.undo()/redo()`, the exact path a real Ctrl+Z uses). Skips text-editing surfaces (reusing `isTextEditingSurface`) so a host-issued undo can't clobber the diagram while the caret is in a property field.
- **`WarmBrowser.kt`** — the two shortcuts just call the hook by name; no DOM query or synthetic key event lives in Kotlin.

This keeps the host↔webview contract to a single function name + `"undo"`/`"redo"`, and moves the only part that can break on a webview change into TypeScript, where it's test-covered.

## Tests

- New `hostEditorActions.spec.ts` (Vitest): undo fires, redo fires, and both skip when an `<input>` / `contenteditable` owns the caret. **4/4 pass.**
- `compileKotlin`, webview Vite build, and `format:check` all green.
- The JCEF shortcut registration itself isn't unit-testable in this repo (needs a live IDE + browser), consistent with the existing untested `JcefShortcutProvider` glue.

## Manual verification

`corepack yarn intellij:run` → open a `.bpmn`, move/add an element → `Ctrl+Z` reverts, `Ctrl+Y` / `Ctrl+Shift+Z` redoes (`Cmd` on macOS). Confirm `Ctrl+Z` while focused in a properties-panel field does **not** revert the diagram.