### PR TITLE
fix(vscode): recover from unregistered marketplaces settings key

### DIFF
--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeNotifier.ts
@@ -34,6 +34,23 @@ export class VsCodeNotifier implements NotifierPort {
     }
 
     /**
+     * Surfaces an error toast carrying a single "Reload Window" action.
+     *
+     * A configuration contribution added by an in-place extension update only
+     * enters the *window's* registry on a full window reload; until then a write
+     * to the new key raises VS Code's ERROR_UNKNOWN_KEY. Restarting the
+     * extension host does not refresh the registry — only a reload does — so we
+     * offer that reload directly rather than leaving the user to discover it.
+     */
+    async showErrorWithReload(message: string): Promise<void> {
+        const reload = "Reload Window";
+        const choice = await window.showErrorMessage(message, reload);
+        if (choice === reload) {
+            await commands.executeCommand("workbench.action.reloadWindow");
+        }
+    }
+
+    /**
      * Logs `error` and surfaces a toast that pairs a caller-supplied
      * `context` line with the error's own message. Centralises the
      * log-then-show pattern so each service only specifies what it was

--- a/apps/vscode-plugin/src/templateMarketplace/controller/TemplateMarketplaceController.spec.ts
+++ b/apps/vscode-plugin/src/templateMarketplace/controller/TemplateMarketplaceController.spec.ts
@@ -42,9 +42,11 @@ function createController() {
         withProgress: vi.fn((_title: string, task: () => Promise<unknown>) => task()),
         showInfo: vi.fn(),
         showError: vi.fn(),
+        showErrorWithReload: vi.fn().mockResolvedValue(undefined),
         notifyError: vi.fn(),
         logInfo: vi.fn(),
         logDebug: vi.fn(),
+        logError: vi.fn(),
     };
 
     const handlers = new Map<string, () => Promise<void>>();
@@ -149,6 +151,38 @@ describe("TemplateMarketplaceController.addMarketplace", () => {
         await handlers.get(ADD_MARKETPLACE_CMD)!();
 
         expect(settings.addMarketplace).not.toHaveBeenCalled();
+        expect(notifier.notifyError).toHaveBeenCalledOnce();
+    });
+
+    it("steers to a window reload and prunes the orphaned cache when the settings key is unregistered", async () => {
+        const { handlers, marketplaceSvc, settings, notifier } = createController();
+        (window.showInputBox as Mock).mockResolvedValue("~/templates");
+        // Models VS Code's ERROR_UNKNOWN_KEY: the `marketplaces` contribution is
+        // absent from a not-yet-reloaded window after an in-place update.
+        settings.addMarketplace.mockRejectedValue(
+            new Error(
+                "Unable to write to Workspace Settings because " +
+                    "miragon.bpmnModeler.marketplaces is not a registered configuration.",
+            ),
+        );
+
+        await handlers.get(ADD_MARKETPLACE_CMD)!();
+
+        // The fetch already cached templates before the write failed, so the
+        // orphaned entry must be pruned rather than left as residue.
+        expect(marketplaceSvc.pruneOrphanedCaches).toHaveBeenCalledOnce();
+        expect(notifier.showErrorWithReload).toHaveBeenCalledOnce();
+        expect(notifier.notifyError).not.toHaveBeenCalled();
+    });
+
+    it("shows the generic failure toast for any other add error", async () => {
+        const { handlers, marketplaceSvc, notifier } = createController();
+        (window.showInputBox as Mock).mockResolvedValue("/bad/folder");
+        marketplaceSvc.addMarketplace.mockRejectedValue(new Error("no marketplace.json"));
+
+        await handlers.get(ADD_MARKETPLACE_CMD)!();
+
+        expect(notifier.showErrorWithReload).not.toHaveBeenCalled();
         expect(notifier.notifyError).toHaveBeenCalledOnce();
     });
 

--- a/apps/vscode-plugin/src/templateMarketplace/controller/TemplateMarketplaceController.ts
+++ b/apps/vscode-plugin/src/templateMarketplace/controller/TemplateMarketplaceController.ts
@@ -118,8 +118,34 @@ export class TemplateMarketplaceController {
             await this.refreshOpenEditors();
             this.notifier.showInfo("Marketplace added.");
         } catch (error) {
-            this.notifier.notifyError("Failed to add marketplace.", error as Error);
+            await this.handleAddFailure(error as Error);
         }
+    }
+
+    /**
+     * The fetch caches templates *before* the settings write, so a failed
+     * persist leaves an orphaned cache entry — prune it first so a failed add
+     * leaves no residue. Then, when the write failed because the `marketplaces`
+     * key is not yet in the window's configuration registry (an in-place update
+     * from ≤1.3.x whose window hasn't reloaded), steer the user to the one fix
+     * that works — a window reload — instead of the generic failure toast.
+     */
+    private async handleAddFailure(error: Error): Promise<void> {
+        try {
+            await this.marketplaceSvc.pruneOrphanedCaches();
+        } catch (pruneError) {
+            // A prune failure must not mask the original add failure below.
+            this.notifier.logError(pruneError as Error);
+        }
+
+        if ((error.message ?? "").includes("not a registered configuration")) {
+            await this.notifier.showErrorWithReload(
+                "The BPMN Modeler extension was just updated. Reload the window to " +
+                    "finish enabling marketplaces, then add it again.",
+            );
+            return;
+        }
+        this.notifier.notifyError("Failed to add marketplace.", error);
     }
 
     /**


### PR DESCRIPTION
**Issue**

Adding a marketplace with **workspace** scope right after an in-place extension update from ≤1.3.x fails with "…`miragon.bpmnModeler.marketplaces` is not a registered configuration." The key *is* registered in 1.4.0, but VS Code's contribution registry for the current window isn't refreshed until a full reload, so the workspace-scope write raises `ERROR_UNKNOWN_KEY`.

**Description**

Detect that specific error in the Add Marketplace flow and, instead of a generic failure toast, surface an actionable error with a **Reload Window** button (`workbench.action.reloadWindow`). The catch block also prunes the orphaned template cache that the fetch wrote before the failed settings persist, so a failed add leaves no residue. Adds a `showErrorWithReload` helper on `VsCodeNotifier` and unit tests for both the reload-hint and generic-error paths.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
