### PR TITLE
feat(vscode-plugin): improve inline-script intellisense and manifest robustness

### DIFF
--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.spec.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.spec.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The participant touches the `vscode` value namespace (`Uri.parse`) to split
+// the editor URI into scheme + fs path, so the factory supplies a stand-in that
+// mirrors VS Code decoding a `file://` string (follows the modes-spec style).
+vi.mock("vscode", () => ({
+    Uri: {
+        parse: (value: string) => {
+            const path = decodeURIComponent(value.replace(/^file:\/\//, ""));
+            return { scheme: value.startsWith("file:") ? "file" : "untitled", fsPath: path };
+        },
+    },
+}));
+
+import { ScriptVariableManifestService, ScriptVariableStore } from "@miragon/bpmn-modeler-core";
+import { VariableDef } from "@miragon/bpmn-modeler-shared";
+import { VsCodeNotifier } from "../../../../shared/infrastructure/VsCodeNotifier";
+import { EditorSessionContext } from "../../../editor-session/EditorSessionParticipant";
+import { ScriptManifestParticipant } from "./ScriptManifestParticipant";
+
+const EDITOR_ID = "file:///work/diagram.bpmn";
+const DOCUMENT_PATH = "/work/diagram.bpmn";
+const MANIFEST_PATH = "/work/.camunda/vars/diagram.bpmn.vars.json";
+
+const VARIABLE: VariableDef = {
+    name: "orderId",
+    origin: "declared in diagram.bpmn.vars.json",
+    typeHint: "String",
+    description: undefined,
+    confidence: "authored",
+};
+
+function createContext(): EditorSessionContext {
+    return {
+        editorId: EDITOR_ID,
+        panel: {} as never,
+        onDocumentChange: vi.fn(),
+        onSettingChange: vi.fn(),
+        onDispose: vi.fn(),
+        addDisposable: vi.fn(),
+    };
+}
+
+describe("ScriptManifestParticipant", () => {
+    let manifestSvc: {
+        loadWithStatus: ReturnType<typeof vi.fn>;
+        createWatcher: ReturnType<typeof vi.fn>;
+    };
+    let store: { setManifest: ReturnType<typeof vi.fn> };
+    let notifier: { logInfo: ReturnType<typeof vi.fn>; notifyError: ReturnType<typeof vi.fn> };
+
+    beforeEach(() => {
+        manifestSvc = {
+            loadWithStatus: vi.fn(),
+            createWatcher: vi.fn().mockResolvedValue({ dispose: vi.fn() }),
+        };
+        store = { setManifest: vi.fn() };
+        notifier = { logInfo: vi.fn(), notifyError: vi.fn() };
+    });
+
+    function participant(): ScriptManifestParticipant {
+        return new ScriptManifestParticipant(
+            manifestSvc as unknown as ScriptVariableManifestService,
+            store as unknown as ScriptVariableStore,
+            notifier as unknown as VsCodeNotifier,
+        );
+    }
+
+    it("stores the variables and logs the resolved path when a manifest is found", async () => {
+        manifestSvc.loadWithStatus.mockResolvedValue({
+            manifestPath: MANIFEST_PATH,
+            found: true,
+            variables: [VARIABLE],
+        });
+
+        await participant().onResolve(createContext());
+
+        expect(store.setManifest).toHaveBeenCalledWith(EDITOR_ID, [VARIABLE]);
+        expect(notifier.logInfo).toHaveBeenCalledWith(
+            `Variable manifest loaded: ${MANIFEST_PATH} (1 variable(s))`,
+        );
+        expect(notifier.notifyError).not.toHaveBeenCalled();
+    });
+
+    it("logs the lookup path when no manifest exists (so a mislocation is debuggable)", async () => {
+        manifestSvc.loadWithStatus.mockResolvedValue({
+            manifestPath: MANIFEST_PATH,
+            found: false,
+            variables: [],
+        });
+
+        await participant().onResolve(createContext());
+
+        expect(store.setManifest).toHaveBeenCalledWith(EDITOR_ID, []);
+        expect(notifier.logInfo).toHaveBeenCalledWith(`No variable manifest at ${MANIFEST_PATH}`);
+    });
+
+    it("surfaces a read error and leaves the store untouched", async () => {
+        const error = new Error("EACCES");
+        manifestSvc.loadWithStatus.mockRejectedValue(error);
+
+        await participant().onResolve(createContext());
+
+        expect(notifier.notifyError).toHaveBeenCalledWith(
+            "Failed to read process-variable manifest",
+            error,
+        );
+        expect(store.setManifest).not.toHaveBeenCalled();
+    });
+
+    it("ignores a non-file editor (a diff/untitled URI has no manifest on disk)", async () => {
+        const context = { ...createContext(), editorId: "untitled:Untitled-1" };
+
+        await participant().onResolve(context);
+
+        expect(manifestSvc.loadWithStatus).not.toHaveBeenCalled();
+        expect(manifestSvc.createWatcher).not.toHaveBeenCalled();
+    });
+
+    it("registers a watcher that reloads the manifest on change", async () => {
+        manifestSvc.loadWithStatus.mockResolvedValue({
+            manifestPath: MANIFEST_PATH,
+            found: false,
+            variables: [],
+        });
+        const context = createContext();
+
+        await participant().onResolve(context);
+
+        expect(manifestSvc.createWatcher).toHaveBeenCalledWith(DOCUMENT_PATH, expect.any(Function));
+        expect(context.addDisposable).toHaveBeenCalled();
+
+        // The watcher callback must re-drive reload so a live manifest edit is picked up.
+        manifestSvc.loadWithStatus.mockClear();
+        const onChange = manifestSvc.createWatcher.mock.calls[0][1] as () => void;
+        onChange();
+        await vi.waitFor(() => expect(manifestSvc.loadWithStatus).toHaveBeenCalled());
+    });
+});

--- a/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.ts
+++ b/apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptManifestParticipant.ts
@@ -42,10 +42,22 @@ export class ScriptManifestParticipant implements EditorSessionParticipant {
         );
     }
 
-    /** Re-reads the manifest into the store; a read error leaves the store untouched. */
+    /**
+     * Re-reads the manifest into the store and logs the resolved lookup path so
+     * a mislocated manifest is debuggable. A read error leaves the store
+     * untouched and is surfaced as an error notification (fires on session
+     * resolve and on every watcher-triggered reload).
+     */
     private async reload(editorId: string, documentPath: string): Promise<void> {
         try {
-            this.store.setManifest(editorId, await this.manifestSvc.load(documentPath));
+            const { manifestPath, found, variables } =
+                await this.manifestSvc.loadWithStatus(documentPath);
+            this.store.setManifest(editorId, variables);
+            this.notifier.logInfo(
+                found
+                    ? `Variable manifest loaded: ${manifestPath} (${variables.length} variable(s))`
+                    : `No variable manifest at ${manifestPath}`,
+            );
         } catch (error) {
             this.notifier.notifyError("Failed to read process-variable manifest", error as Error);
         }

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
@@ -9,6 +9,7 @@ vi.mock("vscode", () => {
         detail?: string;
         documentation?: unknown;
         insertText?: unknown;
+        additionalTextEdits?: unknown[];
         constructor(
             public label: string,
             public kind: number,
@@ -20,11 +21,30 @@ vi.mock("vscode", () => {
     class SnippetString {
         constructor(public value: string) {}
     }
+    class Position {
+        constructor(
+            public line: number,
+            public character: number,
+        ) {}
+    }
+    // Mirrors the real `TextEdit.insert` shape (an empty range at the position)
+    // so assertions can read `edit.range.start` through the vscode typings.
+    class TextEdit {
+        constructor(
+            public range: { start: Position; end: Position },
+            public newText: string,
+        ) {}
+        static insert(position: Position, newText: string): TextEdit {
+            return new TextEdit({ start: position, end: position }, newText);
+        }
+    }
     return {
         CompletionItem,
         CompletionItemKind: { Text: 0, Method: 1, Function: 2, Variable: 5, Class: 6 },
         MarkdownString,
+        Position,
         SnippetString,
+        TextEdit,
         languages: { registerCompletionItemProvider: vi.fn() },
     };
 });
@@ -261,6 +281,76 @@ describe("ScriptCompletionProvider modes", () => {
                 line: 1,
             });
             expect(labels).not.toContain("myTotal");
+        });
+    });
+
+    describe("groovy SPIN auto-import", () => {
+        it("attaches the S import at line 0 when the script has no imports", () => {
+            const items = completeItems(buildProvider(storeWith()), "S", { scriptText: "S" });
+            const edit = items.find((item) => item.label === "S")?.additionalTextEdits?.[0];
+            expect(edit?.newText).toBe("import static org.camunda.spin.Spin.S\n");
+            expect(edit?.range.start).toMatchObject({ line: 0, character: 0 });
+        });
+
+        it("inserts below the last existing import", () => {
+            const items = completeItems(buildProvider(storeWith()), "S", {
+                scriptText: "import foo.Bar\nS",
+                line: 1,
+            });
+            const edit = items.find((item) => item.label === "S")?.additionalTextEdits?.[0];
+            expect(edit?.range.start.line).toBe(1);
+        });
+
+        it("attaches no edit when the import is already present", () => {
+            const items = completeItems(buildProvider(storeWith()), "S", {
+                scriptText: "import static org.camunda.spin.Spin.S\nS",
+                line: 1,
+            });
+            expect(items.find((item) => item.label === "S")?.additionalTextEdits).toBeUndefined();
+        });
+
+        it("treats a covering wildcard import as satisfying", () => {
+            const items = completeItems(buildProvider(storeWith()), "JSO", {
+                scriptText: "import static org.camunda.spin.Spin.*\nJSO",
+                line: 1,
+            });
+            const item = items.find((candidate) => candidate.label === "JSON");
+            expect(item?.additionalTextEdits).toBeUndefined();
+        });
+
+        it("attaches no import edit outside groovy", () => {
+            const items = completeItems(buildProvider(storeWith()), "S", {
+                languageId: "javascript",
+                scriptText: "S",
+            });
+            expect(items.find((item) => item.label === "S")?.additionalTextEdits).toBeUndefined();
+        });
+
+        it("offers SpinJsonNode as a class completion carrying its import", () => {
+            const items = completeItems(buildProvider(storeWith()), "Spin", {
+                scriptText: "Spin",
+            });
+            const item = items.find((candidate) => candidate.label === "SpinJsonNode");
+            expect(item?.kind).toBe(6); // CompletionItemKind.Class
+            expect(item?.detail).toBe("import org.camunda.spin.json.SpinJsonNode");
+            expect(item?.additionalTextEdits?.[0]?.newText).toBe(
+                "import org.camunda.spin.json.SpinJsonNode\n",
+            );
+        });
+
+        it("keeps SpinJsonNode out of non-groovy scripts", () => {
+            const labels = complete(buildProvider(storeWith()), "Spin", {
+                languageId: "javascript",
+                scriptText: "Spin",
+            });
+            expect(labels).not.toContain("SpinJsonNode");
+        });
+
+        it("keeps SpinJsonNode out when the SPIN setting is off", () => {
+            const labels = complete(buildProvider(storeWith(), false), "Spin", {
+                scriptText: "Spin",
+            });
+            expect(labels).not.toContain("SpinJsonNode");
         });
     });
 

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.modes.spec.ts
@@ -22,7 +22,7 @@ vi.mock("vscode", () => {
     }
     return {
         CompletionItem,
-        CompletionItemKind: { Variable: 5, Method: 1 },
+        CompletionItemKind: { Text: 0, Method: 1, Function: 2, Variable: 5, Class: 6 },
         MarkdownString,
         SnippetString,
         languages: { registerCompletionItemProvider: vi.fn() },
@@ -53,17 +53,39 @@ function buildProvider(store: ScriptVariableStore, spinEnabled = true): ScriptCo
     return new ScriptCompletionProvider(store, settings);
 }
 
+interface CompleteOptions {
+    path?: string;
+    triggerCharacter?: string;
+    languageId?: string;
+    /** Full document text for the local-declaration scan; defaults to the line prefix. */
+    scriptText?: string;
+    /** 0-based cursor line; drives the declaration self-suppression rule. */
+    line?: number;
+}
+
+function completeItems(
+    provider: ScriptCompletionProvider,
+    linePrefix: string,
+    options: CompleteOptions = {},
+): ReturnType<ScriptCompletionProvider["provideCompletionItems"]> {
+    const path = options.path ?? SCRIPT_PATH;
+    const document = {
+        uri: { path },
+        languageId: options.languageId ?? "groovy",
+        lineAt: () => ({ text: linePrefix }),
+        getText: () => options.scriptText ?? linePrefix,
+    } as never;
+    const position = { line: options.line ?? 0, character: linePrefix.length } as never;
+    const context = { triggerCharacter: options.triggerCharacter } as never;
+    return provider.provideCompletionItems(document, position, undefined, context);
+}
+
 function complete(
     provider: ScriptCompletionProvider,
     linePrefix: string,
-    options: { path?: string; triggerCharacter?: string } = {},
+    options: CompleteOptions = {},
 ): string[] {
-    const path = options.path ?? SCRIPT_PATH;
-    const document = { uri: { path }, lineAt: () => ({ text: linePrefix }) } as never;
-    const position = { character: linePrefix.length } as never;
-    const context = { triggerCharacter: options.triggerCharacter } as never;
-    const items = provider.provideCompletionItems(document, position, undefined, context);
-    return items.map((item) => item.label as string);
+    return completeItems(provider, linePrefix, options).map((item) => item.label as string);
 }
 
 const variable = (name: string, typeHint?: string): VariableDef => ({
@@ -144,6 +166,102 @@ describe("ScriptCompletionProvider modes", () => {
     it("member access on a primitive-typed variable returns nothing", () => {
         const provider = buildProvider(storeWith(variable("node", "long")));
         expect(complete(provider, "node.")).toEqual([]);
+    });
+
+    describe("local declarations at root", () => {
+        it("offers a local declared on an earlier line", () => {
+            const provider = buildProvider(storeWith());
+            const labels = complete(provider, "myT", {
+                scriptText: "def myTotal = 1\nmyT",
+                line: 1,
+            });
+            expect(labels).toContain("myTotal");
+        });
+
+        it("marks locals with a local-variable / local-function detail", () => {
+            const provider = buildProvider(storeWith());
+            const items = completeItems(provider, "x", {
+                scriptText: "def myTotal = 1\ndef helper() {\nx",
+                line: 2,
+            });
+            const byLabel = new Map(items.map((item) => [item.label as string, item]));
+            expect(byLabel.get("myTotal")?.detail).toBe("local variable");
+            expect(byLabel.get("helper")?.detail).toBe("local function");
+        });
+
+        it("does not suggest a declaration to itself while it is being typed", () => {
+            const provider = buildProvider(storeWith());
+            const labels = complete(provider, "def myTotal = 1", {
+                scriptText: "def myTotal = 1",
+                line: 0,
+            });
+            expect(labels).not.toContain("myTotal");
+        });
+
+        it("lets the bean win over a same-named local (no duplicate)", () => {
+            const provider = buildProvider(storeWith());
+            const labels = complete(provider, "ex", {
+                scriptText: "def execution = wat\nex",
+                line: 1,
+            });
+            expect(labels.filter((label) => label === "execution")).toHaveLength(1);
+        });
+
+        it("lets the process variable win over a same-named local (docs preserved)", () => {
+            const provider = buildProvider(storeWith(variable("amount", "long")));
+            const items = completeItems(provider, "am", {
+                scriptText: "def amount = 1\nam",
+                line: 1,
+            });
+            const amounts = items.filter((item) => item.label === "amount");
+            expect(amounts).toHaveLength(1);
+            // The surviving item is the store's (typeHint detail), not the local.
+            expect(amounts[0].detail).toBe("long");
+        });
+
+        it("lets a SPIN global win while enabled, and frees the name when disabled", () => {
+            const script = "def S = 5\nx";
+            const spinOn = complete(buildProvider(storeWith()), "x", {
+                scriptText: script,
+                line: 1,
+            });
+            expect(spinOn.filter((label) => label === "S")).toHaveLength(1);
+
+            const spinOff = complete(buildProvider(storeWith(), false), "x", {
+                scriptText: script,
+                line: 1,
+            });
+            expect(spinOff).toContain("S");
+        });
+
+        it("collects javascript locals and functions for a javascript document", () => {
+            const provider = buildProvider(storeWith());
+            const labels = complete(provider, "ra", {
+                languageId: "javascript",
+                scriptText: "const rate = 2\nfunction fmt(x) {}\nra",
+                line: 2,
+            });
+            expect(labels).toContain("rate");
+            expect(labels).toContain("fmt");
+        });
+
+        it("keeps locals out of the variable-string-arg mode", () => {
+            const provider = buildProvider(storeWith(variable("amount")));
+            const labels = complete(provider, `execution.getVariable("`, {
+                scriptText: 'def myTotal = 1\nexecution.getVariable("',
+                line: 1,
+            });
+            expect(labels).toEqual(["amount"]);
+        });
+
+        it("keeps locals out of member completion", () => {
+            const provider = buildProvider(storeWith());
+            const labels = complete(provider, "execution.", {
+                scriptText: "def myTotal = 1\nexecution.",
+                line: 1,
+            });
+            expect(labels).not.toContain("myTotal");
+        });
     });
 
     it("carries the typeHint as the completion detail", () => {

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -22,6 +22,8 @@ import {
     methodsForType,
 } from "@miragon/bpmn-modeler-core";
 import {
+    collectLocalDeclarations,
+    LocalDeclaration,
     matchMemberAccess,
     matchVariableStringArg,
     parseEditorHashFromUri,
@@ -61,8 +63,10 @@ import { VariableDef } from "@miragon/bpmn-modeler-shared";
  *    Returns the methods rendered as snippets so the cursor lands inside the
  *    parentheses with parameter placeholders.
  * 3. **Root completion**: returns the SPIN global functions (`S`/`JSON`, when
- *    the `scripting.spin` setting is on), the bean names, and the process
- *    variables whenever a word is being typed at root scope.
+ *    the `scripting.spin` setting is on), the bean names, the process
+ *    variables, and identifiers declared in the script body (slim lexical
+ *    scan — see {@link collectLocalDeclarations}) whenever a word is being
+ *    typed at root scope.
  *
  * The provider depends on a {@link ScriptVariableStore} (populated by the
  * webview's live variable extraction) so suggestions reflect the current model
@@ -141,19 +145,31 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
             return [];
         }
 
-        // Mode 3: root — globals first, then beans, then process variables, with
-        // beans winning any name clash (a variable named `execution` would be
-        // shadowed anyway). The setting is read live on every invocation, so a
+        // Mode 3: root — globals first, then beans, then process variables, then
+        // local declarations. The setting is read live on every invocation, so a
         // toggle takes effect on the next completion request with no reload.
         const globals = this.settings.getScriptingSpin() ? globalFunctionsFor(kind) : [];
+        const variables = this.variablesFor(document);
         const beanNames = new Set(beans.map((b) => b.name));
-        const variableItems = this.variableItems(document).filter(
-            (item) => !beanNames.has(item.label as string),
-        );
+        // Catalog/model items win any name clash — they carry type and docs; a
+        // same-named local would insert identical text anyway (and a variable
+        // named `execution` would be shadowed by the bean at runtime).
+        const taken = new Set([
+            ...beanNames,
+            ...variables.map((v) => v.name),
+            ...globals.map((g) => g.name),
+        ]);
+        const locals = collectLocalDeclarations(document.getText(), document.languageId)
+            .filter((decl) => !taken.has(decl.name))
+            // A declaration must not complete itself while it is being typed.
+            // Over-suppression when the name is re-declared on a later line is
+            // accepted as cosmetic.
+            .filter((decl) => decl.line !== position.line);
         return [
             ...globals.map(globalToCompletion),
             ...beans.map(beanToCompletion),
-            ...variableItems,
+            ...variables.filter((v) => !beanNames.has(v.name)).map(variableToCompletion),
+            ...locals.map(localToCompletion),
         ];
     }
 
@@ -171,6 +187,15 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
         const editorHash = parseEditorHashFromUri(document.uri.path) ?? "";
         return this.store.getByEditorHash(editorHash);
     }
+}
+
+function localToCompletion(decl: LocalDeclaration): CompletionItem {
+    const item = new CompletionItem(
+        decl.name,
+        decl.kind === "function" ? CompletionItemKind.Function : CompletionItemKind.Variable,
+    );
+    item.detail = decl.kind === "function" ? "local function" : "local variable";
+    return item;
 }
 
 function variableToCompletion(variable: VariableDef): CompletionItem {

--- a/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
+++ b/apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts
@@ -10,19 +10,23 @@ import {
     Position,
     SnippetString,
     TextDocument,
+    TextEdit,
 } from "vscode";
 
 import {
     BeanDef,
     beansFor,
+    COMPLEX_TYPES,
     GlobalFunctionDef,
     globalFunctionsFor,
     MethodDef,
     methodsForBean,
     methodsForType,
+    TypeDef,
 } from "@miragon/bpmn-modeler-core";
 import {
     collectLocalDeclarations,
+    groovyImportInsertionLine,
     LocalDeclaration,
     matchMemberAccess,
     matchVariableStringArg,
@@ -66,7 +70,11 @@ import { VariableDef } from "@miragon/bpmn-modeler-shared";
  *    the `scripting.spin` setting is on), the bean names, the process
  *    variables, and identifiers declared in the script body (slim lexical
  *    scan — see {@link collectLocalDeclarations}) whenever a word is being
- *    typed at root scope.
+ *    typed at root scope. In Groovy scripts the SPIN items additionally carry
+ *    their import statement as an `additionalTextEdits` entry (skipped when
+ *    the script already imports the symbol — see
+ *    {@link groovyImportInsertionLine}), and importable SPIN type names
+ *    (`SpinJsonNode`) are offered as class completions for typed declarations.
  *
  * The provider depends on a {@link ScriptVariableStore} (populated by the
  * webview's live variable extraction) so suggestions reflect the current model
@@ -148,7 +156,16 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
         // Mode 3: root — globals first, then beans, then process variables, then
         // local declarations. The setting is read live on every invocation, so a
         // toggle takes effect on the next completion request with no reload.
-        const globals = this.settings.getScriptingSpin() ? globalFunctionsFor(kind) : [];
+        const spinEnabled = this.settings.getScriptingSpin();
+        const globals = spinEnabled ? globalFunctionsFor(kind) : [];
+        // Importable type names only in Groovy: it is the sole language where a
+        // script names a SPIN type directly (`SpinJsonNode node = …`) and where
+        // the attached Java-style import line is valid syntax.
+        const importableTypes =
+            spinEnabled && document.languageId === "groovy"
+                ? COMPLEX_TYPES.filter((type) => type.groovyImport)
+                : [];
+        const scriptText = document.getText();
         const variables = this.variablesFor(document);
         const beanNames = new Set(beans.map((b) => b.name));
         // Catalog/model items win any name clash — they carry type and docs; a
@@ -158,15 +175,22 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
             ...beanNames,
             ...variables.map((v) => v.name),
             ...globals.map((g) => g.name),
+            ...importableTypes.map((t) => t.name),
         ]);
-        const locals = collectLocalDeclarations(document.getText(), document.languageId)
+        const locals = collectLocalDeclarations(scriptText, document.languageId)
             .filter((decl) => !taken.has(decl.name))
             // A declaration must not complete itself while it is being typed.
             // Over-suppression when the name is re-declared on a later line is
             // accepted as cosmetic.
             .filter((decl) => decl.line !== position.line);
+        const languageId = document.languageId;
         return [
-            ...globals.map(globalToCompletion),
+            ...globals.map((fn) =>
+                withGroovyImport(globalToCompletion(fn), fn.groovyImport, languageId, scriptText),
+            ),
+            ...importableTypes.map((type) =>
+                withGroovyImport(typeToCompletion(type), type.groovyImport, languageId, scriptText),
+            ),
             ...beans.map(beanToCompletion),
             ...variables.filter((v) => !beanNames.has(v.name)).map(variableToCompletion),
             ...locals.map(localToCompletion),
@@ -187,6 +211,38 @@ export class ScriptCompletionProvider implements CompletionItemProvider {
         const editorHash = parseEditorHashFromUri(document.uri.path) ?? "";
         return this.store.getByEditorHash(editorHash);
     }
+}
+
+/**
+ * Attaches the symbol's Groovy import as an additional edit, applied together
+ * with the completion insert. Groovy-only: the other JSR-223 languages bind
+ * SPIN through their own mechanisms (`Java.type`, `from … import`), where a
+ * Java-style import line would be a syntax error. Skipped when the script
+ * already satisfies the import (exactly or via wildcard).
+ */
+function withGroovyImport(
+    item: CompletionItem,
+    groovyImport: string | undefined,
+    languageId: string,
+    scriptText: string,
+): CompletionItem {
+    if (!groovyImport || languageId !== "groovy") {
+        return item;
+    }
+    const line = groovyImportInsertionLine(scriptText, groovyImport);
+    if (line !== undefined) {
+        item.additionalTextEdits = [TextEdit.insert(new Position(line, 0), `${groovyImport}\n`)];
+    }
+    return item;
+}
+
+function typeToCompletion(type: TypeDef): CompletionItem {
+    const item = new CompletionItem(type.name, CompletionItemKind.Class);
+    // The import statement as detail tells the user which package the bare
+    // name will resolve against before they accept.
+    item.detail = type.groovyImport;
+    item.documentation = new MarkdownString(type.description);
+    return item;
 }
 
 function localToCompletion(decl: LocalDeclaration): CompletionItem {

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.spec.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const findFilesMock = vi.fn();
 const createDirectoryMock = vi.fn();
 const writeFileMock = vi.fn();
+const readFileMock = vi.fn();
 const deleteMock = vi.fn();
 const createFileSystemWatcherMock = vi.fn();
 
@@ -10,7 +11,7 @@ vi.mock("vscode", () => ({
     workspace: {
         fs: {
             readDirectory: vi.fn(),
-            readFile: vi.fn(),
+            readFile: (...args: unknown[]) => readFileMock(...args),
             writeFile: (...args: unknown[]) => writeFileMock(...args),
             createDirectory: (...args: unknown[]) => createDirectoryMock(...args),
             delete: (...args: unknown[]) => deleteMock(...args),
@@ -46,6 +47,7 @@ vi.mock("vscode", () => ({
 
 import { FileSystemError, workspace } from "vscode";
 
+import { FileNotFound } from "@miragon/bpmn-modeler-core";
 import { VsCodeWorkspace } from "./VsCodeWorkspace";
 
 const getWorkspaceFolderMock = workspace.getWorkspaceFolder as unknown as ReturnType<typeof vi.fn>;
@@ -57,6 +59,7 @@ beforeEach(() => {
     createDirectoryMock.mockResolvedValue(undefined);
     writeFileMock.mockReset();
     writeFileMock.mockResolvedValue(undefined);
+    readFileMock.mockReset();
     deleteMock.mockReset();
     deleteMock.mockResolvedValue(undefined);
     createFileSystemWatcherMock.mockReset();
@@ -207,6 +210,43 @@ describe("VsCodeWorkspace.deleteDirectory", () => {
         await expect(sut.deleteDirectory("/global/marketplaces/locked")).rejects.toThrow(
             /NoPermissions/,
         );
+    });
+});
+
+describe("VsCodeWorkspace.readFile", () => {
+    it("decodes the read buffer to a string", async () => {
+        readFileMock.mockResolvedValueOnce(Buffer.from("hello"));
+        const sut = new VsCodeWorkspace();
+
+        await expect(sut.readFile("/work/a.txt")).resolves.toBe("hello");
+    });
+
+    it("maps a FileNotFound fs error to the domain FileNotFound carrying the path", async () => {
+        readFileMock.mockRejectedValue(new FileSystemError("FileNotFound"));
+        const sut = new VsCodeWorkspace();
+
+        // The path — not the raw rejection — is what callers log, so the domain
+        // error must carry it (mirrors NodeWorkspace.readFile).
+        await expect(sut.readFile("/work/gone.txt")).rejects.toBeInstanceOf(FileNotFound);
+        await expect(sut.readFile("/work/gone.txt")).rejects.toThrow(/gone\.txt/);
+    });
+
+    it("rethrows a non-FileNotFound fs error instead of masking it as FileNotFound", async () => {
+        readFileMock.mockRejectedValue(new FileSystemError("NoPermissions"));
+        const sut = new VsCodeWorkspace();
+
+        // A real read failure must reach the caller so the manifest participant
+        // can surface it — the old catch-all swallowed it as "no manifest".
+        await expect(sut.readFile("/work/locked.txt")).rejects.not.toBeInstanceOf(FileNotFound);
+        await expect(sut.readFile("/work/locked.txt")).rejects.toThrow(/NoPermissions/);
+    });
+
+    it("rethrows a plain Error unchanged", async () => {
+        readFileMock.mockRejectedValue(new Error("boom"));
+        const sut = new VsCodeWorkspace();
+
+        await expect(sut.readFile("/work/x.txt")).rejects.not.toBeInstanceOf(FileNotFound);
+        await expect(sut.readFile("/work/x.txt")).rejects.toThrow(/boom/);
     });
 });
 

--- a/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
+++ b/apps/vscode-plugin/src/shared/infrastructure/VsCodeWorkspace.ts
@@ -134,15 +134,22 @@ export class VsCodeWorkspace implements WorkspacePort {
      *
      * @param path Absolute path to the file.
      * @returns The file content as a string.
-     * @throws {FileNotFound} If the file does not exist or cannot be read.
+     * @throws {FileNotFound} only when the file is absent. Any other fs failure
+     *   (permission denied, target is a directory, …) propagates unchanged so
+     *   callers can surface it — `ScriptVariableManifestService` relies on this
+     *   to distinguish "no manifest" from "manifest unreadable" (mirrors
+     *   `NodeWorkspace.readFile`).
      */
     async readFile(path: string): Promise<string> {
-        return fs.readFile(toUri(path)).then(
-            (buffer) => buffer.toString(),
-            (reason) => {
-                throw new FileNotFound(reason);
-            },
-        );
+        try {
+            const buffer = await fs.readFile(toUri(path));
+            return buffer.toString();
+        } catch (error) {
+            if (error instanceof FileSystemError && error.code === "FileNotFound") {
+                throw new FileNotFound(path);
+            }
+            throw error;
+        }
     }
 
     /**

--- a/docs/vscode/contributing/architecture/inline-scripting.md
+++ b/docs/vscode/contributing/architecture/inline-scripting.md
@@ -66,6 +66,7 @@ those listeners are what propagate edits and clean up tracking state.
 | `libs/modeler-core/src/scriptTask/domain/scriptCompletion.ts` | Pure helpers — `parseKindFromUri`, `matchMemberAccess`, `matchVariableStringArg` (testable without `vscode`) |
 | `libs/modeler-core/src/scriptTask/domain/scriptApi.ts` | Camunda 7 bean and method catalogue (`DELEGATE_EXECUTION_METHODS`, `DELEGATE_TASK_METHODS`, `beansFor`) |
 | `libs/modeler-core/src/scriptTask/domain/localDeclarations.ts` | `collectLocalDeclarations` — slim per-line scan for script-local variable/function declarations |
+| `libs/modeler-core/src/scriptTask/domain/groovyImports.ts` | `groovyImportInsertionLine` — placement / already-satisfied check for auto-inserted Groovy SPIN imports |
 | `libs/modeler-core/src/scriptTask/domain/scriptLanguage.ts` | `ScriptLanguage` value object — supported formats, extensions, language ids |
 | `libs/modeler-core/src/scriptTask/domain/ScriptUri.ts` | `ScriptUri` value object — encodes the `bpmn-script:/…` URI shape (slug, filename, editor hash) |
 | `apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts` | `openScriptEditorHandler` + `resyncScriptTasksHandler`, dispatched by the BPMN `WebviewMessageRouter` |
@@ -194,7 +195,7 @@ three modes, checked in order:
 |---|---|---|
 | Variable-name completion | Cursor inside the string argument of `getVariable("…` / `setVariable("…` (and `has`/`remove` variants) | Process variables for the owning editor (from `ScriptVariableStore`) |
 | Member completion | Trailing `.` after a known bean or a SPIN-typed variable | Methods rendered as snippets with parameter placeholders |
-| Root completion | Word being typed at root scope | SPIN globals (`scripting.spin`-gated), bean names for the current `kind`, process variables, and local declarations (`collectLocalDeclarations`) |
+| Root completion | Word being typed at root scope | SPIN globals (`scripting.spin`-gated), bean names for the current `kind`, process variables, and local declarations (`collectLocalDeclarations`). In Groovy, SPIN items carry their import as an `additionalTextEdits` insert (`groovyImportInsertionLine` decides placement / already-satisfied), and importable SPIN type names (`SpinJsonNode`) are offered as class completions |
 
 Beans-in-scope are derived from the URI slug via `parseKindFromUri`:
 

--- a/docs/vscode/contributing/architecture/inline-scripting.md
+++ b/docs/vscode/contributing/architecture/inline-scripting.md
@@ -63,10 +63,11 @@ those listeners are what propagate edits and clean up tracking state.
 | `apps/vscode-plugin/src/scriptTask/infrastructure/BpmnScriptFileSystem.ts` | `FileSystemProvider` impl — `Map<string, Uint8Array>` keyed by URI path; fires `FileChangeEvent`s for create / change / delete |
 | `apps/vscode-plugin/src/scriptTask/controller/ScriptTaskService.ts` | Open / track / sync / clean up virtual script documents; URI scheme; format prompt; resync after webview reload |
 | `apps/vscode-plugin/src/scriptTask/controller/ScriptCompletionProvider.ts` | `CompletionItemProvider` scoped to `bpmn-script` scheme; root + member completion modes |
-| `apps/vscode-plugin/src/scriptTask/domain/scriptCompletion.ts` | Pure helpers — `parseKindFromUri`, `matchMemberAccess` (testable without `vscode`) |
-| `apps/vscode-plugin/src/scriptTask/domain/scriptApi.ts` | Camunda 7 bean and method catalogue (`DELEGATE_EXECUTION_METHODS`, `DELEGATE_TASK_METHODS`, `beansFor`) |
-| `apps/vscode-plugin/src/scriptTask/domain/scriptLanguage.ts` | `ScriptLanguage` value object — supported formats, extensions, language ids |
-| `apps/vscode-plugin/src/scriptTask/domain/ScriptUri.ts` | `ScriptUri` value object — encodes the `bpmn-script:/…` URI shape (slug, filename, editor hash) |
+| `libs/modeler-core/src/scriptTask/domain/scriptCompletion.ts` | Pure helpers — `parseKindFromUri`, `matchMemberAccess`, `matchVariableStringArg` (testable without `vscode`) |
+| `libs/modeler-core/src/scriptTask/domain/scriptApi.ts` | Camunda 7 bean and method catalogue (`DELEGATE_EXECUTION_METHODS`, `DELEGATE_TASK_METHODS`, `beansFor`) |
+| `libs/modeler-core/src/scriptTask/domain/localDeclarations.ts` | `collectLocalDeclarations` — slim per-line scan for script-local variable/function declarations |
+| `libs/modeler-core/src/scriptTask/domain/scriptLanguage.ts` | `ScriptLanguage` value object — supported formats, extensions, language ids |
+| `libs/modeler-core/src/scriptTask/domain/ScriptUri.ts` | `ScriptUri` value object — encodes the `bpmn-script:/…` URI shape (slug, filename, editor hash) |
 | `apps/vscode-plugin/src/modeler/bpmn/controller/webview-handlers/bpmnMessageHandlers.ts` | `openScriptEditorHandler` + `resyncScriptTasksHandler`, dispatched by the BPMN `WebviewMessageRouter` |
 | `apps/vscode-plugin/src/modeler/bpmn/controller/editor-participants/ScriptTaskTeardownParticipant.ts` | Calls `disposeForEditor` when the BPMN editor closes |
 | `libs/shared/src/lib/modeler.ts` | `OpenScriptEditorCommand`, `UpdateScriptContentQuery`, `UpdateScriptFormatQuery`, `ScriptKind` |
@@ -186,13 +187,14 @@ sequenceDiagram
 ## Completion provider
 
 `ScriptCompletionProvider` registers for the `bpmn-script` scheme on every
-supported language (`javascript`, `groovy`, `python`, `ruby`). It runs in two
-modes:
+supported language (`javascript`, `groovy`, `python`, `ruby`). It runs in
+three modes, checked in order:
 
 | Mode | Trigger | Returns |
 |---|---|---|
-| Member completion | Trailing `.` after a known bean | Bean's methods rendered as snippets with parameter placeholders |
-| Root completion | Word being typed at root scope | Bean names available in the current `kind` |
+| Variable-name completion | Cursor inside the string argument of `getVariable("…` / `setVariable("…` (and `has`/`remove` variants) | Process variables for the owning editor (from `ScriptVariableStore`) |
+| Member completion | Trailing `.` after a known bean or a SPIN-typed variable | Methods rendered as snippets with parameter placeholders |
+| Root completion | Word being typed at root scope | SPIN globals (`scripting.spin`-gated), bean names for the current `kind`, process variables, and local declarations (`collectLocalDeclarations`) |
 
 Beans-in-scope are derived from the URI slug via `parseKindFromUri`:
 

--- a/docs/vscode/features/inline-scripting.md
+++ b/docs/vscode/features/inline-scripting.md
@@ -137,6 +137,16 @@ variables** the modeler discovered in the diagram. These are inferred
 heuristically from input/output mappings, form fields, result variables,
 call-activity mappings, and `setVariable(…)` / `${…}` occurrences.
 
+### Local script variables
+
+Identifiers you declare in the script body itself are offered at root
+scope too — `def total = …` (Groovy), `let x` / `const x` (JavaScript),
+`x = …` (Python/Ruby), and function declarations like `def helper(…)`.
+Detection is a lightweight per-line heuristic (one declarator per
+statement, no function parameters), not a full parser. Camunda beans and
+process variables win any name clash, so a local never hides an item
+that carries type information and documentation.
+
 ### Declaring variables with a `*.bpmn.vars.json` manifest
 
 Heuristic discovery cannot see variables injected from outside the model

--- a/docs/vscode/features/inline-scripting.md
+++ b/docs/vscode/features/inline-scripting.md
@@ -147,6 +147,29 @@ statement, no function parameters), not a full parser. Camunda beans and
 process variables win any name clash, so a local never hides an item
 that carries type information and documentation.
 
+### Camunda SPIN completions and Groovy auto-import
+
+With the `miragon.bpmnModeler.scripting.spin` setting on (the default),
+the SPIN globals `S(…)` and `JSON(…)` are offered at root scope, and a
+variable the modeler recognises as JSON-typed gets `SpinJsonNode` member
+completions (`prop`, `stringValue`, `mapTo`, …) after its `.`. Disable
+the setting if your project does not have `camunda-spin` on the
+classpath.
+
+In **Groovy** scripts, accepting `S`, `JSON`, or the `SpinJsonNode` type
+name also inserts the matching import — `import static
+org.camunda.spin.Spin.S` and friends — below your last import statement
+(or at the top of the script). The insert is skipped when the import is
+already present, exactly or via a covering wildcard like `import static
+org.camunda.spin.Spin.*`. `SpinJsonNode` itself appears as a class
+completion so typed declarations (`SpinJsonNode node = S(payload)`) are
+one accept away.
+
+> Camunda's script runtime binds the SPIN functions automatically, so a
+> script without the import still runs — the explicit import keeps the
+> script self-contained and lets external Groovy tooling resolve the
+> symbols.
+
 ### Declaring variables with a `*.bpmn.vars.json` manifest
 
 Heuristic discovery cannot see variables injected from outside the model

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -79,6 +79,7 @@ export * from "./template-marketplace/service/TemplateMarketplaceService";
 // ── scriptTask: domain ───────────────────────────────────────────────────────
 export * from "./scriptTask/domain/ScriptUri";
 export * from "./scriptTask/domain/ScriptVariableStore";
+export * from "./scriptTask/domain/localDeclarations";
 export * from "./scriptTask/domain/scriptApi";
 export * from "./scriptTask/domain/scriptCompletion";
 export * from "./scriptTask/domain/scriptLanguage";

--- a/libs/modeler-core/src/index.ts
+++ b/libs/modeler-core/src/index.ts
@@ -79,6 +79,7 @@ export * from "./template-marketplace/service/TemplateMarketplaceService";
 // ── scriptTask: domain ───────────────────────────────────────────────────────
 export * from "./scriptTask/domain/ScriptUri";
 export * from "./scriptTask/domain/ScriptVariableStore";
+export * from "./scriptTask/domain/groovyImports";
 export * from "./scriptTask/domain/localDeclarations";
 export * from "./scriptTask/domain/scriptApi";
 export * from "./scriptTask/domain/scriptCompletion";

--- a/libs/modeler-core/src/scriptTask/domain/groovyImports.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/groovyImports.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { groovyImportInsertionLine } from "./groovyImports";
+
+const SPIN_S = "import static org.camunda.spin.Spin.S";
+const SPIN_JSON_NODE = "import org.camunda.spin.json.SpinJsonNode";
+
+describe("groovyImportInsertionLine", () => {
+    describe("insertion placement", () => {
+        it("targets line 0 for an empty script", () => {
+            expect(groovyImportInsertionLine("", SPIN_S)).toBe(0);
+        });
+
+        it("targets line 0 for a script without imports", () => {
+            expect(groovyImportInsertionLine("def x = S(json)", SPIN_S)).toBe(0);
+        });
+
+        it("targets the line below the last existing import", () => {
+            const script = "import foo.Bar\nimport foo.Baz\n\ndef x = 1";
+            expect(groovyImportInsertionLine(script, SPIN_S)).toBe(2);
+        });
+
+        it("targets below an import that is not on the first line", () => {
+            const script = "// header comment\nimport foo.Bar\ndef x = 1";
+            expect(groovyImportInsertionLine(script, SPIN_S)).toBe(2);
+        });
+
+        it("handles CRLF line endings", () => {
+            expect(groovyImportInsertionLine("import foo.Bar\r\ndef x = 1", SPIN_S)).toBe(1);
+        });
+    });
+
+    describe("already satisfied", () => {
+        it("detects an exact match", () => {
+            expect(groovyImportInsertionLine(`${SPIN_S}\ndef x = S(json)`, SPIN_S)).toBeUndefined();
+        });
+
+        it("tolerates a trailing semicolon", () => {
+            expect(groovyImportInsertionLine(`${SPIN_S};`, SPIN_S)).toBeUndefined();
+        });
+
+        it("tolerates extra whitespace inside the statement", () => {
+            const script = "  import  static   org.camunda.spin.Spin.S  ";
+            expect(groovyImportInsertionLine(script, SPIN_S)).toBeUndefined();
+        });
+
+        it("accepts a covering static wildcard import", () => {
+            const script = "import static org.camunda.spin.Spin.*";
+            expect(groovyImportInsertionLine(script, SPIN_S)).toBeUndefined();
+        });
+
+        it("accepts a covering package wildcard import for a type", () => {
+            const script = "import org.camunda.spin.json.*";
+            expect(groovyImportInsertionLine(script, SPIN_JSON_NODE)).toBeUndefined();
+        });
+    });
+
+    describe("not satisfied by lookalikes", () => {
+        it("is not satisfied by an unrelated import", () => {
+            expect(groovyImportInsertionLine("import foo.Bar", SPIN_S)).toBe(1);
+        });
+
+        it("is not satisfied by the sibling symbol from the same class", () => {
+            const script = "import static org.camunda.spin.Spin.JSON";
+            expect(groovyImportInsertionLine(script, SPIN_S)).toBe(1);
+        });
+
+        it("is not satisfied by a commented-out import", () => {
+            expect(groovyImportInsertionLine(`// ${SPIN_S}`, SPIN_S)).toBe(0);
+        });
+    });
+});

--- a/libs/modeler-core/src/scriptTask/domain/groovyImports.ts
+++ b/libs/modeler-core/src/scriptTask/domain/groovyImports.ts
@@ -1,0 +1,58 @@
+/**
+ * Placement logic for auto-inserted Groovy import statements, feeding the
+ * completion provider's `additionalTextEdits` for SPIN symbols.
+ *
+ * Camunda's `SpinScriptEnv` prepends the SPIN static import at runtime, so a
+ * script *runs* without one — but the source is then not self-contained and
+ * external Groovy tooling cannot resolve the symbol. Completion therefore
+ * offers the import, and this helper decides whether it is already satisfied
+ * and, if not, on which line it belongs.
+ *
+ * Line-based like {@link collectLocalDeclarations}: an import statement inside
+ * a block comment or multiline string can false-positive as satisfied
+ * (accepted — the cost is a missing import the author can add by hand).
+ */
+
+// Trailing `;`, leading/trailing space, and internal whitespace runs are all
+// legal Groovy variance of the same import — normalize before comparing.
+function normalize(line: string): string {
+    return line.trim().replace(/;$/, "").trimEnd().replace(/\s+/g, " ");
+}
+
+/**
+ * The wildcard form that also satisfies the import: the last dotted segment
+ * (the imported symbol) replaced by `*` — `import static org.camunda.spin.Spin.S`
+ * is covered by `import static org.camunda.spin.Spin.*`.
+ */
+function wildcardForm(normalizedImport: string): string {
+    return normalizedImport.replace(/\.[A-Za-z_$][\w$]*$/, ".*");
+}
+
+/**
+ * Returns the 0-based line at which `importStatement` should be inserted into
+ * `scriptText`, or `undefined` when the script already satisfies it (exact
+ * normalized match or a covering wildcard import). New imports go directly
+ * below the last existing import so a growing import block stays contiguous;
+ * a script without imports gets it on line 0.
+ */
+export function groovyImportInsertionLine(
+    scriptText: string,
+    importStatement: string,
+): number | undefined {
+    const wanted = normalize(importStatement);
+    const wildcard = wildcardForm(wanted);
+
+    let lastImportLine = -1;
+    const lines = scriptText.split(/\r?\n/);
+    for (let line = 0; line < lines.length; line++) {
+        if (!/^\s*import\b/.test(lines[line])) {
+            continue;
+        }
+        const found = normalize(lines[line]);
+        if (found === wanted || found === wildcard) {
+            return undefined;
+        }
+        lastImportLine = line;
+    }
+    return lastImportLine + 1;
+}

--- a/libs/modeler-core/src/scriptTask/domain/localDeclarations.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/localDeclarations.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import { collectLocalDeclarations, LocalDeclaration } from "./localDeclarations";
+
+const names = (declarations: LocalDeclaration[]): string[] => declarations.map((decl) => decl.name);
+
+describe("collectLocalDeclarations", () => {
+    describe("groovy", () => {
+        it("collects a def declaration with initializer", () => {
+            expect(collectLocalDeclarations("def total = 1", "groovy")).toEqual([
+                { name: "total", line: 0, kind: "variable" },
+            ]);
+        });
+
+        it("collects a bare def declaration without initializer", () => {
+            expect(names(collectLocalDeclarations("def x", "groovy"))).toEqual(["x"]);
+        });
+
+        it("collects typed declarations, including generics", () => {
+            const script = 'String name = "x"\nList<String> xs = []';
+            expect(names(collectLocalDeclarations(script, "groovy"))).toEqual(["name", "xs"]);
+        });
+
+        it("classifies a def method as a function, not a variable", () => {
+            expect(collectLocalDeclarations("def helper() {", "groovy")).toEqual([
+                { name: "helper", line: 0, kind: "function" },
+            ]);
+        });
+
+        it("ignores a comparison that only looks like a declaration", () => {
+            expect(collectLocalDeclarations("def x == y", "groovy")).toEqual([]);
+        });
+
+        it("skips commented-out declarations", () => {
+            const script = "// def ghost = 1\n/* def spectre = 2 */\n * def phantom = 3";
+            expect(collectLocalDeclarations(script, "groovy")).toEqual([]);
+        });
+
+        it("yields nothing for plain statements", () => {
+            expect(collectLocalDeclarations('execution.setVariable("a", 1)', "groovy")).toEqual([]);
+        });
+
+        it("dedups a re-declared name to its first line, preserving order", () => {
+            const script = "def total = 1\ndef other = 2\ndef total = 3";
+            expect(collectLocalDeclarations(script, "groovy")).toEqual([
+                { name: "total", line: 0, kind: "variable" },
+                { name: "other", line: 1, kind: "variable" },
+            ]);
+        });
+    });
+
+    describe("javascript", () => {
+        it("collects var, let and const declarations", () => {
+            const script = "var a = 1\nlet b = 2\nconst c = 3";
+            expect(names(collectLocalDeclarations(script, "javascript"))).toEqual(["a", "b", "c"]);
+        });
+
+        it("classifies function declarations, async included", () => {
+            const script = "function fmt(x) {}\nasync function load() {}";
+            expect(collectLocalDeclarations(script, "javascript")).toEqual([
+                { name: "fmt", line: 0, kind: "function" },
+                { name: "load", line: 1, kind: "function" },
+            ]);
+        });
+
+        it("collects only the first declarator of a multi-declaration (accepted gap)", () => {
+            expect(names(collectLocalDeclarations("let a, b", "javascript"))).toEqual(["a"]);
+        });
+    });
+
+    describe("python", () => {
+        it("collects assignments, indented ones included", () => {
+            const script = "x = 1\n    y = 2";
+            expect(names(collectLocalDeclarations(script, "python"))).toEqual(["x", "y"]);
+        });
+
+        it("ignores comparisons and comments", () => {
+            const script = "x == 1\n# x = 1";
+            expect(collectLocalDeclarations(script, "python")).toEqual([]);
+        });
+
+        it("classifies def as a function", () => {
+            expect(collectLocalDeclarations("def handle(msg):", "python")).toEqual([
+                { name: "handle", line: 0, kind: "function" },
+            ]);
+        });
+
+        it("never suggests a stop-word capture from malformed input", () => {
+            expect(collectLocalDeclarations("if = 1", "python")).toEqual([]);
+        });
+    });
+
+    describe("ruby", () => {
+        it("collects assignments but not comparisons", () => {
+            const script = "x = 1\ny == 2";
+            expect(names(collectLocalDeclarations(script, "ruby"))).toEqual(["x"]);
+        });
+
+        it("ignores hash rockets inside a literal but keeps the assignment", () => {
+            expect(names(collectLocalDeclarations('h = { "a" => 1 }', "ruby"))).toEqual(["h"]);
+        });
+
+        it("classifies def as a function", () => {
+            expect(collectLocalDeclarations("def handle", "ruby")).toEqual([
+                { name: "handle", line: 0, kind: "function" },
+            ]);
+        });
+    });
+
+    it("returns nothing for an unknown language id", () => {
+        expect(collectLocalDeclarations("def x = 1", "plaintext")).toEqual([]);
+    });
+
+    it("returns nothing for empty text", () => {
+        expect(collectLocalDeclarations("", "groovy")).toEqual([]);
+    });
+
+    it("handles CRLF line endings with correct line numbers", () => {
+        expect(collectLocalDeclarations("def a = 1\r\ndef b = 2", "groovy")).toEqual([
+            { name: "a", line: 0, kind: "variable" },
+            { name: "b", line: 1, kind: "variable" },
+        ]);
+    });
+});

--- a/libs/modeler-core/src/scriptTask/domain/localDeclarations.ts
+++ b/libs/modeler-core/src/scriptTask/domain/localDeclarations.ts
@@ -1,0 +1,132 @@
+/**
+ * Lexical scan for identifiers declared in an inline script body, feeding the
+ * root-completion mode of the script completion provider.
+ *
+ * VS Code's suggest model is winner-takes-all by provider group: because the
+ * script provider always returns root items (the Camunda beans at minimum),
+ * the built-in word-based provider — which would otherwise complete a local
+ * `def myVar` — is never consulted. Locals therefore have to come from us.
+ *
+ * This is a deliberately slim, line-based fallback, not a parser: inline
+ * scripts are short snippets, and once scripts live on disk (#1219) external
+ * language servers own general language intelligence. Known, accepted gaps:
+ * multi-declarators (`def a, b`), destructuring, dotted type names
+ * (`java.util.List x`), function parameters, and declaration-shaped text
+ * inside block comments or multiline strings.
+ */
+
+/** A single identifier declared in the script body. */
+export interface LocalDeclaration {
+    readonly name: string;
+    /**
+     * 0-based line of the first declaration — lets the provider suppress a
+     * declaration completing itself while it is being typed.
+     */
+    readonly line: number;
+    readonly kind: "variable" | "function";
+}
+
+interface DeclarationMatcher {
+    readonly kind: LocalDeclaration["kind"];
+    // Capture group 1 is the declared name.
+    readonly pattern: RegExp;
+}
+
+// Keywords a loose assignment pattern could capture (`if = …` in a mangled
+// script, ruby `end`, …). Cheap insurance across all four languages.
+const STOP_WORDS = new Set([
+    "if",
+    "for",
+    "while",
+    "return",
+    "def",
+    "else",
+    "end",
+    "true",
+    "false",
+    "null",
+    "nil",
+    "new",
+    "in",
+    "case",
+]);
+
+// A line whose first non-whitespace chars open a comment is skipped entirely.
+// `*` catches the continuation lines of javadoc-style block comments.
+const COMMENT_OPENERS: Record<string, readonly string[]> = {
+    groovy: ["//", "/*", "*"],
+    javascript: ["//", "/*", "*"],
+    python: ["#"],
+    ruby: ["#"],
+};
+
+/**
+ * Matchers per VS Code language id (see `ScriptLanguage.MAPPINGS`). Function
+ * patterns come first: a Groovy `def helper(` must classify as a function
+ * before the variable pattern gets a chance to consider the same line.
+ */
+const MATCHERS: Record<string, readonly DeclarationMatcher[]> = {
+    groovy: [
+        { kind: "function", pattern: /^\s*(?:def|[A-Z]\w*(?:<[^>]*>)?)\s+([A-Za-z_$][\w$]*)\s*\(/ },
+        // `=(?!=)` keeps comparisons (`def x == y` noise) out; `;|$` accepts a
+        // bare `def x` declaration without initializer.
+        { kind: "variable", pattern: /^\s*(?:def|final)\s+([A-Za-z_$][\w$]*)\s*(?:=(?!=)|;|$)/ },
+        // Typed declaration (`String x = …`). The initializer is required so a
+        // stray `Foo bar` expression line doesn't register a variable.
+        { kind: "variable", pattern: /^\s*[A-Z]\w*(?:<[^>]*>)?\s+([A-Za-z_$][\w$]*)\s*=(?!=)/ },
+    ],
+    javascript: [
+        { kind: "function", pattern: /^\s*(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(/ },
+        // First declarator only; `let a, b` yields just `a` (accepted gap).
+        { kind: "variable", pattern: /^\s*(?:var|let|const)\s+([A-Za-z_$][\w$]*)/ },
+    ],
+    python: [
+        { kind: "function", pattern: /^\s*def\s+([A-Za-z_]\w*)\s*\(/ },
+        { kind: "variable", pattern: /^\s*([A-Za-z_]\w*)\s*=(?!=)/ },
+    ],
+    ruby: [
+        { kind: "function", pattern: /^\s*def\s+([a-z_]\w*[!?]?)\b/ },
+        // The lookahead rejects `==`, `=~`, and hash-rocket `=>` lines.
+        { kind: "variable", pattern: /^\s*([a-z_]\w*)\s*=(?![=~>])/ },
+    ],
+};
+
+/**
+ * Collects the identifiers declared in `scriptText` for the given VS Code
+ * language id. Duplicate names collapse to their first declaration (stable
+ * completion order, and the self-suppression line stays the earliest one).
+ * Unknown language ids yield `[]` so a `plaintext` fallback tab stays silent.
+ */
+export function collectLocalDeclarations(
+    scriptText: string,
+    languageId: string,
+): LocalDeclaration[] {
+    const matchers = MATCHERS[languageId];
+    if (!matchers) {
+        return [];
+    }
+    const commentOpeners = COMMENT_OPENERS[languageId] ?? [];
+
+    const byName = new Map<string, LocalDeclaration>();
+    const lines = scriptText.split(/\r?\n/);
+    for (let line = 0; line < lines.length; line++) {
+        const text = lines[line];
+        const trimmed = text.trimStart();
+        if (commentOpeners.some((opener) => trimmed.startsWith(opener))) {
+            continue;
+        }
+        for (const { kind, pattern } of matchers) {
+            const match = pattern.exec(text);
+            if (!match) {
+                continue;
+            }
+            const name = match[1];
+            if (!STOP_WORDS.has(name) && !byName.has(name)) {
+                byName.set(name, { name, line, kind });
+            }
+            // One declaration per line: the first (most specific) matcher wins.
+            break;
+        }
+    }
+    return [...byName.values()];
+}

--- a/libs/modeler-core/src/scriptTask/domain/scriptApi.spec.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptApi.spec.ts
@@ -24,11 +24,23 @@ describe("globalFunctionsFor", () => {
         const globals = globalFunctionsFor("script-task");
         expect(globals.every((fn) => fn.returnType === "SpinJsonNode")).toBe(true);
     });
+
+    it("carries the groovy static import for each SPIN global", () => {
+        const byName = new Map(globalFunctionsFor("script-task").map((fn) => [fn.name, fn]));
+        expect(byName.get("S")?.groovyImport).toBe("import static org.camunda.spin.Spin.S");
+        expect(byName.get("JSON")?.groovyImport).toBe("import static org.camunda.spin.Spin.JSON");
+    });
 });
 
 describe("SpinJsonNode catalog entry", () => {
     it("is registered in COMPLEX_TYPES so 2c can resolve a typeHint", () => {
         expect(COMPLEX_TYPES.some((type) => type.name === "SpinJsonNode")).toBe(true);
+    });
+
+    it("is the only complex type carrying a groovy import (context beans need none)", () => {
+        const importable = COMPLEX_TYPES.filter((type) => type.groovyImport);
+        expect(importable.map((type) => type.name)).toEqual(["SpinJsonNode"]);
+        expect(importable[0].groovyImport).toBe("import org.camunda.spin.json.SpinJsonNode");
     });
 
     it("resolves its methods through methodsForBean for a SpinJsonNode-typed bean", () => {

--- a/libs/modeler-core/src/scriptTask/domain/scriptApi.ts
+++ b/libs/modeler-core/src/scriptTask/domain/scriptApi.ts
@@ -37,12 +37,20 @@ export interface MethodDef {
 
 /**
  * A global function callable at script root with no receiver (e.g. Camunda
- * SPIN's `S(…)` / `JSON(…)`). Structurally identical to {@link MethodDef} —
- * the distinction is purely positional: a {@link MethodDef} is reached through
+ * SPIN's `S(…)` / `JSON(…)`). Structurally a {@link MethodDef} — the
+ * distinction is purely positional: a {@link MethodDef} is reached through
  * `<receiver>.method(…)`, a `GlobalFunctionDef` is reached bare. Sharing the
  * shape keeps a single renderer and one snippet convention.
  */
-export type GlobalFunctionDef = MethodDef;
+export interface GlobalFunctionDef extends MethodDef {
+    /**
+     * Groovy import statement that makes the bare symbol resolvable. Camunda's
+     * `SpinScriptEnv` prepends the SPIN static import at runtime, so scripts run
+     * without it — completion still offers to insert it so the script is
+     * self-contained and external Groovy tooling can resolve the symbol.
+     */
+    readonly groovyImport?: string;
+}
 
 /**
  * Describes a complex Camunda type (e.g. `DelegateExecution`) — the bag
@@ -55,6 +63,10 @@ export interface TypeDef {
     readonly description: string;
     // Methods callable on instances of this type.
     readonly methods: readonly MethodDef[];
+    // Groovy import that resolves the bare type name (see
+    // GlobalFunctionDef.groovyImport). Absent for context-injected types like
+    // DelegateExecution that scripts never name explicitly.
+    readonly groovyImport?: string;
 }
 
 /**
@@ -333,6 +345,7 @@ const SPIN_JSON_NODE_TYPE: TypeDef = {
     name: "SpinJsonNode",
     description: "Camunda SPIN wrapper for reading and writing JSON variables.",
     methods: SPIN_JSON_NODE_METHODS,
+    groovyImport: "import org.camunda.spin.json.SpinJsonNode",
 };
 
 const DELEGATE_EXECUTION_TYPE: TypeDef = {
@@ -431,12 +444,14 @@ const SPIN_GLOBAL_FUNCTIONS: readonly GlobalFunctionDef[] = [
         params: [{ name: "input", type: "Object" }],
         returnType: "SpinJsonNode",
         description: "Camunda SPIN: wraps a JSON string or value as a SpinJsonNode.",
+        groovyImport: "import static org.camunda.spin.Spin.S",
     },
     {
         name: "JSON",
         params: [{ name: "input", type: "Object" }],
         returnType: "SpinJsonNode",
         description: "Camunda SPIN: parses a JSON string or value into a SpinJsonNode.",
+        groovyImport: "import static org.camunda.spin.Spin.JSON",
     },
 ];
 

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.spec.ts
@@ -101,6 +101,62 @@ describe("ScriptVariableManifestService", () => {
         expect(await service(ws).load(DOCUMENT)).toEqual([]);
     });
 
+    it("resolves the manifest path under <configFolder>/vars/ mirroring the diagram path", async () => {
+        expect(await service(ws).resolveManifestPath(DOCUMENT)).toBe(MANIFEST_PATH);
+    });
+
+    describe("loadWithStatus", () => {
+        it("reports found: true with the variables when the manifest is present", async () => {
+            ws.files.set(
+                MANIFEST_PATH,
+                JSON.stringify({ variables: [{ name: "orderId", type: "String" }] }),
+            );
+
+            const result = await service(ws).loadWithStatus(DOCUMENT);
+
+            expect(result).toEqual({
+                manifestPath: MANIFEST_PATH,
+                found: true,
+                variables: [
+                    {
+                        name: "orderId",
+                        origin: "declared in diagram.bpmn.vars.json",
+                        typeHint: "String",
+                        description: undefined,
+                        confidence: "authored",
+                    },
+                ],
+            });
+        });
+
+        it("reports found: false with [] when the manifest is absent", async () => {
+            expect(await service(ws).loadWithStatus(DOCUMENT)).toEqual({
+                manifestPath: MANIFEST_PATH,
+                found: false,
+                variables: [],
+            });
+        });
+
+        it("reports found: true with [] for a malformed manifest (present but unparseable)", async () => {
+            ws.files.set(MANIFEST_PATH, "{ not json");
+
+            expect(await service(ws).loadWithStatus(DOCUMENT)).toEqual({
+                manifestPath: MANIFEST_PATH,
+                found: true,
+                variables: [],
+            });
+        });
+    });
+
+    it("propagates a non-FileNotFound read error from load and loadWithStatus", async () => {
+        // Pins the contract this fix hangs on: only FileNotFound means "no
+        // manifest"; a real read failure must reach the host to be surfaced.
+        ws.readFile = () => Promise.reject(new Error("EACCES"));
+
+        await expect(service(ws).load(DOCUMENT)).rejects.toThrow(/EACCES/);
+        await expect(service(ws).loadWithStatus(DOCUMENT)).rejects.toThrow(/EACCES/);
+    });
+
     it("watches the config folder for the manifest path", async () => {
         const onChange = vi.fn();
         await service(ws).createWatcher(DOCUMENT, onChange);

--- a/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
+++ b/libs/modeler-core/src/scriptTask/service/ScriptVariableManifestService.ts
@@ -14,6 +14,18 @@ import { ArtifactService } from "../../shared/service/ArtifactService";
 const VARS_DIR = "vars";
 
 /**
+ * The outcome of a manifest load, carrying the resolved lookup path so hosts can
+ * log *where* the extension looked — the most common trip (a mislocated
+ * manifest) is otherwise undebuggable.
+ */
+export interface ManifestLoadResult {
+    readonly manifestPath: string;
+    /** `false` when no manifest file exists; a present-but-malformed manifest is `found: true` with `[]`. */
+    readonly found: boolean;
+    readonly variables: VariableDef[];
+}
+
+/**
  * Reads (and watches) the `*.bpmn.vars.json` process-variable manifest, turning
  * it into the `authored`-tier variable model that overrides heuristic
  * extraction. Both hosts reuse it because it depends only on the shared
@@ -50,19 +62,36 @@ export class ScriptVariableManifestService {
      * propagate, so the host can surface them.
      */
     async load(documentPath: string): Promise<VariableDef[]> {
-        const manifestPath = await this.manifestPathFor(documentPath);
+        return (await this.loadWithStatus(documentPath)).variables;
+    }
+
+    /**
+     * Status-carrying variant of {@link load}: returns the resolved
+     * `manifestPath` and whether a file was `found`, so a host can log the
+     * lookup location and distinguish "no manifest" from "loaded N variables".
+     * `load` delegates here (single read, no double-parse).
+     *
+     * `FileNotFound` degrades to `{ found: false, variables: [] }`; any other
+     * read error propagates so the host can surface it.
+     */
+    async loadWithStatus(documentPath: string): Promise<ManifestLoadResult> {
+        const manifestPath = await this.resolveManifestPath(documentPath);
         let jsonText: string;
         try {
             jsonText = await this.workspace.readFile(manifestPath);
         } catch (error) {
             if (error instanceof FileNotFound) {
-                return [];
+                return { manifestPath, found: false, variables: [] };
             }
             throw error;
         }
         // The origin label uses the bare manifest basename, unchanged by the
         // relocation (`order.bpmn.vars.json`), so origin strings stay stable.
-        return parseVariableManifest(jsonText, posix.basename(manifestPath));
+        return {
+            manifestPath,
+            found: true,
+            variables: parseVariableManifest(jsonText, posix.basename(manifestPath)),
+        };
     }
 
     /**
@@ -79,7 +108,7 @@ export class ScriptVariableManifestService {
      * clobbering hand-edited content the author would lose.
      */
     async upsert(documentPath: string, entry: VariableManifestEntry): Promise<string> {
-        const manifestPath = await this.manifestPathFor(documentPath);
+        const manifestPath = await this.resolveManifestPath(documentPath);
         const manifest = await this.readRawManifest(manifestPath);
 
         if (!manifest.variables.some((existing) => existing.name === entry.name)) {
@@ -125,7 +154,7 @@ export class ScriptVariableManifestService {
     async createWatcher(documentPath: string, onChange: () => void): Promise<{ dispose(): void }> {
         const documentDir = this.workspace.getDocumentDirectory(documentPath);
         const workspaceRoot = await this.artifactSvc.getWorkspaceRoot(documentDir);
-        const manifestPath = await this.manifestPathFor(documentPath);
+        const manifestPath = await this.resolveManifestPath(documentPath);
         // The chokidar/node adapter anchors the glob (`^…$`) and matches against
         // absolute paths, so a root-relative glob must be prefixed `**/` to match
         // the bridge the same way VS Code does (the template watcher does the same).
@@ -140,8 +169,11 @@ export class ScriptVariableManifestService {
     /**
      * `<root>/src/foo.bpmn` → `<root>/<configFolder>/vars/src/foo.bpmn.vars.json`,
      * mirroring the diagram's workspace-relative path under the config folder.
+     *
+     * Public so hosts can log/inspect the exact lookup location — a mislocated
+     * manifest is the most common trip and is otherwise undebuggable.
      */
-    private async manifestPathFor(documentPath: string): Promise<string> {
+    async resolveManifestPath(documentPath: string): Promise<string> {
         // Compute everything in the `uri.path` space `getDocumentDirectory`
         // returns: on Windows the raw `documentPath` is `fsPath` (`c:\a\b`) while
         // the directory is `uri.path` (`/c:/a/b`), so a relative path derived

--- a/libs/shared/src/lib/variableManifest.ts
+++ b/libs/shared/src/lib/variableManifest.ts
@@ -1,9 +1,15 @@
 /**
  * Pure, dependency-free parser for a `*.bpmn.vars.json` manifest — the explicit,
- * author-written override that sits next to a diagram and declares process
- * variables the heuristic extraction (see {@link import("./processVariables")})
- * can't see: variables injected from outside the model (REST start, message
- * correlation, a parent process) plus author-supplied types and docs.
+ * author-written override that declares process variables the heuristic
+ * extraction (see {@link import("./processVariables")}) can't see: variables
+ * injected from outside the model (REST start, message correlation, a parent
+ * process) plus author-supplied types and docs.
+ *
+ * The manifest lives at
+ * `<workspaceRoot>/<configFolder>/vars/<workspace-relative-diagram-path>.vars.json`
+ * (config folder defaults to `.camunda`, overridable via the
+ * `miragon.bpmnModeler.configFolder` setting) — never beside the diagram. Path
+ * resolution lives in `ScriptVariableManifestService.resolveManifestPath`.
  *
  * The parser deliberately never throws. A malformed or hand-edited manifest must
  * not break completion for the whole diagram, so any structural problem (bad


### PR DESCRIPTION
**Issue**

Relates to #1219 — all three changes are listed there as pre-migration groundwork.

**Description**

Three independent improvements to inline-script IntelliSense, one commit each. **Manifest robustness (fix):** `VsCodeWorkspace.readFile` no longer coerces every fs rejection to `FileNotFound` (only genuinely missing files), so a real read error on a `*.bpmn.vars.json` manifest surfaces instead of silently yielding zero variables; the participant now logs the resolved manifest path (found / not found) via the new `ScriptVariableManifestService.loadWithStatus`, and the misleading `variableManifest.ts` docstring points to the real `<configFolder>/vars/…` location. **Local-declaration completion (feat):** VS Code's winner-takes-all suggest model starves word-based suggestions whenever our provider returns items, so `def myVar` never completed — root completion now includes a slim per-language lexical scan (`collectLocalDeclarations`, groovy/js/python/ruby); beans, process variables, and SPIN globals win name clashes, and a declaration is not suggested to itself. **Groovy SPIN auto-import (feat):** accepting `S`, `JSON`, or the new `SpinJsonNode` class completion in a Groovy script inserts the matching import below the last existing import (skipped when an exact or wildcard import already covers it, via the pure `groovyImportInsertionLine` helper); Camunda's `SpinScriptEnv` binds the globals at runtime either way, so the import is about self-containedness and external-tooling resolvability. All heuristics are deliberately minimal by design pending #1219, where external language servers take over general language intelligence.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
