### PR TITLE
fix(templates): stop keychain popup when adding a public marketplace

### DIFF
--- a/libs/modeler-core/src/shared/domain/hostPorts.ts
+++ b/libs/modeler-core/src/shared/domain/hostPorts.ts
@@ -220,6 +220,11 @@ export interface SecretStorePort {
  * deployment-shaped (basic-auth / OAuth2 pairs) and reshaping it would touch
  * every host. Keyed by `host` for a distinct token per origin; setting an
  * existing host overwrites, which is how token rotation is expressed.
+ *
+ * `getToken` may be user-visible — IntelliJ's PasswordSafe adapter raises a
+ * macOS keychain prompt on read — so callers must read lazily, only after an
+ * auth-shaped failure, never speculatively before a request that might succeed
+ * anonymously.
  */
 export interface TokenStorePort {
     getToken(host: string): Promise<string | undefined>;

--- a/libs/modeler-core/src/template-marketplace/service/TemplateMarketplaceService.spec.ts
+++ b/libs/modeler-core/src/template-marketplace/service/TemplateMarketplaceService.spec.ts
@@ -692,30 +692,54 @@ describe("TemplateMarketplaceService.getCachedTemplatePaths", () => {
 });
 
 describe("TemplateMarketplaceService private-repo auth", () => {
-    it("places a stored token on the github config but never on a local one", async () => {
-        // A github marketplace pointing at an external provider:local folder.
+    it("reads the stored token only after an auth failure and never places it on a local config", async () => {
+        // A github marketplace whose root is private (needs the stored token)
+        // pointing at an external provider:local folder.
         const manifest = JSON.stringify({
             sources: [{ path: "element-templates" }, { provider: "local", path: "/opt/ext" }],
         });
-        const { service, sourceFactory, tokenPrompt } = (() => {
-            const svc = createService({ manifest });
-            svc.stored.set("github.com", "stored-tok");
-            return svc;
-        })();
+        // A local `provider:"local"` source also resolves to `path: ""`, so the
+        // gate must be kind-aware or it would deny the local read too.
+        const factory = vi.fn((config: RepositorySourceConfig): RepositorySource => {
+            if (config.kind === "github" && config.path === "") {
+                return {
+                    listTemplateFiles: vi.fn().mockResolvedValue([]),
+                    fetchFile: vi.fn(async () => {
+                        if (config.token !== "stored-tok") {
+                            throw new RepositoryAccessError(
+                                "github.com",
+                                404,
+                                "acme/templates",
+                                false,
+                            );
+                        }
+                        return manifest;
+                    }),
+                };
+            }
+            return {
+                listTemplateFiles: vi.fn().mockResolvedValue([`${config.path}/t.json`]),
+                fetchFile: vi.fn().mockResolvedValue("{}"),
+            };
+        });
+        const { service, tokens, tokenPrompt } = serviceOver(factory, async () => "unused", {
+            "github.com": "stored-tok",
+        });
 
         await service.addMarketplace("https://github.com/acme/templates");
 
-        // The github manifest + relative source carry the token; the local one does not.
-        expect(sourceFactory).toHaveBeenCalledWith(
+        // The github root + relative source carry the token; the local one does not.
+        expect(factory).toHaveBeenCalledWith(
             expect.objectContaining({ kind: "github", path: "", token: "stored-tok" }),
         );
-        expect(sourceFactory).toHaveBeenCalledWith(
+        expect(factory).toHaveBeenCalledWith(
             expect.objectContaining({ kind: "local", rootDir: "/opt/ext" }),
         );
-        expect(sourceFactory).not.toHaveBeenCalledWith(
+        expect(factory).not.toHaveBeenCalledWith(
             expect.objectContaining({ kind: "local", token: expect.anything() }),
         );
-        // The public-looking marketplace read succeeds with the stored token; no prompt.
+        // The store is read once (lazily, after the anonymous 404), never prompted.
+        expect(tokens.getToken).toHaveBeenCalledOnce();
         expect(tokenPrompt.promptForToken).not.toHaveBeenCalled();
     });
 
@@ -799,34 +823,66 @@ describe("TemplateMarketplaceService private-repo auth", () => {
         expect(stored.get("github.com")).toBe("new");
     });
 
-    it("retries a public repo anonymously when the stored token is rejected, never prompting", async () => {
-        // The fine-grained-PAT case: the stored token is outside the repo's
-        // grant (403 even though the repo is public), but an anonymous request
-        // succeeds. No prompt fires and the working token is preserved.
-        const factory = tokenGatedFactory({
-            manifest: JSON.stringify({ sources: [{ path: "element-templates" }] }),
-            status: 403,
-            denyOnlyWithToken: true,
+    it("retries a run-cached token's public source anonymously, never prompting", async () => {
+        // The fine-grained-PAT case, now surfaced through the run cache: the
+        // private manifest forces a lazy store read (anonymous 404 → stored token
+        // succeeds → token run-cached), then a github *source* outside that
+        // token's grant returns 403 with the token but serves anonymously. The
+        // anonymous retry (branch a) wins with no prompt and the token preserved.
+        const manifest = JSON.stringify({
+            sources: [{ provider: "github", repo: "acme/pub", path: "resources" }],
+        });
+        const factory = vi.fn((config: RepositorySourceConfig): RepositorySource => {
+            const token = config.kind === "github" ? config.token : undefined;
+            if (config.kind === "github" && config.path === "") {
+                // Private manifest root: only the stored token reads it.
+                return {
+                    listTemplateFiles: vi.fn().mockResolvedValue([]),
+                    fetchFile: vi.fn(async () => {
+                        if (token !== "stored-tok") {
+                            throw new RepositoryAccessError(
+                                "github.com",
+                                404,
+                                "acme/templates",
+                                false,
+                            );
+                        }
+                        return manifest;
+                    }),
+                };
+            }
+            // A public source a fine-grained token can't reach: 403 with a token,
+            // served anonymously.
+            const denied = token !== undefined;
+            const denyAccess = () => {
+                throw new RepositoryAccessError("github.com", 403, "acme/pub", false);
+            };
+            return {
+                listTemplateFiles: vi.fn(async () =>
+                    denied ? denyAccess() : [`${config.path}/t.json`],
+                ),
+                fetchFile: vi.fn(async () => (denied ? denyAccess() : "{}")),
+            };
         });
         const { service, cache, tokenPrompt, tokens, stored } = serviceOver(
             factory,
             async () => "should-not-be-used",
-            { "github.com": "fine-grained" },
+            { "github.com": "stored-tok" },
         );
 
         await service.addMarketplace("https://github.com/acme/templates");
 
         expect(tokenPrompt.promptForToken).not.toHaveBeenCalled();
         expect(tokens.setToken).not.toHaveBeenCalled();
-        expect(stored.get("github.com")).toBe("fine-grained");
+        expect(stored.get("github.com")).toBe("stored-tok");
         expect(cache.write).toHaveBeenCalled();
     });
 
-    it("attempts the manifest in order stored → anonymous → new when a stale token guards a private repo", async () => {
-        // A private repo whose stored token is stale: the anonymous fallback
-        // also fails (proving the repo isn't public), so the prompt runs and the
-        // fresh token is tried last. The root-path token sequence must be exactly
-        // old → undefined → new.
+    it("attempts the manifest in order anonymous → stored → new when a stale token guards a private repo", async () => {
+        // A private repo whose stored token is stale: the anonymous first attempt
+        // fails, the lazily-read stored token also fails (proving it's stale), so
+        // the prompt runs and the fresh token is tried last. The root-path token
+        // sequence must be exactly undefined → old → new.
         const attempted: (string | undefined)[] = [];
         const factory = vi.fn((config: RepositorySourceConfig): RepositorySource => {
             if (config.path === "") {
@@ -858,13 +914,14 @@ describe("TemplateMarketplaceService private-repo auth", () => {
 
         await service.addMarketplace("https://github.com/acme/templates");
 
-        expect(attempted).toEqual(["old", undefined, "new"]);
+        expect(attempted).toEqual([undefined, "old", "new"]);
         expect(tokenPrompt.promptForToken).toHaveBeenCalledOnce();
     });
 
-    it("skips the anonymous retry for a rate-limited 403 and prompts straight away", async () => {
-        // Anonymous limits are lower, so an anonymous retry would only fail
-        // harder; a stored-token rate-limit must go straight to the prompt.
+    it("a rate-limited anonymous 403 retries with the stored token before prompting", async () => {
+        // A rate-limited anonymous 403 escalates to the stored token (its limit
+        // is higher); the branch-(a) anonymous *fallback* is skipped because it
+        // would only fail harder. Both attempts rate-limit, so the prompt runs.
         const attempted: (string | undefined)[] = [];
         const factory = vi.fn((config: RepositorySourceConfig): RepositorySource => {
             const token = config.kind === "github" ? config.token : undefined;
@@ -883,8 +940,8 @@ describe("TemplateMarketplaceService private-repo auth", () => {
         await expect(service.addMarketplace("https://github.com/acme/templates")).rejects.toThrow(
             /rate limit/i,
         );
-        // Only the stored-token attempt ran — no anonymous (undefined) attempt.
-        expect(attempted).toEqual(["have-it"]);
+        // Anonymous first, then the lazily-read stored token — no branch-(a) retry.
+        expect(attempted).toEqual([undefined, "have-it"]);
         expect(tokenPrompt.promptForToken).toHaveBeenCalledOnce();
     });
 
@@ -908,11 +965,13 @@ describe("TemplateMarketplaceService private-repo auth", () => {
                 fetchFile: vi.fn(),
             };
         });
-        const { service, tokenPrompt } = serviceOver(factory, async () => undefined);
+        const { service, tokenPrompt, tokens } = serviceOver(factory, async () => undefined);
 
         await expect(service.addMarketplace("https://github.com/acme/templates")).rejects.toThrow();
 
         expect(attempted).toEqual([undefined]);
+        // The store is read once, lazily, after the anonymous 404 — and finds nothing.
+        expect(tokens.getToken).toHaveBeenCalledOnce();
         expect(tokenPrompt.promptForToken).toHaveBeenCalledOnce();
     });
 
@@ -975,7 +1034,7 @@ describe("TemplateMarketplaceService private-repo auth", () => {
             manifest: JSON.stringify({ sources: [{ path: "x" }] }),
             // Both marketplaces are private and the user declines.
         });
-        const { service, notifier, tokenPrompt, settings } = serviceOver(
+        const { service, notifier, tokenPrompt, tokens, settings } = serviceOver(
             factory,
             async () => undefined,
         );
@@ -989,6 +1048,8 @@ describe("TemplateMarketplaceService private-repo auth", () => {
         expect(outcome.succeeded).toBe(0);
         expect(outcome.failures).toHaveLength(2);
         expect(tokenPrompt.promptForToken).toHaveBeenCalledOnce(); // one run spans both
+        // The second marketplace reuses the run cache, so the store is read once.
+        expect(tokens.getToken).toHaveBeenCalledOnce();
         expect(notifier.logWarning).toHaveBeenCalledTimes(2);
     });
 
@@ -1009,6 +1070,100 @@ describe("TemplateMarketplaceService private-repo auth", () => {
         await expect(
             service.addMarketplace("https://github.com/acme/templates"),
         ).rejects.not.toThrow(/can't access/);
+    });
+
+    // Regression #1250: a public marketplace raised the macOS keychain popup
+    // because every fetch eagerly read the PasswordSafe-backed token store.
+    it("never consults the token store or prompt for a public marketplace", async () => {
+        // The default service serves a public manifest (relative + github source)
+        // with no gating, so every fetch succeeds anonymously.
+        const { service, sourceFactory, tokens, tokenPrompt } = createService();
+
+        await service.addMarketplace("https://github.com/acme/templates");
+
+        expect(tokens.getToken).not.toHaveBeenCalled();
+        expect(tokenPrompt.promptForToken).not.toHaveBeenCalled();
+        // No config ever carried a token value (anonymous throughout).
+        const carriedToken = sourceFactory.mock.calls.some(
+            ([config]) =>
+                (config.kind === "github" || config.kind === "gitlab") &&
+                config.token !== undefined,
+        );
+        expect(carriedToken).toBe(false);
+    });
+
+    it("reads the store at most once per host per run after repeated auth failures", async () => {
+        // A public manifest with two github sources that 404 anonymously and with
+        // any token; the prompt declines. The store must be read exactly once.
+        const manifest = JSON.stringify({
+            sources: [
+                { provider: "github", repo: "acme/one", path: "a" },
+                { provider: "github", repo: "acme/two", path: "b" },
+            ],
+        });
+        const factory = vi.fn((config: RepositorySourceConfig): RepositorySource => {
+            if (config.kind === "github" && config.path === "") {
+                return {
+                    listTemplateFiles: vi.fn().mockResolvedValue([]),
+                    fetchFile: vi.fn().mockResolvedValue(manifest),
+                };
+            }
+            const deny = () => {
+                throw new RepositoryAccessError("github.com", 404, "acme/src", false);
+            };
+            return {
+                listTemplateFiles: vi.fn(deny),
+                fetchFile: vi.fn(deny),
+            };
+        });
+        const { service, tokens, tokenPrompt } = serviceOver(factory, async () => undefined);
+
+        await service.addMarketplace("https://github.com/acme/templates");
+
+        expect(tokens.getToken).toHaveBeenCalledOnce();
+        expect(tokenPrompt.promptForToken).toHaveBeenCalledOnce();
+    });
+
+    it("run-caches a prompted token and reuses it for later sources without re-reading the store", async () => {
+        // A private manifest plus two private github sources, all gated on the
+        // prompted token, store empty. The prompt (one read of nothing + one
+        // prompt) resolves the token, then every source carries it first-try.
+        const manifest = JSON.stringify({
+            sources: [
+                { provider: "github", repo: "acme/one", path: "a" },
+                { provider: "github", repo: "acme/two", path: "b" },
+            ],
+        });
+        const factory = vi.fn((config: RepositorySourceConfig): RepositorySource => {
+            const token = config.kind === "github" ? config.token : undefined;
+            const denied = token !== "granted";
+            const deny = () => {
+                throw new RepositoryAccessError("github.com", 404, "acme/repo", false);
+            };
+            if (config.path === "") {
+                return {
+                    listTemplateFiles: vi.fn().mockResolvedValue([]),
+                    fetchFile: vi.fn(async () => (denied ? deny() : manifest)),
+                };
+            }
+            return {
+                listTemplateFiles: vi.fn(async () => (denied ? deny() : [`${config.path}/t.json`])),
+                fetchFile: vi.fn(async () => (denied ? deny() : "{}")),
+            };
+        });
+        const { service, tokens, tokenPrompt } = serviceOver(factory, async () => "granted");
+
+        await service.addMarketplace("https://github.com/acme/templates");
+
+        expect(tokens.getToken).toHaveBeenCalledOnce();
+        expect(tokenPrompt.promptForToken).toHaveBeenCalledOnce();
+        // Both sources carried the run-cached token on their first attempt.
+        expect(factory).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: "github", path: "a", token: "granted" }),
+        );
+        expect(factory).toHaveBeenCalledWith(
+            expect.objectContaining({ kind: "github", path: "b", token: "granted" }),
+        );
     });
 });
 

--- a/libs/modeler-core/src/template-marketplace/service/TemplateMarketplaceService.ts
+++ b/libs/modeler-core/src/template-marketplace/service/TemplateMarketplaceService.ts
@@ -35,6 +35,10 @@ const MARKETPLACE_MANIFEST = "marketplace.json";
  */
 interface PromptRun {
     readonly promptedHosts: Set<string>;
+    /** host → token resolved this run. `has(host)` = the store (or a prompt)
+     *  was already consulted, so the keychain is read at most once per host
+     *  per run; the value may be `undefined` (nothing stored / declined). */
+    readonly hostTokens: Map<string, string | undefined>;
 }
 
 /**
@@ -48,13 +52,18 @@ interface PromptRun {
  * blocks the others. Per-source failures are always swallowed — a failing source
  * keeps the last-good cache and warns, leaving siblings intact.
  *
- * Private repos are reached with per-host personal access tokens, prompted once
- * per host per run on an auth-shaped {@link RepositoryAccessError} and retried.
- * The token lives only in {@link TokenStorePort} and never reaches settings, the
- * cache, logs, or error messages; token lifecycle events (prompt, store,
- * decline) are logged by host name only. {@link hostForConfig} is the single place a
- * config maps to the host its token is keyed by, so github.com, gitlab.com, and
- * self-hosted `baseUrl` origins are handled the same way.
+ * Private repos are reached with per-host personal access tokens. The auth
+ * ladder is lazy — anonymous first, and {@link TokenStorePort} is read only
+ * *after* an auth-shaped {@link RepositoryAccessError}, at most once per host per
+ * run — because a store read is not free: on IntelliJ the port is
+ * PasswordSafe-backed and every read raises the macOS confidential-information
+ * popup, so a public marketplace must never touch the keychain. On such a
+ * failure the host is prompted once per run and retried. The token lives only in
+ * {@link TokenStorePort} and never reaches settings, the cache, logs, or error
+ * messages; token lifecycle events (prompt, store, decline) are logged by host
+ * name only. {@link hostForConfig} is the single place a config maps to the host
+ * its token is keyed by, so github.com, gitlab.com, and self-hosted `baseUrl`
+ * origins are handled the same way.
  */
 export class TemplateMarketplaceService {
     /**
@@ -74,6 +83,11 @@ export class TemplateMarketplaceService {
         private readonly homeDir: string,
     ) {}
 
+    /** A fresh {@link PromptRun} — one per user-initiated command. */
+    private newRun(): PromptRun {
+        return { promptedHosts: new Set(), hostTokens: new Map() };
+    }
+
     /**
      * Registers and fetches a single marketplace from a pasted URL. Self-hosted
      * `baseUrl` marketplaces are object entries in settings and never flow
@@ -88,7 +102,7 @@ export class TemplateMarketplaceService {
         // paste, and a bad URL fails before any log line implies work started.
         const registration = parseMarketplaceUrl(url);
         this.notifier.logInfo(`Adding marketplace: ${registration.url}`);
-        const cached = await this.fetchAndCache(registration, { promptedHosts: new Set() });
+        const cached = await this.fetchAndCache(registration, this.newRun());
         this.notifier.logInfo(
             `Marketplace added: ${registration.url} (${cached} template file(s) cached)`,
         );
@@ -114,7 +128,7 @@ export class TemplateMarketplaceService {
      * than risk deleting a still-valid marketplace's cache.
      */
     async updateAll(): Promise<MarketplaceUpdateOutcome> {
-        const run: PromptRun = { promptedHosts: new Set() };
+        const run = this.newRun();
         const entries = this.settings.getMarketplaces();
         this.notifier.logInfo(`Updating ${entries.length} marketplace(s)`);
         let succeeded = 0;
@@ -394,20 +408,27 @@ export class TemplateMarketplaceService {
     }
 
     /**
-     * Runs `task` down an escalating auth ladder: stored token → anonymous →
-     * prompt-and-retry. On an auth-shaped {@link RepositoryAccessError} with a
-     * *stored* token that isn't rate-limited, it first retries **without** the
-     * token, because a fine-grained PAT's grant is scoped to specific repos and
-     * GitHub returns 403 for any repo outside that grant — even a public one.
-     * The anonymous retry lets public marketplaces succeed without clobbering
-     * the working token stored for some other private repo on the same host.
-     * Only if the anonymous attempt also fails do we prompt once and retry.
+     * Runs `task` down a lazy auth ladder: anonymous → stored (read on demand) →
+     * prompt-and-retry. The first attempt is always anonymous (or a token already
+     * resolved this run), so a public marketplace never touches {@link tokens} —
+     * on IntelliJ that store is PasswordSafe-backed and a read raises the macOS
+     * confidential-information popup even when nothing private is involved. The
+     * keychain is consulted only *after* an auth-shaped {@link RepositoryAccessError},
+     * at most once per host per run (cached in `run.hostTokens`, including a
+     * `undefined` miss).
+     *
+     * When a *run-cached* token is rejected and the failure isn't rate-limited,
+     * it retries **without** the token first: a fine-grained PAT's grant is
+     * scoped to specific repos and GitHub returns 403 for any repo outside that
+     * grant — even a public one — so the anonymous retry lets such a marketplace
+     * succeed without clobbering the working token stored for another private
+     * repo on the same host.
      *
      * A non-auth error or an unauthenticated host (a local folder) propagates
-     * unchanged. A rate-limited 403 skips the anonymous retry (unauthenticated
-     * limits are lower, so it would only fail harder) and goes straight to the
-     * prompt. On decline or a final denial the failure is rewritten via
-     * {@link accessFailure}; the raw text would say "HTTP 404" for a private repo.
+     * unchanged. A rate-limited anonymous 403 escalates to the stored token
+     * (higher limits) and, failing that, to the prompt. On decline or a final
+     * denial the failure is rewritten via {@link accessFailure}; the raw text
+     * would say "HTTP 404" for a private repo.
      */
     private async withAuthRetry<T>(
         baseConfig: RepositorySourceConfig,
@@ -415,12 +436,10 @@ export class TemplateMarketplaceService {
         task: (config: RepositorySourceConfig) => Promise<T>,
     ): Promise<T> {
         const host = hostForConfig(baseConfig);
-        const stored = host ? await this.tokens.getToken(host) : undefined;
-        if (stored !== undefined) {
-            this.notifier.logDebug(`Using stored token for ${host}`);
-        }
+        // Never a store read: only a token already resolved this run (or none).
+        const runToken = host === undefined ? undefined : run.hostTokens.get(host);
         try {
-            return await task(this.withToken(baseConfig, stored));
+            return await task(this.withToken(baseConfig, runToken));
         } catch (error) {
             if (!(error instanceof RepositoryAccessError) || host === undefined) {
                 throw error;
@@ -431,11 +450,13 @@ export class TemplateMarketplaceService {
             this.notifier.logDebug(
                 `${error.host} denied access to ${error.resource} (HTTP ${error.status}${rateNote})`,
             );
-            const hadToken = stored !== undefined;
+            let hadToken = runToken !== undefined;
+            let denial = error;
+
+            // (a) A run-cached (likely fine-grained) token was rejected for a repo
+            // outside its grant. Try anonymously before prompting: a public repo
+            // then just works and the stored token survives untouched.
             if (hadToken && !error.rateLimited) {
-                // The stored (likely fine-grained) token was rejected for a repo
-                // outside its grant. Try anonymously before prompting: a public
-                // repo then just works and the stored token survives untouched.
                 this.notifier.logDebug(
                     `Retrying ${error.resource} on ${error.host} without the stored token`,
                 );
@@ -454,12 +475,40 @@ export class TemplateMarketplaceService {
                     }
                 }
             }
-            const fresh = await this.promptOncePerRun(host, run, hadToken, error);
-            if (fresh === undefined) {
-                throw this.accessFailure(error, hadToken);
+
+            // (b) Lazy store read: the keychain is touched only now, after an auth
+            // failure, and at most once per host per run. Also the rate-limit
+            // escalation path — a stored token raises the anonymous limit.
+            if (!hadToken && !run.hostTokens.has(host)) {
+                const stored = await this.tokens.getToken(host);
+                run.hostTokens.set(host, stored);
+                if (stored !== undefined) {
+                    this.notifier.logDebug(`Using stored token for ${host}`);
+                    hadToken = true;
+                    try {
+                        return await task(this.withToken(baseConfig, stored));
+                    } catch (storedError) {
+                        if (!(storedError instanceof RepositoryAccessError)) {
+                            throw storedError;
+                        }
+                        // Keep the "was rejected" wording pointing at the token attempt.
+                        denial = storedError;
+                        this.notifier.logDebug(
+                            `Stored token rejected: HTTP ${storedError.status} for ${storedError.resource}`,
+                        );
+                    }
+                }
             }
+
+            // (c) Prompt once per run; a granted token is run-cached so later
+            // same-host fetches pick it up on their first attempt.
+            const fresh = await this.promptOncePerRun(host, run, hadToken, denial);
+            if (fresh === undefined) {
+                throw this.accessFailure(denial, hadToken);
+            }
+            run.hostTokens.set(host, fresh);
             this.notifier.logDebug(
-                `Retrying ${error.resource} on ${error.host} with the new token`,
+                `Retrying ${denial.resource} on ${denial.host} with the new token`,
             );
             try {
                 return await task(this.withToken(baseConfig, fresh));
@@ -518,6 +567,12 @@ export class TemplateMarketplaceService {
      * source and no stored token, so `withAuthRetry` picks the token up first
      * try. `visibility` is only a hint: undeclared-private sources still get the
      * failure-driven prompt instead.
+     *
+     * A declared-private source is the one case that justifies a deliberate
+     * up-front store read — the marketplace author told us the repo needs a
+     * token. The read is still routed through `run.hostTokens` so nothing
+     * double-reads the keychain, and a resolved token seeds the run cache so the
+     * source's very first fetch already carries it.
      */
     private async ensureTokensForPrivateSources(
         sources: TemplateSource[],
@@ -539,12 +594,19 @@ export class TemplateMarketplaceService {
             this.notifier.logDebug(`Declared-private source host(s): ${[...hosts].join(", ")}`);
         }
         for (const host of hosts) {
-            if (run.promptedHosts.has(host) || (await this.tokens.getToken(host)) !== undefined) {
+            if (run.promptedHosts.has(host)) {
+                continue;
+            }
+            const known = run.hostTokens.has(host)
+                ? run.hostTokens.get(host)
+                : await this.tokens.getToken(host);
+            run.hostTokens.set(host, known);
+            if (known !== undefined) {
                 continue;
             }
             run.promptedHosts.add(host);
             const reason = `${host} hosts a private template source. Enter a personal access token to fetch it.`;
-            await this.promptAndStore(host, reason);
+            run.hostTokens.set(host, await this.promptAndStore(host, reason));
         }
     }
 


### PR DESCRIPTION
**Issue**

Closes #1250

**Description**

Adding a public marketplace in IntelliJ raised the macOS "wants to access confidential information" popup because `TemplateMarketplaceService` eagerly read the PasswordSafe-backed token store before every fetch. The auth ladder is now lazy — anonymous first, with the token store consulted only after an auth-shaped failure and at most once per host per run (cached in the `PromptRun`), so public marketplaces never touch the keychain. Private-repo behavior is preserved: the stored token is retried on failure, the fine-grained-PAT anonymous fallback and rate-limit escalation still work, and declared-private sources still seed their token up front. Includes a regression test asserting a public marketplace never calls `getToken`, plus updated/new specs for the inverted ladder and per-run store-read caching.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created