### PR TITLE
chore(conductor): replace autostart with selectable run targets

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -2,8 +2,24 @@
 
 [scripts]
 setup = "corepack yarn install"
-run = "corepack yarn workspace @miragon/bpmn-modeler-webview dev"
 archive = "rm -rf dist node_modules"
-
 run_mode = "concurrent"
-auto_run_after_setup = true
+
+# Nothing autostarts after setup — pick a target from the Run button dropdown.
+
+[scripts.run.vscode]
+command = "corepack yarn watch"
+default = true
+icon = "code"
+
+[scripts.run.intellij]
+command = "corepack yarn intellij:run"
+icon = "flame"
+
+[scripts.run.docs]
+command = "corepack yarn docs:dev"
+icon = "book-open"
+
+[scripts.run.webview]
+command = "corepack yarn workspace @miragon/bpmn-modeler-webview dev"
+icon = "globe"


### PR DESCRIPTION
## What

Reworks the Conductor run configuration in `.conductor/settings.toml`:

- **Removes** the single auto-running run script and `auto_run_after_setup` — nothing launches automatically on workspace setup anymore.
- **Adds** four pickable targets to the Run-button dropdown:
  | Target | Command |
  |---|---|
  | **vscode** (default) | `corepack yarn watch` — F5 dev loop (watch-build webviews + extension host) |
  | **intellij** | `corepack yarn intellij:run` |
  | **docs** | `corepack yarn docs:dev` |
  | **webview** | `corepack yarn workspace @miragon/bpmn-modeler-webview dev` (browser preview) |

`run_mode = concurrent`, `setup` and `archive` are unchanged.

## Why

Autostarting a single target on every new workspace was unwanted; a chooser lets each workspace start the host it actually needs.

## Note

Because this is the shared committed config, Conductor only reflects the new dropdown after it lands on `main`.