### PR TITLE
docs: link jetbrains marketplace and correct standalone platforms

### DIFF
--- a/docs/intellij/getting-started.md
+++ b/docs/intellij/getting-started.md
@@ -5,9 +5,10 @@ IntelliJ-based JetBrains IDEs ≥ 2024.2). It opens `.bpmn` files in a JCEF
 (embedded Chromium) editor that renders the same bpmn-js modeler used by the
 VS Code extension and the standalone app.
 
-The plugin is available on the official **JetBrains Marketplace**, so it
-installs through the regular *Marketplace* flow — no custom repository setup
-required.
+The plugin is published on the official
+[**JetBrains Marketplace**](https://plugins.jetbrains.com/plugin/32634-miragon-bpmn-modeler),
+so it installs through the regular *Marketplace* flow — no custom repository
+setup required.
 
 ## Requirements
 
@@ -25,6 +26,11 @@ binary for each supported platform.
 2. Select the *Marketplace* tab.
 3. Search for **Miragon BPMN Modeler** and click *Install*.
 4. Restart the IDE when prompted.
+
+Prefer the browser? Open the
+[JetBrains Marketplace listing](https://plugins.jetbrains.com/plugin/32634-miragon-bpmn-modeler)
+to read reviews and the changelog, then click **Get → Install to IDE** to push
+it straight into a running IDE.
 
 Updates are delivered automatically: the IDE offers new versions from the
 Marketplace on its normal schedule under *Settings → Plugins → Updates*.

--- a/docs/standalone/getting-started.md
+++ b/docs/standalone/getting-started.md
@@ -5,15 +5,24 @@ built on [Eclipse Theia](https://theia-ide.org/). Same modeler as the
 [VS Code extension](/vscode/getting-started), packaged as a native Electron
 app for when you don't want to run a full IDE.
 
-The standalone app currently ships for **macOS on Apple Silicon**.
-Windows and Linux builds may follow.
+The standalone app currently ships for **macOS** and **Windows**.
+A Linux build may follow.
 
 ## Install
 
-Head to the [**Download** page](/download) for the latest macOS `.dmg` and the
-Homebrew tap snippet. Both options install the same signed and notarized
-build; the app auto-updates from GitHub Releases on each launch, regardless
-of how it was installed.
+Grab the latest signed, notarized `.dmg` from the
+[**Download** page](/download), or install straight from the terminal with
+Homebrew:
+
+```bash
+brew tap miragon/tap
+brew install --cask miragon-bpmn-modeler
+```
+
+Every asset also lives on
+[GitHub Releases](https://github.com/Miragon/bpmn-modeler/releases). Both
+options install the same build; the app auto-updates from GitHub Releases on
+each launch, regardless of how it was installed.
 
 ### Upgrade later
 


### PR DESCRIPTION
## Why

The getting-started pages for IntelliJ and Standalone lacked the direct install links the central **Download** page already carries, and the Standalone page overstated which platforms are still pending.

## Changes

**IntelliJ getting-started**
- Link the "JetBrains Marketplace" mention to the actual listing (`plugins.jetbrains.com/plugin/32634-miragon-bpmn-modeler`) — the URL already lives in `DownloadPage.vue`.
- Add a browser-based install path (open the listing → *Get → Install to IDE*) alongside the in-IDE search steps.

**Standalone getting-started**
- Correct the platform line: Windows already ships an **NSIS installer** (`apps/standalone/electron-builder.yml` has both `mac` and `win` targets; the Download page surfaces the `.exe`). Only **Linux** is genuinely still pending.
- Give the *Install* section direct actionable links — DMG (Download page), inline Homebrew commands, and GitHub Releases — matching the VS Code page's pattern.

Docs-only; no code or build changes.