### PR TITLE
docs: add apps and libs overview readmes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ docs/.vitepress/cache
 .gstack/
 .agent/logs/
 .agent/settings.local.json
+.claude/logs/

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,48 @@
+# `apps/` — deliverables
+
+Each package in `apps/` is a self-contained deliverable: it is built, run, or
+shipped on its own, and no other package in this repository imports code from
+it. Reusable code lives in [`../libs`](../libs), which an app only consumes.
+
+## Webview frontends
+
+These are browser bundles built with Vite. Each one builds itself to
+`dist/webview-staging/<name>/` and is loaded inside a sandboxed webview by a
+host. They export nothing, and they communicate with their host only over an
+asynchronous `postMessage` channel that is typed by
+[`libs/shared`](../libs/shared) and [`libs/modeler-core`](../libs/modeler-core).
+
+| Package | What's inside |
+| --- | --- |
+| `bpmn-webview` | This webview hosts the BPMN diagram editor, built on bpmn-js with the properties panel. |
+| `dmn-webview` | This webview hosts the DMN decision-table and DRD editor, built on dmn-js. |
+| `deployment-webview` | This webview renders the Camunda deployment sidebar form. |
+
+## Host applications
+
+Each host embeds the webview bundles and drives the modeling engine in
+[`libs/modeler-core`](../libs/modeler-core).
+
+| Package | What's inside |
+| --- | --- |
+| `vscode-plugin` | This is the VS Code extension (Node and Webpack), whose custom text editors serve the webview HTML and route its messages. |
+| `intellij-plugin` | This is the IntelliJ and JetBrains host (Kotlin and Gradle), which renders the same webview bundles in a JCEF browser. |
+| `standalone` | This is the Theia and Electron desktop shell, which pairs with [`libs/standalone-extension`](../libs/standalone-extension). |
+| `modeler-bridge` | This is a stdio JSON-RPC Bun binary that runs `modeler-core` out of process for the IntelliJ host, which has no Node runtime. |
+
+## How a host and a webview connect
+
+There is no import link between a host and a webview. They are joined by three
+deliberately weak seams instead.
+
+1. **Build.** The host copies the webview's staged bundle into its own output,
+   for example through the `CopyWebpackPlugin` step in `vscode-plugin`. This is
+   why the root build order is libraries, then webviews, then hosts.
+2. **Load.** The host writes the webview HTML shell and points its `<script>`
+   and `<link>` tags at the copied files through `webview.asWebviewUri(...)`.
+3. **Talk.** The two halves exchange `Command` and `Query` messages over
+   `postMessage`, so the only import-level coupling between them flows through
+   `libs/`.
+
+This boundary is what lets the same webview bundle serve VS Code, IntelliJ, and
+the standalone shell unchanged.

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,34 @@
+# `libs/` — building blocks
+
+Each package in `libs/` is reusable code that other packages consume through its
+public API with an `import` statement. The runnable and shippable ends of the
+project, namely the webviews and hosts, live in [`../apps`](../apps). These
+libraries are the shared foundation that both the hosts and the webviews depend
+on.
+
+## Foundation
+
+| Package | What's inside |
+| --- | --- |
+| `modeler-core` | This is the host-agnostic BPMN and DMN engine, holding the domain models, services, host-capability ports, and the `vscode`-free infrastructure registries such as `EditorSessionStore` and `WebviewMessageRouter`. It must never import `vscode`. |
+| `shared` | This holds the `Command` and `Query` message types and utilities that both the extension host and the webviews use, so it defines the vocabulary of the `postMessage` seam. |
+
+## bpmn-js and dmn-js feature modules
+
+Each of these is a self-contained editor feature, packaged separately so that it
+can be composed into a webview and unit-tested in isolation.
+
+| Package | What's inside |
+| --- | --- |
+| `append-menu` | This replaces the flat "Append element" dropdown with a two-panel Preact overlay. |
+| `element-template-chooser` | This provides a richer, searchable overlay for picking an element template. |
+| `bpmn-clipboard` | This makes copy and paste of elements and label text work inside the sandboxed webview iframe. |
+| `code-link` | This adds a "Go to implementation" context-pad action that jumps to the task's source file. |
+| `model-navigation` | This adds a "Navigate to referenced model" action, jumping from a Call Activity to its BPMN process or from a Business Rule Task to its DMN decision. |
+| `bpmn-i18n` | This provides runtime language switching for bpmn-js, dmn-js, the properties panel, and the app's own strings. |
+
+## Host extension
+
+| Package | What's inside |
+| --- | --- |
+| `standalone-extension` | This is a Theia frontend extension contributing Miragon themes, a splash screen, and view overrides, consumed by [`apps/standalone`](../apps/standalone). It ships as its own package because Theia only discovers `theiaExtensions` that are declared on dependencies. |


### PR DESCRIPTION
## What

Adds two directory-level READMEs that document the workspace layout:

- **`apps/README.md`** — explains that each app is a self-contained deliverable (built, run, or shipped on its own, imported by nothing), indexes the three webview frontends and four host applications, and describes the three weak seams (build-time copy, HTML/`asWebviewUri` load, `postMessage`) that connect a host to a webview.
- **`libs/README.md`** — explains that each lib is reusable code consumed via its public API, and indexes the foundation packages (`modeler-core`, `shared`), the bpmn-js/dmn-js feature modules, and the Theia host extension.

## Why

Makes the apps-vs-libs distinction discoverable from the tree itself, so contributors know where new code belongs and how the hosts and webviews are wired together.

Docs only — no code or build changes.