### PR TITLE
chore(bpmn-webview): add netlify browser demo build

### DIFF
--- a/apps/bpmn-webview/demo/index.html
+++ b/apps/bpmn-webview/demo/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <!--
+        Vite does not auto-inject these because this HTML is copied in, not a
+        Vite HTML entry — so they are linked explicitly with the stable output
+        names the demo build produces. `index.css` carries the app's own
+        component styles; the theme stylesheet carries the bpmn-font @font-face
+        that renders the palette/element icons (same as the VS Code host).
+    -->
+    <link href="./index.css" rel="stylesheet" />
+    <link href="./lightTheme.css" id="theme-link" rel="stylesheet" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>BPMN Modeler — Demo</title>
+</head>
+<body>
+<div id="app" style="height: 100vh">
+    <div class="content with-diagram" id="js-drop-zone">
+
+        <div class="message error">
+            <div class="note">
+                <p>Ooops, we could not display the BPMN 2.0 diagram.</p>
+
+                <div class="details">
+                    <span>Import Error Details</span>
+                    <pre></pre>
+                </div>
+            </div>
+        </div>
+
+        <div class="canvas" id="js-canvas"></div>
+        <div class="panel-resizer" id="js-panel-resizer"></div>
+        <div class="properties-panel-parent" id="js-properties-panel"></div>
+    </div>
+</div>
+<!--
+    Light theme only: the demo's MockHost reports a fixed `colorTheme: "light"`
+    (apps/bpmn-webview/src/app/host.ts), so a runtime dark switch would be
+    overridden on the settings round-trip. Kept simple on purpose.
+-->
+<script src="./index.js" type="module"></script>
+</body>
+</html>

--- a/apps/bpmn-webview/package.json
+++ b/apps/bpmn-webview/package.json
@@ -6,6 +6,7 @@
     "description": "Webview frontend for the BPMN modeler.",
     "scripts": {
         "build": "vite build",
+        "build:demo": "vite build --config vite.config.demo.mts",
         "dev": "portless",
         "dev:app": "vite --port $PORT --host 127.0.0.1",
         "watch": "vite build --watch",

--- a/apps/bpmn-webview/vite.config.demo.mts
+++ b/apps/bpmn-webview/vite.config.demo.mts
@@ -1,0 +1,48 @@
+/// <reference types="vitest" />
+import { copyFileSync } from "fs";
+import { resolve } from "path";
+import { mergeConfig, type Plugin } from "vite";
+import baseConfig from "./vite.config.mts";
+
+const OUT_DIR = "../../dist/demo/bpmn-webview";
+
+/**
+ * Copies the static demo shell to the publish root as `index.html`.
+ *
+ * The base build has no HTML entry (hosts inject their own shell), and
+ * `vite-plugin-static-copy` preserves the source's directory structure, so a
+ * copy target would land at `demo/index.html`. A direct copy at `closeBundle`
+ * puts it exactly where Netlify serves from.
+ */
+function copyDemoShell(): Plugin {
+    return {
+        name: "copy-demo-shell",
+        closeBundle() {
+            copyFileSync(
+                resolve(__dirname, "demo/index.html"),
+                resolve(__dirname, OUT_DIR, "index.html"),
+            );
+        },
+    };
+}
+
+/**
+ * Build variant for the standalone browser demo (Netlify).
+ *
+ * The regular build targets an embedding host: it runs under
+ * `NODE_ENV=production`, so `getHostApi()` returns `HostApiImpl`, whose
+ * constructor calls `acquireVsCodeApi()` — undefined in a plain browser, an
+ * immediate crash. Forcing `process.env.NODE_ENV` to `"development"` in the
+ * bundle keeps the `MockHost` path (fixed sample diagram, native clipboard),
+ * exactly what `yarn serve` exercises, while `vite build` still minifies.
+ */
+export default mergeConfig(baseConfig, {
+    plugins: [copyDemoShell()],
+    build: {
+        outDir: OUT_DIR,
+        minify: "esbuild",
+    },
+    define: {
+        "process.env.NODE_ENV": JSON.stringify("development"),
+    },
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+# Standalone browser demo of the BPMN modeler (bpmn-webview).
+#
+# Netlify's Git integration builds this for every branch/PR (deploy previews)
+# and for `main` (production). 
+
+[build]
+  command = "corepack yarn build:demo"
+  publish = "dist/demo/bpmn-webview"
+
+[build.environment]
+  NODE_VERSION = "22"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
         "build:lib:shared": "corepack yarn workspace @miragon/bpmn-modeler-shared build",
         "build:lib:modeler-core": "corepack yarn workspace @miragon/bpmn-modeler-core build",
         "build:bpmn-webview": "corepack yarn workspace @miragon/bpmn-modeler-webview build",
+        "build:demo": "npm-run-all -s build:lib:shared build:bpmn-webview:demo",
+        "build:bpmn-webview:demo": "corepack yarn workspace @miragon/bpmn-modeler-webview build:demo",
         "build:dmn-webview": "corepack yarn workspace @miragon/dmn-modeler-webview build",
         "build:deployment-webview": "corepack yarn workspace @miragon/bpmn-modeler-deployment-webview build",
         "build:plugin": "corepack yarn workspace vs-code-bpmn-modeler build",


### PR DESCRIPTION
## What

Adds a standalone **browser demo build** of the `bpmn-webview` so the BPMN modeler can be tried without installing the VS Code / IntelliJ extension — analogous to the wardley-maps and team-topologies modeler demos.

- `apps/bpmn-webview/vite.config.demo.mts` — inherits the base Vite config, forces `NODE_ENV=development` in the bundle so `getHostApi()` keeps the in-browser `MockHost` (fixed sample diagram, native clipboard) instead of calling `acquireVsCodeApi()`. Output to `dist/demo/bpmn-webview`, minified. A small inline plugin copies the HTML shell to the publish root.
- `apps/bpmn-webview/demo/index.html` — static shell referencing the stable build outputs (`index.css`, `lightTheme.css`, `index.js`), mirroring the VS Code host shell.
- Root + webview `package.json` — `build:demo` scripts.
- `netlify.toml` — `corepack yarn build:demo` → `dist/demo/bpmn-webview`, Node 22.

## How to enable

Netlify's Git integration is **not** wired yet. One-time: connect the repo in the Netlify UI (New site → GitHub → repo). `netlify.toml` supplies build command + publish dir. Enable *Branch deploys* + *Deploy previews* → per-branch/PR previews and `main` → production automatically. Deploy Previews build for draft PRs too.

## Verified

Built locally and loaded the output in a browser: diagram renders (Start → Call Activity → Service Task → End), palette + properties panel work, elements selectable, **no `acquireVsCodeApi` crash**.

## Known limitations (intentional, minimal demo)

- Fixed sample diagram; edits are ephemeral (no save/open, no persistence).
- BPMN only (no DMN / deployment webview); light theme only.
- Console noise: the MockHost doesn't handle a few messages (`SyncActivitiesCommand`, `GetBpmnlintConfigCommand`, `UpdateScriptVariablesCommand`) and logs errors for them — nothing visibly breaks (same as `yarn serve`). Making the MockHost swallow unknown messages would be a small follow-up.