### PR TITLE
chore(conductor): add run targets for dmn and deployment webviews

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -19,6 +19,14 @@ icon = "flame"
 command = "corepack yarn docs:dev"
 icon = "book-open"
 
-[scripts.run.webview]
+[scripts.run.bpmn-webview]
 command = "corepack yarn workspace @miragon/bpmn-modeler-webview dev"
+icon = "globe"
+
+[scripts.run.dmn-webview]
+command = "corepack yarn workspace @miragon/dmn-modeler-webview dev"
+icon = "globe"
+
+[scripts.run.deployment-webview]
+command = "corepack yarn workspace @miragon/bpmn-modeler-deployment-webview dev"
 icon = "globe"


### PR DESCRIPTION
## Summary

Conductor's Run-button dropdown only exposed a start target for the BPMN webview. This adds targets for the DMN and deployment webviews so any of the three can be launched (concurrently) from the dropdown.

## Changes

- Rename the generic `webview` target to `bpmn-webview` for clarity.
- Add `dmn-webview` → `@miragon/dmn-modeler-webview dev`.
- Add `deployment-webview` → `@miragon/bpmn-modeler-deployment-webview dev`.

Each runs the workspace's `dev` script (portless entrypoint serving the Vite app under a stable `<worktree>.<app>.localhost` URL), matching the existing BPMN target.