### PR TITLE
chore(agent): refresh stale settings, docs and gitignore

### DIFF
--- a/.agent/AGENT.md
+++ b/.agent/AGENT.md
@@ -6,7 +6,8 @@ This file provides guidance to AI coding agents when working with code in this r
 
 VS Code extension for BPMN/DMN process modeling, built with **Yarn 4 workspaces**.
 Detailed architecture knowledge is available via skills — invoke `/architecture`,
-`/bpmn-js`, `/vscode-custom-editors`, `/vscode-webviews`, or `/vscode-ux-guidelines`.
+`/bpmn-js`, `/vscode-custom-editors`, `/vscode-webviews`, `/vscode-ux-guidelines`,
+`/intellij-plugin`, `/i18n-translate`, or `/bpmn-browser-testing`.
 
 ## Commands
 
@@ -29,7 +30,7 @@ corepack yarn workspace vs-code-bpmn-modeler build
 corepack yarn workspace @miragon/bpmn-modeler-webview build
 
 # Run a single test file
-corepack yarn test apps/vscode-plugin/src/shared/domain/BpmnDocument.spec.ts
+corepack yarn test libs/modeler-core/src/shared/domain/BpmnDocument.spec.ts
 ```
 
 For the full IntelliJ dev/verify loop (prerequisites, sandbox behaviour, and how
@@ -65,9 +66,20 @@ apps/
   bpmn-webview/          # BPMN webview frontend (Vite/browser)
   dmn-webview/           # DMN webview frontend (Vite/browser)
   deployment-webview/    # Deployment sidebar webview (Vite/browser)
+  intellij-plugin/       # IntelliJ host (Kotlin/Gradle, JCEF editors)
+  modeler-bridge/        # stdio JSON-RPC Bun binary running modeler-core
+                         # out-of-process for the IntelliJ host
   standalone/            # Theia/Electron desktop host shell
 libs/
+  modeler-core/          # Host-agnostic engine core (domain/service/
+                         # infrastructure), consumed by all hosts (ADR #1060)
   shared/                # Shared webview utilities and message types
+  append-menu/           # bpmn-js append-menu module
+  bpmn-clipboard/        # bpmn-js clipboard modules
+  bpmn-i18n/             # BPMN/DMN i18n
+  code-link/             # Code-link feature
+  element-template-chooser/ # Element-template chooser module
+  model-navigation/      # Model navigation module
   standalone-extension/  # Theia frontend extension consumed by
                          # `apps/standalone/` (Miragon themes, splash,
                          # hidden built-in views)
@@ -84,13 +96,25 @@ build → package plugin → bundle → start chain.
 ## Build System
 
 - **Extension host**: Webpack + `ts-loader` — `apps/vscode-plugin/webpack.config.js`
-- **Webviews**: Vite — `apps/{bpmn,dmn}-webview/vite.config.mts`
-- **Tests**: Vitest — `apps/vscode-plugin/vitest.config.ts`
+- **Webviews**: Vite — `apps/{bpmn,dmn,deployment}-webview/vite.config.mts`
+- **Tests**: Vitest — root `vitest.config.ts` aggregates per-workspace projects
+  (vscode-plugin, modeler-bridge, bpmn-webview, bpmn-i18n,
+  element-template-chooser, modeler-core, shared); root `test` =
+  `vitest run --coverage`
 - **Output**: `dist/apps/vscode-plugin/`
 
 ## Path Aliases (`tsconfig.base.json`)
 
-- `@miragon/bpmn-modeler-shared` → `libs/shared/src/index.ts`
+Each `@miragon/...` alias maps to `libs/<dir>/src/index.ts`:
+
+- `@miragon/bpmn-modeler-shared` → `libs/shared`
+- `@miragon/bpmn-modeler-core` → `libs/modeler-core`
+- `@miragon/bpmn-modeler-clipboard` → `libs/bpmn-clipboard`
+- `@miragon/bpmn-modeler-i18n` → `libs/bpmn-i18n`
+- `@miragon/bpmn-modeler-element-template-chooser` → `libs/element-template-chooser`
+- `@miragon/bpmn-modeler-append-menu` → `libs/append-menu`
+- `@miragon/bpmn-model-navigation` → `libs/model-navigation`
+- `@miragon/bpmn-modeler-code-link` → `libs/code-link`
 - Resolved by `TsconfigPathsPlugin` (webpack) and `vite-tsconfig-paths` (Vite)
 
 ## Configuration Namespace

--- a/.agent/settings.json
+++ b/.agent/settings.json
@@ -1,10 +1,8 @@
 {
-  "plugins": [".claude/plugins/miranum-ide"],
   "attribution": {
     "commit": "",
     "pr": ""
   },
-  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
       "mcp__plugin_playwright_playwright__browser_navigate",
@@ -12,7 +10,7 @@
       "mcp__plugin_playwright_playwright__browser_click",
       "mcp__plugin_playwright_playwright__browser_drag",
       "mcp__plugin_playwright_playwright__browser_take_screenshot",
-      "mcp__plugin_playwright_playwright__browser_run_code",
+      "mcp__plugin_playwright_playwright__browser_run_code_unsafe",
       "mcp__plugin_playwright_playwright__browser_type",
       "mcp__plugin_playwright_playwright__browser_fill_form",
       "mcp__plugin_playwright_playwright__browser_hover",

--- a/.agent/skills/architecture/SKILL.md
+++ b/.agent/skills/architecture/SKILL.md
@@ -145,7 +145,7 @@ The deployment subsystem uses ports & adapters to decouple business logic from e
 
 **Benefit**: `DeploymentService` / `StartInstanceService` depend only on `CamundaEnginePort`. Adding a new engine version is a new adapter, no service change.
 
-> Note the two distinct port families (both in the core): `shared/domain/hostPorts.ts` (10 interfaces) abstracts the *host* (VS Code / IntelliJ) facilities; `deployment/domain/ports.ts` abstracts the *Camunda engine*. Each host provides its own adapter set — `VsCode*` in the plugin, RPC-backed adapters in the bridge.
+> Note the two distinct port families (both in the core): `shared/domain/hostPorts.ts` (13 interfaces) abstracts the *host* (VS Code / IntelliJ) facilities; `deployment/domain/ports.ts` abstracts the *Camunda engine*. Each host provides its own adapter set — `VsCode*` in the plugin, RPC-backed adapters in the bridge.
 
 ## Composition wiring (`main.ts` + `composition/`)
 

--- a/.agent/skills/bpmn-browser-testing/SKILL.md
+++ b/.agent/skills/bpmn-browser-testing/SKILL.md
@@ -151,7 +151,7 @@ Expect these console messages in dev mode — they are not errors in your workfl
 
 ```
 1. browser_snapshot → find "Create task" ref → click it
-2. browser_run_code → page.mouse.click(250, 350) to place on canvas
+2. browser_run_code_unsafe → page.mouse.click(250, 350) to place on canvas
 3. browser_snapshot → find "Change element" ref → click it
 4. browser_snapshot → find "Service task" ref → click it
 5. browser_snapshot → expand "Task definition" → fill in job type

--- a/.agent/skills/intellij-plugin/SKILL.md
+++ b/.agent/skills/intellij-plugin/SKILL.md
@@ -55,7 +55,7 @@ corepack yarn workspace @miragon/bpmn-modeler-bridge compile
 
 Other Gradle tasks: `./gradlew build`, `./gradlew verifyPlugin` (binary-
 compatibility gate). Versions are pinned in `build.gradle.kts` (IntelliJ
-Platform Gradle Plugin `2.5.0`) and `gradle.properties` (`ideaVersion=2024.2.5`,
+Platform Gradle Plugin `2.17.0`) and `gradle.properties` (`ideaVersion=2024.2.5`,
 JCEF requires 2024.2+); bump to a locally available combo if resolution fails.
 This subproject is **not** a yarn workspace (no `package.json`), so the JS
 lint/tsc globs never touch the Kotlin sources.

--- a/.agent/skills/vscode-custom-editors/SKILL.md
+++ b/.agent/skills/vscode-custom-editors/SKILL.md
@@ -93,8 +93,8 @@ Both editors share `ModelerEditorController`; the difference is purely in the `o
 
 | Concern | BPMN editor | DMN editor |
 |---|---|---|
-| **Router handlers** | full set (get-file, element-templates, settings + script resync, properties-panel get/set, structured + text clipboard, sync, open-script-editor, navigate-to-referenced-model) | 2 (`GetDmnFileCommand`, `SyncDocumentCommand`) |
-| **Participants** | `BpmnRenderParticipant`, `ElementTemplatesParticipant`, `SettingsParticipant`, `EngineVersionStatusBarParticipant`, `ScriptTaskTeardownParticipant` | `DmnRenderParticipant` only |
+| **Router handlers** | full set (get-file, element-templates, settings + script resync, properties-panel get/set, structured + text clipboard, sync, open-script-editor, navigate-to-referenced-model) | 5 (`GetDmnFileCommand`, `GetDmnModelerSettingCommand`, `GetPropertiesPanelStateCommand`, `SetPropertiesPanelStateCommand`, `SyncDocumentCommand`) |
+| **Participants** | `BpmnRenderParticipant`, `ElementTemplatesParticipant`, `BpmnlintParticipant`, `SettingsParticipant`, `EngineVersionStatusBarParticipant`, `ScriptTaskTeardownParticipant`, `ScriptManifestParticipant`, `CodeLinkParticipant` | `DmnRenderParticipant`, `DmnSettingsParticipant` |
 | **Diff delegation** | yes (`delegateResolve` → `BpmnDiffController`) | no |
 
 DMN files don't use element templates, BPMN settings, inline scripts, or the diff viewer, so the DMN editor simply gets fewer handlers and one participant.

--- a/.agent/skills/vscode-ux-guidelines/SKILL.md
+++ b/.agent/skills/vscode-ux-guidelines/SKILL.md
@@ -94,11 +94,17 @@ Webviews run in sandboxed iframes without `clipboard-read`/`clipboard-write` per
 
 Defined in `libs/shared/src/lib/modeler.ts`:
 
+Two separate host round-trips — **element** clipboard (BPMN shapes as JSON) and
+**text** clipboard (labels, FEEL editor):
+
 | Message | Direction | Purpose |
 |---------|-----------|---------|
-| `GetClipboardCommand` | webview → extension host | Request to read system clipboard |
-| `SetClipboardCommand(text)` | webview → extension host | Request to write text to system clipboard |
-| `ClipboardQuery(text)` | extension host → webview | Response with clipboard content |
+| `GetClipboardCommand` | webview → extension host | Request to read system clipboard (element) |
+| `SetClipboardCommand(text)` | webview → extension host | Request to write element JSON to system clipboard |
+| `ClipboardQuery(text)` | extension host → webview | Response with element clipboard content |
+| `GetTextClipboardCommand` | webview → extension host | Request to read system clipboard (text) |
+| `SetTextClipboardCommand(text)` | webview → extension host | Request to write text to system clipboard |
+| `TextClipboardQuery(text)` | extension host → webview | Response with text clipboard content |
 
 ### Extension Host Side
 
@@ -111,51 +117,74 @@ async writeClipboard(text: string): Promise<void>  // vscode.env.clipboard.write
 
 The BPMN `WebviewMessageRouter` dispatches incoming `GetClipboardCommand` / `SetClipboardCommand` to the clipboard handlers in `bpmnMessageHandlers.ts`, which call `BpmnClipboardMediator` → `VsCodeClipboard`.
 
-### Webview Side — Two Polyfills
+### Webview Side — Two DI Modules
 
-The webview needs two separate clipboard polyfills because diagram elements and contenteditable labels have different event handling:
+The webview installs two **bpmn-js DI modules** (from the shared
+`libs/bpmn-clipboard` package, `@miragon/bpmn-modeler-clipboard`) because diagram
+elements and contenteditable labels have different event handling. Both are
+passed as `additionalModules` in `apps/bpmn-webview/src/main.ts`; each receives
+its host bridge through didi value injection — a `{ requestClipboard,
+writeClipboard }` pair — rather than the old `installClipboardInterceptor(...)`
+call, which no longer exists.
 
-**1. Diagram element copy/paste** (`apps/bpmn-webview/src/app/modeler.ts`):
+**1. Diagram element copy/paste** (`VsCodeClipboardModule`,
+`libs/bpmn-clipboard/src/VsCodeClipboardModule.ts`, injected
+`elementClipboardBridge`):
 
-`installClipboardInterceptor(requestClipboard, writeClipboard)` intercepts bpmn-js `copyPaste.elementsCopied` and `copyPaste.pasteElements` events at priority 2051 (above NativeCopyPaste).
+Intercepts bpmn-js `copyPaste.elementsCopied` / `copyPaste.pasteElements` at
+priority 2051 (above `NativeCopyPaste`, which it disables on construction).
 
-- **Copy**: Serializes the element tree as `"bpmn-js-clip----" + JSON.stringify(tree)` and sends it to the extension host via `SetClipboardCommand`.
-- **Paste**: When the internal clipboard is empty (cross-editor paste), requests clipboard text via `GetClipboardCommand`, deserializes the JSON, and re-triggers paste. Snapshots the event context before the async `await` to prevent `defaultPrevented` issues.
+- **Copy**: Serializes the element tree as `"bpmn-js-clip----" + JSON.stringify(tree)` and sends it via `SetClipboardCommand`.
+- **Paste**: On cross-editor paste (no internal `context.tree`), snapshots the context, cancels the default paste, requests clipboard text via `GetClipboardCommand`, then reconstructs typed model objects with `createReviver(moddle)` and re-triggers `copyPaste.paste()`.
 
-**2. Contenteditable label copy/paste** (`apps/bpmn-webview/src/app/propertiesPanelClipboard.ts`):
+**2. Direct-editing label overlays** (`LabelClipboardModule`,
+`libs/bpmn-clipboard/src/LabelClipboardModule.ts`, injected
+`textClipboardBridge`):
 
-`installContentEditableClipboardPolyfill(requestClipboard, writeClipboard)` installs a **capture-phase** keydown listener that fires before diagram-js's `DirectEditing._handleKey` (which calls `stopPropagation()` on every keydown).
+Attaches a **capture-phase** keydown listener on the label element while direct
+editing is active — it fires before diagram-js's `DirectEditing._handleKey`
+calls `stopPropagation()`.
 
-- **Cmd/Ctrl+C**: Extracts selected text from the contenteditable element, sends via `SetClipboardCommand`.
-- **Cmd/Ctrl+V**: Requests clipboard via `GetClipboardCommand`, dispatches a synthetic `ClipboardEvent("paste")`, falls back to `document.execCommand("insertText")`.
+- **Cmd/Ctrl+C**: Reads `window.getSelection()`, writes via `textClipboardBridge` → `SetTextClipboardCommand`.
+- **Cmd/Ctrl+V**: Reads via `textClipboardBridge` → `GetTextClipboardCommand`, dispatches a synthetic `ClipboardEvent("paste")`, falls back to `document.execCommand("insertText")`.
+
+See the `/bpmn-js` skill for the full three-layer copy-paste architecture (the
+third layer is a webview-local FEEL-editor polyfill).
 
 ### Wiring (Production Only)
 
-Both polyfills are wired in `apps/bpmn-webview/src/main.ts` using a promise-based resolver pattern:
+The bridges are wired in `apps/bpmn-webview/src/main.ts` using a promise-based
+resolver pattern, then injected as `value` providers:
 
 ```typescript
-const requestClipboard = async (): Promise<string> => {
+const requestElementClipboard = async (): Promise<string> => {
     clipboardResolver = createResolver<ClipboardQuery>();
-    vscode.postMessage(new GetClipboardCommand());
+    host.postMessage(new GetClipboardCommand());
     return (await clipboardResolver.wait())?.text ?? "";
 };
-
-const writeClipboard = (text: string): void => {
-    vscode.postMessage(new SetClipboardCommand(text));
+const writeElementClipboard = (text: string): void => {
+    host.postMessage(new SetClipboardCommand(text));
 };
+// (text bridge mirrors this with the *Text* commands / TextClipboardQuery)
 
-bpmnModeler.installClipboardInterceptor(requestClipboard, writeClipboard);
-installContentEditableClipboardPolyfill(requestClipboard, writeClipboard);
+clipboardModules = [
+    VsCodeClipboardModule,
+    LabelClipboardModule,
+    {
+        elementClipboardBridge: ["value", { requestClipboard: requestElementClipboard, writeClipboard: writeElementClipboard }],
+        textClipboardBridge: ["value", { requestClipboard: requestTextClipboard, writeClipboard: writeTextClipboard }],
+    },
+];
 ```
 
-These are only installed in production (not development) because in dev mode the webview runs in a regular browser with native clipboard access.
+These modules are only added in production (not development) because in dev mode the webview runs in a regular browser with native clipboard access.
 
 ## Webview Theming
 
 Webviews **must** respect the user's VS Code theme:
 
 - BPMN/DMN webviews ship `lightTheme.css` and `darkTheme.css`
-- Theme detection via `document.body.dataset.vscodeThemeKind`
+- Theme detection via VS Code's body classes — `document.body.classList.contains("vscode-dark")` / `"vscode-high-contrast"` (`libs/shared/src/lib/theme.ts`), watched by a `MutationObserver` on the body `class` attribute
 - Initial HTML loads light theme; JS swaps stylesheet on init
 - Use VS Code CSS custom properties (`--vscode-*`) for colors when possible
 - Test with light, dark, and high-contrast themes

--- a/.agent/skills/vscode-webviews/SKILL.md
+++ b/.agent/skills/vscode-webviews/SKILL.md
@@ -221,18 +221,24 @@ host.setState(state);            // Write persisted state
 
 ### Detection
 
-VS Code sets `data-vscode-theme-kind` on `document.body`:
+VS Code adds a theme **class** to `document.body` (not a `data-` attribute):
 - `vscode-light` — light theme
 - `vscode-dark` — dark theme
 - `vscode-high-contrast` — high contrast
+
+`libs/shared/src/lib/theme.ts` reads these with
+`document.body.classList.contains("vscode-dark")` /
+`"vscode-high-contrast")` and installs a `MutationObserver` on the body
+`class` attribute to re-apply the theme when the user switches it live.
 
 ### Stylesheet Swap
 
 The webview ships two CSS files (`lightTheme.css`, `darkTheme.css`). On initialization:
 
-1. Read `document.body.dataset.vscodeThemeKind`
+1. Read the body theme classes (`classList.contains("vscode-dark")` / `"vscode-high-contrast"`)
 2. Set the `<link>` element's `href` to the matching stylesheet
 3. The initial HTML always references `lightTheme.css`; the JS swaps if needed
+4. A `MutationObserver` on the body `class` attribute repeats the swap on live theme changes
 
 ### CSS Custom Properties
 
@@ -243,12 +249,14 @@ VS Code also exposes theme colors as CSS custom properties (e.g., `--vscode-edit
 Files bundled with the extension must be converted to webview-safe URIs:
 
 ```typescript
-const scriptUri = webview.asWebviewUri(
-  vscode.Uri.joinPath(extensionUri, 'dist', 'apps', 'bpmn-modeler', 'bpmn-webview', 'index.js')
-);
+// BPMN_WEBVIEW_PATH === "bpmn-webview"; extensionUri already points at the
+// packaged extension root (dist/apps/vscode-plugin), so it is not re-joined.
+const baseUri = vscode.Uri.joinPath(extensionUri, BPMN_WEBVIEW_PATH);
+const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(baseUri, 'index.js'));
 ```
 
 This converts `file://` paths to `vscode-resource:` URIs that pass the webview's CSP.
+See `apps/vscode-plugin/src/shared/infrastructure/WebviewHtml.ts`.
 
 ## Key Files
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,5 @@ vitest.config.*.timestamp*
 docs/.vitepress/dist
 docs/.vitepress/cache
 .gstack/
-.agent/
-.claude/logs/
+.agent/logs/
+.agent/settings.local.json


### PR DESCRIPTION
**Issue**

The `.agent/` config had drifted from the codebase since the modeler-core extraction, and the blanket `.agent/` gitignore silently dropped newly added skills or commands.

**Description**

Removes the dead `plugins` entry (the plugin manifest was deleted in the `.agent` migration) and the legacy `includeCoAuthoredBy` key from `settings.json`, and renames the Playwright permission to `browser_run_code_unsafe`. Updates `AGENT.md` with the current workspace tree (intellij-plugin, modeler-bridge, modeler-core + six libs), all eight tsconfig aliases, the root vitest setup, and the moved single-test example path. Fixes stale skill content: the removed `installClipboardInterceptor` API (now `VsCodeClipboardModule`/`LabelClipboardModule` DI), theme detection via body classes instead of `dataset.vscodeThemeKind`, the missing text-clipboard messages, DMN handler/participant lists, and the IntelliJ Gradle plugin version. Narrows the `.gitignore` rule from `.agent/` to `.agent/logs/` and `.agent/settings.local.json` so new agent files are committable again.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created