### PR TITLE
feat(bpmn-webview): add keyboard focus and append-menu arrow navigation

### DIFF
--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -3,5 +3,6 @@ export * from "./viewport";
 export * from "./selection";
 export * from "./state";
 export * from "./propertiesPanelClipboard";
+export * from "./keyboardFocus";
 export * from "./host";
 export * from "./webviewState";

--- a/apps/bpmn-webview/src/app/keyboardFocus.spec.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.spec.ts
@@ -1,0 +1,61 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installKeyboardFocus } from "./keyboardFocus";
+
+const focusCanvas = vi.fn();
+const isSearchPadOpen = vi.fn<() => boolean>();
+const closeSearchPad = vi.fn();
+
+/** Dispatches a bubble-phase keydown on `document`, honouring preventDefault. */
+function dispatchKeydown(key: string, defaultPrevented = false): void {
+    const event = new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true });
+    if (defaultPrevented) {
+        // Mark as already-handled the way an earlier listener would.
+        event.preventDefault();
+    }
+    document.dispatchEvent(event);
+}
+
+// Install exactly once: installKeyboardFocus adds a document listener with no
+// removal API, so reinstalling per-test would stack duplicate listeners that
+// all fire on the same keydown and inflate the mock call counts.
+beforeAll(() => {
+    installKeyboardFocus({
+        focusCanvas: () => focusCanvas(),
+        isSearchPadOpen: () => isSearchPadOpen(),
+        closeSearchPad: () => closeSearchPad(),
+    });
+});
+
+beforeEach(() => {
+    focusCanvas.mockReset();
+    isSearchPadOpen.mockReset();
+    closeSearchPad.mockReset();
+    isSearchPadOpen.mockReturnValue(false);
+});
+
+describe("installKeyboardFocus", () => {
+    it("focuses the canvas on Escape", () => {
+        dispatchKeydown("Escape");
+        expect(focusCanvas).toHaveBeenCalledTimes(1);
+        expect(closeSearchPad).not.toHaveBeenCalled();
+    });
+
+    it("ignores keys other than Escape", () => {
+        dispatchKeydown("a");
+        expect(focusCanvas).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the Escape was already handled (defaultPrevented)", () => {
+        dispatchKeydown("Escape", true);
+        expect(focusCanvas).not.toHaveBeenCalled();
+        expect(closeSearchPad).not.toHaveBeenCalled();
+    });
+
+    it("closes the search pad then focuses the canvas when the pad is open", () => {
+        isSearchPadOpen.mockReturnValue(true);
+        dispatchKeydown("Escape");
+        expect(closeSearchPad).toHaveBeenCalledTimes(1);
+        expect(focusCanvas).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/bpmn-webview/src/app/keyboardFocus.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.ts
@@ -1,0 +1,63 @@
+/**
+ * Injected dependencies for the webview-level "Escape → focus canvas" guard.
+ *
+ * Closures rather than a service handle so this stays testable without a live
+ * bpmn-js modeler and so the real services can be resolved lazily (they don't
+ * exist until the modeler is created).
+ */
+export interface KeyboardFocusDeps {
+    /** Moves DOM focus onto the canvas SVG (`canvas.focus()`). */
+    focusCanvas: () => void;
+    /** Whether the diagram-js SearchPad is currently open. */
+    isSearchPadOpen: () => boolean;
+    /** Closes the SearchPad (restores the cached selection). */
+    closeSearchPad: () => void;
+}
+
+/**
+ * Installs a document-level Escape handler that pulls focus back onto the
+ * canvas — the Vim-style "return to normal mode".
+ *
+ * bpmn-js's Keyboard service only listens on the canvas SVG (diagram-js ≥ 15,
+ * `tabindex=0`), so while focus sits in the properties panel, a FEEL editor,
+ * or a search field, keystrokes like `A`/`N`/arrows never reach the modeler.
+ * Escape re-homes focus so the next keystroke drives the diagram again.
+ *
+ * The listener runs in the **bubble** phase and stays deliberately passive
+ * (no preventDefault/stopPropagation) so host Escape behaviour is untouched.
+ *
+ * @param deps Injected focus/search-pad closures (see {@link KeyboardFocusDeps}).
+ */
+export function installKeyboardFocus(deps: KeyboardFocusDeps): void {
+    document.addEventListener("keydown", (e: KeyboardEvent) => {
+        if (e.key !== "Escape") return;
+
+        // Something already handled this Escape. Covers CodeMirror 6 (FEEL
+        // editor), whose Escape binding preventDefault-s only while its
+        // autocomplete popup is open — so the first Escape closes the popup
+        // and the second reaches us — plus any Escape bpmn-js itself consumes.
+        if (e.defaultPrevented) return;
+
+        // The append-menu and template-chooser overlays need no guard here:
+        // both register Escape as a document *capture* listener with
+        // stopPropagation, so this bubble listener never fires while they are
+        // open. First Escape closes the overlay; a second one lands here and
+        // focuses the canvas.
+
+        // SearchPad closes on keyup, not keydown (SearchPad.js). If we pulled
+        // focus to the canvas on this keydown, the matching keyup would miss
+        // the search field and the pad would stay open forever. So close it
+        // explicitly here: one Escape both closes the search and focuses the
+        // canvas.
+        if (deps.isSearchPadOpen()) {
+            deps.closeSearchPad();
+            deps.focusCanvas();
+            return;
+        }
+
+        // Label direct-editing needs no guard: its keydown handler stops
+        // propagation for every key, so we never see its Escape.
+
+        deps.focusCanvas();
+    });
+}

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -48,6 +48,7 @@ import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-model
 import {
     BpmnModeler,
     installContentEditableClipboardPolyfill,
+    installKeyboardFocus,
     UnsupportedEngineError,
 } from "./app";
 import type { HostApi } from "@miragon/bpmn-modeler-shared";
@@ -359,6 +360,17 @@ async function initializeModeler(
                 .getService<{ trigger(action: string): void }>("editorActions")
                 .trigger(action),
         );
+        // Escape re-homes focus on the canvas so keyboard-driven modelling
+        // (A/N/arrows, all owned by bpmn-js's canvas-scoped Keyboard service)
+        // works even when focus sits in the properties panel or a search field.
+        // Services are resolved lazily inside the closures because the modeler
+        // exists by the time an Escape can fire.
+        installKeyboardFocus({
+            focusCanvas: () => bpmnModeler.getService<{ focus(): void }>("canvas").focus(),
+            isSearchPadOpen: () =>
+                bpmnModeler.getService<{ isOpen(): boolean }>("searchPad").isOpen(),
+            closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),
+        });
         // Forward the modeler's non-fatal warnings (element-not-found, missing
         // inline script) to the output channel — they were console-only before.
         bpmnModeler.onWarning((warning) => host.postMessage(new LogWarningCommand(warning)));

--- a/libs/append-menu/package.json
+++ b/libs/append-menu/package.json
@@ -3,7 +3,8 @@
     "version": "0.0.1",
     "private": true,
     "scripts": {
-        "build": "tsc --noEmit"
+        "build": "tsc --noEmit",
+        "test": "vitest run"
     },
     "dependencies": {
         "@miragon/bpmn-modeler-element-template-chooser": "workspace:*",
@@ -14,6 +15,7 @@
     },
     "devDependencies": {
         "bpmn-js": "18.19.0",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "4.1.9"
     }
 }

--- a/libs/append-menu/src/AppendMenuOverride.ts
+++ b/libs/append-menu/src/AppendMenuOverride.ts
@@ -120,12 +120,25 @@ class AppendMenuOverride {
                 customMenuOpen = false;
                 closeCustomMenu = null;
                 executeEntryAction(action, event);
+                // Return focus to the canvas so keyboard-driven modelling chains
+                // without the mouse (A → nav → Enter → A → …); on unmount focus
+                // would otherwise fall to <body>. Deferred a microtask and
+                // gated on directEditing so we never steal the caret from a
+                // label-edit session that appending may open.
+                queueMicrotask(() => {
+                    const directEditing = injector.get("directEditing", false);
+                    if (directEditing?.isActive?.()) {
+                        return;
+                    }
+                    canvas.focus();
+                });
             };
 
             const handleCancel = () => {
                 close();
                 customMenuOpen = false;
                 closeCustomMenu = null;
+                canvas.focus();
             };
 
             const canvasBounds = canvasContainer.getBoundingClientRect();

--- a/libs/append-menu/src/append-menu.css
+++ b/libs/append-menu/src/append-menu.css
@@ -377,7 +377,8 @@
 }
 
 @keyframes am-hover-appear {
-    from { opacity: 0; transform: translateX(-4px); }
+    /* Card now opens to the left of the panel, so ease it in from the panel edge. */
+    from { opacity: 0; transform: translateX(4px); }
     to   { opacity: 1; transform: translateX(0); }
 }
 

--- a/libs/append-menu/src/append-menu.css
+++ b/libs/append-menu/src/append-menu.css
@@ -718,6 +718,11 @@
     border-color: var(--am-border-bpmn-btn);
 }
 
+.am-bpmn-button--focused {
+    background: var(--am-accent-bg);
+    border-color: var(--am-accent);
+}
+
 .am-bpmn-button--disabled {
     opacity: 0.3;
     cursor: not-allowed;

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -4,9 +4,28 @@
  * Renders a positioned panel anchored near the trigger point (context pad
  * or palette toolbar) with a two-panel layout: templates on the left and
  * a collapsible BPMN element palette on the right.
+ *
+ * The overlay owns all filter *inputs* (search, category, template selection)
+ * and derives both columns' navigable order once (see {@link ../filtering}),
+ * driving a single keyboard highlight (see {@link ../navigation}). The panels
+ * are thin renderers. Keyboard: the search input keeps focus permanently while
+ * ↑/↓ move a highlight in the active column, ←/→ switch columns, Enter selects.
  */
 import { useState, useEffect, useCallback, useMemo, useRef } from "preact/hooks";
 import type { EnrichedTemplateEntry, BpmnElementGroup, PopupMenuEntryAction } from "../types";
+import {
+    filterTemplates,
+    extractCategories,
+    processPaletteGroups,
+    flattenPaletteItems,
+} from "../filtering";
+import {
+    initialHighlight,
+    moveVertical,
+    moveHorizontal,
+    type Highlight,
+    type NavColumns,
+} from "../navigation";
 import { TemplatePanel } from "./TemplatePanel";
 import { BpmnElementPalette } from "./BpmnElementPalette";
 
@@ -52,14 +71,6 @@ function clampToCanvas(
  * Positioned panel that presents the append/create menu anchored near the
  * trigger point.
  *
- * The search bar is shared across both panels: it filters templates on the
- * left and BPMN elements on the right.  Searching for a BPMN type name
- * (e.g. "service task") also surfaces templates that apply to that type.
- *
- * Clicking a single-type template immediately creates the element.
- * Clicking a multi-type template selects it and filters the BPMN palette
- * to only show the matching element types.
- *
  * @param props.templateEntries Enriched element template entries for the left panel.
  * @param props.bpmnGroups BPMN element entries grouped by category for the right panel.
  * @param props.position Viewport coordinates to anchor the panel near.
@@ -84,6 +95,7 @@ export function AppendMenuOverlay({
     // palette so users see the full BPMN element list instead of an awkward
     // icon-only column next to an empty template panel.
     const [paletteExpanded, setPaletteExpanded] = useState(!hasTemplates);
+    const [highlight, setHighlight] = useState<Highlight | null>(null);
     const searchRef = useRef<HTMLInputElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const [panelStyle, setPanelStyle] = useState<{ left: number; top: number } | null>(null);
@@ -96,6 +108,36 @@ export function AppendMenuOverlay({
         return new Set(selectedTemplate.template.appliesTo);
     }, [selectedTemplate]);
 
+    // --- Derived, shared filter state (single source of truth) -------------
+    const filteredTemplates = useMemo(
+        () => filterTemplates(templateEntries, search, activeCategory),
+        [templateEntries, search, activeCategory],
+    );
+    const categories = useMemo(() => extractCategories(templateEntries), [templateEntries]);
+    const processedPalette = useMemo(
+        () => processPaletteGroups(bpmnGroups, favourites, search, appliesToFilter),
+        [bpmnGroups, favourites, search, appliesToFilter],
+    );
+    const paletteItems = useMemo(() => flattenPaletteItems(processedPalette), [processedPalette]);
+    // Only visible (non-hidden) items are navigable; disabled ones stay in the
+    // list so navigation can skip over them but the highlight can still land
+    // adjacent to them.
+    const paletteNav = useMemo(() => paletteItems.filter((i) => !i.hidden), [paletteItems]);
+    const navColumns = useMemo<NavColumns>(
+        () => ({
+            templates: filteredTemplates.map(() => ({ disabled: false })),
+            palette: paletteNav.map((i) => ({ disabled: i.disabled })),
+        }),
+        [filteredTemplates, paletteNav],
+    );
+
+    // Refs let the stable Escape capture listener read the latest values
+    // without re-registering on every keystroke.
+    const navColumnsRef = useRef(navColumns);
+    navColumnsRef.current = navColumns;
+    const selectedTemplateRef = useRef(selectedTemplate);
+    selectedTemplateRef.current = selectedTemplate;
+
     /**
      * Position the panel after initial render, clamped to canvas area.
      */
@@ -107,19 +149,67 @@ export function AppendMenuOverlay({
     }, [position, canvasBounds]);
 
     /**
-     * Auto-focus the search input on mount.
+     * Auto-focus the search input on mount. The input keeps focus for the
+     * whole session; navigation keydowns bubble from it up to the panel.
      */
     useEffect(() => {
         searchRef.current?.focus();
     }, []);
 
+    // A signature of the *visible* items in both columns. Changes only when
+    // filtering reshuffles membership (search/category), not when selecting a
+    // template merely toggles palette entries' disabled state — so an
+    // intentional programmatic highlight move survives a template selection.
+    const listsSignature = useMemo(
+        () =>
+            filteredTemplates.map((t) => t.id).join("|") +
+            "##" +
+            paletteNav.map((i) => i.key).join("|"),
+        [filteredTemplates, paletteNav],
+    );
+
     /**
-     * Close on Escape key.
+     * Re-seed the highlight to the first enabled item whenever the visible
+     * lists change. Default = first item (like the standard popup) so `A`
+     * then `Enter` appends the top hit immediately.
+     */
+    useEffect(() => {
+        // Re-run on membership change only; navColumns is read via ref.
+        setHighlight(initialHighlight(navColumnsRef.current));
+    }, [listsSignature]);
+
+    /**
+     * Selecting a multi-type template always leads to picking the concrete
+     * type next, so expand the palette and move the highlight to its first
+     * enabled item (icon-only highlight would be unreadable).
+     */
+    useEffect(() => {
+        if (!selectedTemplate) {
+            return;
+        }
+        setPaletteExpanded(true);
+        const idx = navColumnsRef.current.palette.findIndex((i) => !i.disabled);
+        if (idx >= 0) {
+            setHighlight({ column: "palette", index: idx });
+        }
+    }, [selectedTemplate]);
+
+    /**
+     * Staged Escape. Registered in the capture phase with `stopPropagation`
+     * so it fires before — and shields — the webview-level "Escape → focus
+     * canvas" handler. A first Escape with a template selected only clears
+     * that selection (back to the templates column); otherwise it cancels.
      */
     useEffect(() => {
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") {
-                e.stopPropagation();
+            if (e.key !== "Escape") {
+                return;
+            }
+            e.stopPropagation();
+            if (selectedTemplateRef.current) {
+                setSelectedTemplate(null);
+                setHighlight(initialHighlight(navColumnsRef.current));
+            } else {
                 onCancel();
             }
         };
@@ -128,10 +218,10 @@ export function AppendMenuOverlay({
     }, [onCancel]);
 
     /**
-     * Handles a template card click.
+     * Handles a template card click / Enter.
      *
-     * Single-type templates are applied immediately.
-     * Multi-type templates are selected so the palette can be filtered.
+     * Single-type templates are applied immediately. Multi-type templates are
+     * selected so the palette can be filtered (see the selection effect).
      */
     const handleTemplateClick = useCallback(
         (enriched: EnrichedTemplateEntry, event: Event) => {
@@ -147,7 +237,7 @@ export function AppendMenuOverlay({
     );
 
     /**
-     * Handles a BPMN element button click in the palette.
+     * Handles a BPMN element button click / Enter in the palette.
      *
      * If a multi-type template is selected, creates the element using
      * the template's action.  Otherwise, creates a plain BPMN element.
@@ -163,6 +253,78 @@ export function AppendMenuOverlay({
         [onSelect, selectedTemplate],
     );
 
+    /**
+     * Activates the currently highlighted item (Enter).
+     */
+    const activateHighlight = useCallback(
+        (event: Event) => {
+            if (!highlight) {
+                return;
+            }
+            if (highlight.column === "templates") {
+                const enriched = filteredTemplates[highlight.index];
+                if (enriched) {
+                    handleTemplateClick(enriched, event);
+                }
+            } else {
+                const item = paletteNav[highlight.index];
+                if (item && !item.disabled) {
+                    handleBpmnSelect(item.entry.action, event);
+                }
+            }
+        },
+        [highlight, filteredTemplates, paletteNav, handleTemplateClick, handleBpmnSelect],
+    );
+
+    /**
+     * Keyboard navigation for the whole overlay.
+     *
+     * Bound on the panel div, not the input, so the search field keeps focus
+     * while its keydowns bubble up here — the trick the diagram-js standard
+     * popup uses. ←/→ deliberately sacrifice the input's caret movement (same
+     * trade-off as the standard popup); Home/End/Backspace still work.
+     */
+    const handlePanelKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (!highlight) {
+                return;
+            }
+            switch (e.key) {
+                case "ArrowDown":
+                    e.preventDefault();
+                    setHighlight(moveVertical(highlight, 1, navColumns));
+                    break;
+                case "ArrowUp":
+                    e.preventDefault();
+                    setHighlight(moveVertical(highlight, -1, navColumns));
+                    break;
+                case "ArrowRight": {
+                    e.preventDefault();
+                    const next = moveHorizontal(highlight, 1, navColumns);
+                    setHighlight(next);
+                    // Expand on arrival: an icon-only highlight is unreadable.
+                    if (next.column === "palette" && !paletteExpanded) {
+                        setPaletteExpanded(true);
+                    }
+                    break;
+                }
+                case "ArrowLeft":
+                    e.preventDefault();
+                    setHighlight(moveHorizontal(highlight, -1, navColumns));
+                    break;
+                case "Enter":
+                    e.preventDefault();
+                    activateHighlight(e as unknown as Event);
+                    break;
+            }
+        },
+        [highlight, navColumns, paletteExpanded, activateHighlight],
+    );
+
+    const highlightedTemplateIndex = highlight?.column === "templates" ? highlight.index : -1;
+    const highlightedPaletteKey =
+        highlight?.column === "palette" ? (paletteNav[highlight.index]?.key ?? null) : null;
+
     return (
         <div class="am-click-away" onClick={onCancel}>
             <div
@@ -174,6 +336,7 @@ export function AppendMenuOverlay({
                         : { left: `${position.x}px`, top: `${position.y}px` }
                 }
                 onClick={(e) => e.stopPropagation()}
+                onKeyDown={handlePanelKeyDown}
             >
                 {/* Search bar */}
                 <div class="am-search-wrapper">
@@ -213,20 +376,21 @@ export function AppendMenuOverlay({
                 <div class="am-body">
                     {hasTemplates && (
                         <TemplatePanel
-                            entries={templateEntries}
+                            entries={filteredTemplates}
+                            categories={categories}
                             search={search}
                             activeCategory={activeCategory}
                             selectedTemplateId={selectedTemplate?.id ?? null}
+                            highlightedIndex={highlightedTemplateIndex}
                             onCategoryChange={setActiveCategory}
                             onTemplateClick={handleTemplateClick}
                         />
                     )}
                     <BpmnElementPalette
-                        groups={bpmnGroups}
-                        favourites={favourites}
-                        search={search}
-                        appliesToFilter={appliesToFilter}
+                        favouriteEntries={processedPalette.favouriteEntries}
+                        groups={processedPalette.groups}
                         expanded={paletteExpanded}
+                        highlightedKey={highlightedPaletteKey}
                         onToggleExpand={() => setPaletteExpanded((prev) => !prev)}
                         onSelect={handleBpmnSelect}
                     />

--- a/libs/append-menu/src/components/AppendMenuOverlay.tsx
+++ b/libs/append-menu/src/components/AppendMenuOverlay.tsx
@@ -95,6 +95,10 @@ export function AppendMenuOverlay({
     // palette so users see the full BPMN element list instead of an awkward
     // icon-only column next to an empty template panel.
     const [paletteExpanded, setPaletteExpanded] = useState(!hasTemplates);
+    // Separate transient hover-peek flag. Kept apart from `paletteExpanded`
+    // (the pinned state) so leaving the palette only collapses a hover-peek,
+    // never a palette the user pinned via chevron/keyboard/template selection.
+    const [palettePeek, setPalettePeek] = useState(false);
     const [highlight, setHighlight] = useState<Highlight | null>(null);
     const searchRef = useRef<HTMLInputElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
@@ -321,6 +325,9 @@ export function AppendMenuOverlay({
         [highlight, navColumns, paletteExpanded, activateHighlight],
     );
 
+    // Pinned expansion OR a transient hover-peek both render the palette expanded.
+    const paletteExpandedVisual = paletteExpanded || palettePeek;
+
     const highlightedTemplateIndex = highlight?.column === "templates" ? highlight.index : -1;
     const highlightedPaletteKey =
         highlight?.column === "palette" ? (paletteNav[highlight.index]?.key ?? null) : null;
@@ -389,9 +396,10 @@ export function AppendMenuOverlay({
                     <BpmnElementPalette
                         favouriteEntries={processedPalette.favouriteEntries}
                         groups={processedPalette.groups}
-                        expanded={paletteExpanded}
+                        expanded={paletteExpandedVisual}
                         highlightedKey={highlightedPaletteKey}
                         onToggleExpand={() => setPaletteExpanded((prev) => !prev)}
+                        onPeekChange={setPalettePeek}
                         onSelect={handleBpmnSelect}
                     />
                 </div>

--- a/libs/append-menu/src/components/BpmnElementPalette.tsx
+++ b/libs/append-menu/src/components/BpmnElementPalette.tsx
@@ -17,6 +17,8 @@ interface BpmnElementPaletteProps {
     /** Nav key of the keyboard-highlighted button, or null when in the other column. */
     highlightedKey: string | null;
     onToggleExpand: () => void;
+    /** Reports hover-peek state so the parent can transiently expand the palette on hover. */
+    onPeekChange?: (peek: boolean) => void;
     onSelect: (action: PopupMenuEntryAction, event: Event) => void;
 }
 
@@ -33,6 +35,7 @@ interface BpmnElementPaletteProps {
  * @param props.expanded Whether the palette shows labels alongside icons.
  * @param props.highlightedKey Nav key of the highlighted button, or null.
  * @param props.onToggleExpand Callback to toggle expanded/collapsed state.
+ * @param props.onPeekChange Callback reporting hover-peek enter/leave.
  * @param props.onSelect Callback invoked when a BPMN element button is clicked.
  */
 export function BpmnElementPalette({
@@ -41,6 +44,7 @@ export function BpmnElementPalette({
     expanded,
     highlightedKey,
     onToggleExpand,
+    onPeekChange,
     onSelect,
 }: BpmnElementPaletteProps) {
     const contentRef = useRef<HTMLDivElement>(null);
@@ -56,7 +60,11 @@ export function BpmnElementPalette({
     }, [highlightedKey]);
 
     return (
-        <div class={`am-palette-panel ${expanded ? "am-palette-panel--expanded" : ""}`}>
+        <div
+            class={`am-palette-panel ${expanded ? "am-palette-panel--expanded" : ""}`}
+            onMouseEnter={() => onPeekChange?.(true)}
+            onMouseLeave={() => onPeekChange?.(false)}
+        >
             <div class="am-palette-header">
                 <h3 class="am-palette-title">BPMN</h3>
                 <button

--- a/libs/append-menu/src/components/BpmnElementPalette.tsx
+++ b/libs/append-menu/src/components/BpmnElementPalette.tsx
@@ -1,130 +1,59 @@
 /**
  * Right panel of the append menu overlay.
  *
- * Displays standard BPMN elements organised by category (Tasks, Gateways,
- * Sub-Processes, Events) as a collapsible palette.  In collapsed mode,
- * only icons are shown; expanding reveals labels.
+ * A thin renderer of the pre-processed palette (favourites row + categorised
+ * groups). Filtering/favourite resolution lives in {@link ../filtering} and
+ * the keyboard highlight in the parent overlay, so this component only draws
+ * buttons and reflects the highlighted key.
  */
-import { useMemo } from "preact/hooks";
-import type { BpmnElementGroup, BpmnElementEntry, PopupMenuEntryAction } from "../types";
-
-/**
- * A palette entry with additional state for filtering.
- */
-interface ProcessedEntry extends BpmnElementEntry {
-    disabled: boolean;
-    hidden: boolean;
-}
-
-/**
- * A processed group with filtering state on entries.
- */
-interface ProcessedGroup {
-    id: string;
-    name: string;
-    entries: ProcessedEntry[];
-}
+import { useEffect, useRef } from "preact/hooks";
+import type { PopupMenuEntryAction } from "../types";
+import type { ProcessedEntry, ProcessedGroup } from "../filtering";
 
 interface BpmnElementPaletteProps {
-    groups: BpmnElementGroup[];
-    favourites: string[];
-    search: string;
-    appliesToFilter: Set<string> | null;
+    favouriteEntries: ProcessedEntry[];
+    groups: ProcessedGroup[];
     expanded: boolean;
+    /** Nav key of the keyboard-highlighted button, or null when in the other column. */
+    highlightedKey: string | null;
     onToggleExpand: () => void;
     onSelect: (action: PopupMenuEntryAction, event: Event) => void;
 }
 
 /**
- * Checks whether a BPMN palette entry matches any of the types in a filter set.
- *
- * @param entry The BPMN palette entry.
- * @param filter The set of `appliesTo` BPMN type strings.
- * @returns `true` if the entry matches any type in the filter.
- */
-function entryMatchesFilter(entry: BpmnElementEntry, filter: Set<string>): boolean {
-    for (const bpmnType of filter) {
-        const shortName = bpmnType.split(":")[1]?.toLowerCase() ?? "";
-        const normalizedLabel = entry.entry.label.toLowerCase().replace(/[\s-]/g, "");
-        if (normalizedLabel === shortName) {
-            return true;
-        }
-        const normalizedId = entry.id.toLowerCase().replace(/[\s-]/g, "");
-        if (normalizedId.includes(shortName)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-/**
- * Checks whether a BPMN palette entry matches a search query.
- *
- * @param entry The BPMN palette entry.
- * @param query The lowercase, trimmed search query.
- * @returns `true` if the entry label or description matches.
- */
-function entryMatchesSearch(entry: BpmnElementEntry, query: string): boolean {
-    const haystack = [entry.entry.label, entry.entry.description ?? ""].join(" ").toLowerCase();
-    return haystack.includes(query);
-}
-
-/**
  * Renders a categorised palette of BPMN element buttons.
  *
- * In collapsed mode, buttons show only icons (compact).
- * In expanded mode, buttons show icons and labels (full).
- * A toggle chevron in the header switches between modes.
+ * In collapsed mode, buttons show only icons; expanded mode adds labels.
+ * Each button carries a namespaced `data-nav-key` (`fav:…` / `grp:…`) so the
+ * keyboard highlight can target the right instance — a favourite appears both
+ * in the favourites row and in its own group.
  *
- * @param props.groups BPMN element entries grouped by category.
- * @param props.search The current search query.
- * @param props.appliesToFilter Set of BPMN types to enable, or null for all.
+ * @param props.favouriteEntries Resolved favourite entries (annotated).
+ * @param props.groups Annotated BPMN element groups.
  * @param props.expanded Whether the palette shows labels alongside icons.
+ * @param props.highlightedKey Nav key of the highlighted button, or null.
  * @param props.onToggleExpand Callback to toggle expanded/collapsed state.
  * @param props.onSelect Callback invoked when a BPMN element button is clicked.
  */
 export function BpmnElementPalette({
+    favouriteEntries,
     groups,
-    favourites,
-    search,
-    appliesToFilter,
     expanded,
+    highlightedKey,
     onToggleExpand,
     onSelect,
 }: BpmnElementPaletteProps) {
-    const query = search.toLowerCase().trim();
-    const favouriteSet = useMemo(() => new Set(favourites), [favourites]);
+    const contentRef = useRef<HTMLDivElement>(null);
 
-    const processedGroups = useMemo<ProcessedGroup[]>(() => {
-        return groups.map((group) => ({
-            ...group,
-            entries: group.entries.map((entry) => ({
-                ...entry,
-                disabled: appliesToFilter ? !entryMatchesFilter(entry, appliesToFilter) : false,
-                hidden: query ? !entryMatchesSearch(entry, query) : false,
-            })),
-        }));
-    }, [groups, appliesToFilter, query]);
-
-    // Extract favourite entries from all groups, preserving their order
-    // as specified in the favourites array.
-    const favouriteEntries = useMemo<ProcessedEntry[]>(() => {
-        if (favouriteSet.size === 0) {
-            return [];
+    /**
+     * Scroll the keyboard-highlighted button into view.
+     */
+    useEffect(() => {
+        if (highlightedKey && contentRef.current) {
+            const el = contentRef.current.querySelector(`[data-nav-key="${highlightedKey}"]`);
+            el?.scrollIntoView({ block: "nearest" });
         }
-        const allEntries = processedGroups.flatMap((g) => g.entries);
-        return favourites
-            .map((type) => {
-                const shortName = type.split(":")[1]?.toLowerCase() ?? "";
-                return allEntries.find((e) => {
-                    const normalizedLabel = e.entry.label.toLowerCase().replace(/[\s-]/g, "");
-                    if (normalizedLabel === shortName) return true;
-                    const normalizedId = e.id.toLowerCase().replace(/[\s-]/g, "");
-                    return normalizedId.includes(shortName);
-                });
-            })
-            .filter((e): e is ProcessedEntry => e !== undefined);
-    }, [favourites, favouriteSet, processedGroups]);
+    }, [highlightedKey]);
 
     return (
         <div class={`am-palette-panel ${expanded ? "am-palette-panel--expanded" : ""}`}>
@@ -145,7 +74,7 @@ export function BpmnElementPalette({
                     </svg>
                 </button>
             </div>
-            <div class="am-palette-content">
+            <div class="am-palette-content" ref={contentRef}>
                 {/* Favourites section — pinned at the top */}
                 {favouriteEntries.length > 0 && (
                     <div class="am-bpmn-group am-bpmn-group--favourites">
@@ -153,11 +82,14 @@ export function BpmnElementPalette({
                         <div class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}>
                             {favouriteEntries.map(({ id, entry, disabled, hidden }) => {
                                 if (hidden) return null;
+                                const navKey = `fav:${id}`;
                                 const isDisabled = disabled || !!entry.disabled;
+                                const isFocused = navKey === highlightedKey;
                                 return (
                                     <button
-                                        key={`fav-${id}`}
-                                        class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
+                                        key={navKey}
+                                        data-nav-key={navKey}
+                                        class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${isFocused ? "am-bpmn-button--focused" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
                                         disabled={isDisabled}
                                         onClick={(e) =>
                                             onSelect(entry.action, e as unknown as Event)
@@ -179,7 +111,7 @@ export function BpmnElementPalette({
                 )}
 
                 {/* Regular groups */}
-                {processedGroups.map((group) => {
+                {groups.map((group) => {
                     const visibleEntries = group.entries.filter((e) => !e.hidden);
                     if (visibleEntries.length === 0) {
                         return null;
@@ -189,11 +121,14 @@ export function BpmnElementPalette({
                             {expanded && <h4 class="am-bpmn-group-title">{group.name}</h4>}
                             <div class={`am-bpmn-grid ${expanded ? "" : "am-bpmn-grid--compact"}`}>
                                 {visibleEntries.map(({ id, entry, disabled }) => {
+                                    const navKey = `grp:${group.id}:${id}`;
                                     const isDisabled = disabled || !!entry.disabled;
+                                    const isFocused = navKey === highlightedKey;
                                     return (
                                         <button
-                                            key={id}
-                                            class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
+                                            key={navKey}
+                                            data-nav-key={navKey}
+                                            class={`am-bpmn-button ${isDisabled ? "am-bpmn-button--disabled" : ""} ${isFocused ? "am-bpmn-button--focused" : ""} ${expanded ? "" : "am-bpmn-button--icon-only"}`}
                                             disabled={isDisabled}
                                             onClick={(e) =>
                                                 onSelect(entry.action, e as unknown as Event)

--- a/libs/append-menu/src/components/TemplatePanel.tsx
+++ b/libs/append-menu/src/components/TemplatePanel.tsx
@@ -1,37 +1,30 @@
 /**
  * Left panel of the append menu overlay.
  *
- * Displays a filterable list of element template entries with category
- * filter chips.  Hovering or focusing a card displays a floating
- * {@link TemplateHoverCard} to the right of the panel.
+ * A thin renderer of the already-filtered template list. Filtering and
+ * keyboard-highlight state live in the parent overlay (see
+ * {@link ../filtering} and {@link ../navigation}) so both columns share one
+ * source of truth; this panel only renders cards and the floating
+ * {@link TemplateHoverCard}.
  */
-import { useMemo, useEffect, useRef, useState, useCallback } from "preact/hooks";
+import { useEffect, useRef, useState, useMemo, useCallback } from "preact/hooks";
 import type { EnrichedTemplateEntry } from "../types";
+import type { TemplateCategory } from "../filtering";
 import { ExpandableTemplateCard } from "./ExpandableTemplateCard";
 import { TemplateHoverCard } from "./TemplateHoverCard";
 
 // Delay in ms before the hover card hides after mouse leave.
 const HOVER_HIDE_DELAY = 150;
 
-/**
- * Converts a BPMN type string to a human-readable label for search matching.
- *
- * E.g. `"bpmn:ServiceTask"` → `"service task"`,
- *      `"bpmn:CallActivity"` → `"call activity"`.
- *
- * @param bpmnType The BPMN type string.
- * @returns A lowercase, space-separated label.
- */
-function bpmnTypeToLabel(bpmnType: string): string {
-    const shortName = bpmnType.split(":")[1] ?? bpmnType;
-    return shortName.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
-}
-
 interface TemplatePanelProps {
     entries: EnrichedTemplateEntry[];
+    categories: TemplateCategory[];
+    /** Non-empty when a search is active — drives only the empty-state hint. */
     search: string;
     activeCategory: string | null;
     selectedTemplateId: string | null;
+    /** Index of the keyboard-highlighted card, or -1 when in the other column. */
+    highlightedIndex: number;
     onCategoryChange: (cat: string | null) => void;
     onTemplateClick: (enriched: EnrichedTemplateEntry, event: Event) => void;
 }
@@ -39,114 +32,56 @@ interface TemplatePanelProps {
 /**
  * Renders the template list panel with category chips and cards.
  *
- * Search filtering matches against template name, description, keywords,
- * category name, and the human-readable names of the template's
- * `appliesTo` types (e.g. searching "service task" finds templates that
- * apply to `bpmn:ServiceTask`).
+ * The keyboard highlight (owned by the overlay) drives the focused card, the
+ * scroll-into-view, and — as a fallback when the mouse isn't hovering — the
+ * floating hover card, so arrow-key navigation always previews the detail card.
  *
- * A floating hover card appears to the right of the panel when a card
- * is hovered or keyboard-focused, showing detailed template info without
- * causing layout shifts in the list.
- *
- * @param props.entries Enriched template entries to display.
- * @param props.search Current search query (from the shared search bar).
+ * @param props.entries Already-filtered template entries to display.
+ * @param props.categories All categories (from the unfiltered list) for chips.
+ * @param props.search Current search query (empty-state hint only).
  * @param props.activeCategory Currently selected category filter, or null.
- * @param props.selectedTemplateId ID of the currently selected multi-type template, or null.
+ * @param props.selectedTemplateId ID of the selected multi-type template, or null.
+ * @param props.highlightedIndex Keyboard-highlighted card index, or -1.
  * @param props.onCategoryChange Callback when a category chip is toggled.
  * @param props.onTemplateClick Callback when a template card is clicked.
  */
 export function TemplatePanel({
     entries,
+    categories,
     search,
     activeCategory,
     selectedTemplateId,
+    highlightedIndex,
     onCategoryChange,
     onTemplateClick,
 }: TemplatePanelProps) {
     const panelRef = useRef<HTMLDivElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
-    const [focusIndex, setFocusIndex] = useState(-1);
     const [hoveredIndex, setHoveredIndex] = useState(-1);
     const hideTimeoutRef = useRef<number>(0);
 
     /**
      * The index whose hover card is currently displayed.
-     * Mouse hover takes priority; keyboard focus is used as fallback.
+     * Mouse hover takes priority; the keyboard highlight is the fallback.
      */
-    const activePreviewIndex = hoveredIndex >= 0 ? hoveredIndex : focusIndex;
-
-    // Extract unique categories from the full ElementTemplate objects.
-    const categories = useMemo(() => {
-        const seen = new Map<string, string>();
-        for (const { template } of entries) {
-            if (template?.category) {
-                seen.set(template.category.id, template.category.name);
-            }
-        }
-        return Array.from(seen.entries()).map(([id, name]) => ({ id, name }));
-    }, [entries]);
-
-    // Filter templates by search query and active category.
-    const filtered = useMemo(() => {
-        const q = search.toLowerCase().trim();
-        return entries.filter(({ entry, template }) => {
-            if (activeCategory && template?.category?.id !== activeCategory) {
-                return false;
-            }
-            if (!q) {
-                return true;
-            }
-            // Build searchable text from name, description, keywords,
-            // category, and appliesTo type labels.
-            const appliesToLabels = (template?.appliesTo ?? []).map(bpmnTypeToLabel);
-            const haystack = [
-                entry.label,
-                entry.description ?? "",
-                template?.category?.name ?? "",
-                ...(entry.search ?? []),
-                ...appliesToLabels,
-            ]
-                .join(" ")
-                .toLowerCase();
-            return haystack.includes(q);
-        });
-    }, [entries, search, activeCategory]);
+    const activePreviewIndex = hoveredIndex >= 0 ? hoveredIndex : highlightedIndex;
 
     /**
-     * Reset focus and hover when filter results change.
+     * Drop stale mouse-hover state when the filtered list changes.
      */
     useEffect(() => {
-        setFocusIndex(-1);
         setHoveredIndex(-1);
-    }, [filtered.length]);
-
-    // Keyboard navigation within the template list.
-    const handleKeyDown = useCallback(
-        (e: KeyboardEvent) => {
-            if (e.key === "ArrowDown") {
-                e.preventDefault();
-                setFocusIndex((prev) => Math.min(prev + 1, filtered.length - 1));
-            } else if (e.key === "ArrowUp") {
-                e.preventDefault();
-                setFocusIndex((prev) => Math.max(prev - 1, 0));
-            } else if (e.key === "Enter" && focusIndex >= 0 && focusIndex < filtered.length) {
-                e.preventDefault();
-                const focused = filtered[focusIndex];
-                onTemplateClick(focused, e as unknown as Event);
-            }
-        },
-        [filtered, focusIndex, onTemplateClick],
-    );
+    }, [entries.length]);
 
     /**
-     * Scroll focused item into view.
+     * Scroll the keyboard-highlighted item into view.
      */
     useEffect(() => {
-        if (focusIndex >= 0 && listRef.current) {
+        if (highlightedIndex >= 0 && listRef.current) {
             const items = listRef.current.querySelectorAll(".am-template-card");
-            items[focusIndex]?.scrollIntoView({ block: "nearest" });
+            items[highlightedIndex]?.scrollIntoView({ block: "nearest" });
         }
-    }, [focusIndex]);
+    }, [highlightedIndex]);
 
     /**
      * Handles hover state changes from individual cards.
@@ -199,10 +134,10 @@ export function TemplatePanel({
         return { top, left, maxHeight };
     }, [activePreviewIndex]);
 
-    const activeEntry = activePreviewIndex >= 0 ? filtered[activePreviewIndex] : null;
+    const activeEntry = activePreviewIndex >= 0 ? entries[activePreviewIndex] : null;
 
     return (
-        <div class="am-template-panel" ref={panelRef} onKeyDown={handleKeyDown}>
+        <div class="am-template-panel" ref={panelRef}>
             {/* Category filter chips */}
             {categories.length > 0 && (
                 <div class="am-filters">
@@ -230,17 +165,17 @@ export function TemplatePanel({
 
             {/* Template list */}
             <div class="am-template-list" ref={listRef}>
-                {filtered.length === 0 ? (
+                {entries.length === 0 ? (
                     <div class="am-empty">
                         <p class="am-empty-text">No templates found</p>
                         {search && <p class="am-empty-hint">Try a different search term</p>}
                     </div>
                 ) : (
-                    filtered.map((enriched, idx) => (
+                    entries.map((enriched, idx) => (
                         <ExpandableTemplateCard
                             key={enriched.id}
                             enrichedEntry={enriched}
-                            focused={focusIndex === idx}
+                            focused={highlightedIndex === idx}
                             selected={selectedTemplateId === enriched.id}
                             onClick={(event) => onTemplateClick(enriched, event)}
                             onHoverChange={(hovered) => handleCardHover(idx, hovered)}

--- a/libs/append-menu/src/components/TemplatePanel.tsx
+++ b/libs/append-menu/src/components/TemplatePanel.tsx
@@ -124,8 +124,14 @@ export function TemplatePanel({
         const cardRect = card.getBoundingClientRect();
         const viewportHeight = window.innerHeight;
 
-        // Position overlapping the template list, starting near its midpoint.
-        const left = cardRect.left + cardRect.width * 0.5;
+        const panelRect = panelRef.current.getBoundingClientRect();
+        // Open to the left of the panel so the card clears both the template list
+        // and the BPMN palette. Clamp to the viewport edge on the rare occasion the
+        // 540px panel sits hard against the left (then it may touch the panel, but
+        // never runs off-screen).
+        const HOVER_CARD_WIDTH = 300; // keep in sync with .am-hover-card width
+        const GAP = 8;
+        const left = Math.max(GAP, panelRect.left - HOVER_CARD_WIDTH - GAP);
 
         // Vertically align with the card, clamped to viewport.
         const top = Math.max(8, Math.min(cardRect.top, viewportHeight - 200));

--- a/libs/append-menu/src/filtering.spec.ts
+++ b/libs/append-menu/src/filtering.spec.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    extractCategories,
+    filterTemplates,
+    flattenPaletteItems,
+    processPaletteGroups,
+} from "./filtering";
+import type { BpmnElementGroup, EnrichedTemplateEntry, PopupMenuEntry } from "./types";
+
+const noop = (): void => {};
+
+/** Builds an enriched template entry with a minimal template stub. */
+function template(
+    id: string,
+    label: string,
+    opts: {
+        appliesTo?: string[];
+        category?: { id: string; name: string };
+        search?: string[];
+        description?: string;
+    } = {},
+): EnrichedTemplateEntry {
+    const entry: PopupMenuEntry = {
+        label,
+        description: opts.description,
+        search: opts.search,
+        action: noop,
+    };
+    return {
+        id: `append.template-${id}`,
+        entry,
+        template: {
+            id,
+            appliesTo: opts.appliesTo ?? [],
+            category: opts.category,
+        } as never,
+    };
+}
+
+/** Builds a BPMN element group. */
+function group(id: string, name: string, entries: [string, string][]): BpmnElementGroup {
+    return {
+        id,
+        name,
+        entries: entries.map(([entryId, label]) => ({
+            id: entryId,
+            entry: { label, action: noop } as PopupMenuEntry,
+        })),
+    };
+}
+
+describe("filterTemplates", () => {
+    const entries = [
+        template("http", "HTTP Worker", { appliesTo: ["bpmn:ServiceTask"], search: ["rest"] }),
+        template("mail", "Send Mail", { appliesTo: ["bpmn:SendTask"] }),
+        template("user", "Approval", {
+            appliesTo: ["bpmn:UserTask"],
+            category: { id: "human", name: "Human" },
+        }),
+    ];
+
+    it("returns all entries for an empty search and no category", () => {
+        expect(filterTemplates(entries, "", null)).toHaveLength(3);
+    });
+
+    it("matches templates by their appliesTo type label", () => {
+        // "service task" must surface the bpmn:ServiceTask template.
+        const result = filterTemplates(entries, "service task", null);
+        expect(result.map((e) => e.template?.id)).toEqual(["http"]);
+    });
+
+    it("matches by keyword search terms", () => {
+        expect(filterTemplates(entries, "rest", null).map((e) => e.template?.id)).toEqual(["http"]);
+    });
+
+    it("filters by active category", () => {
+        expect(filterTemplates(entries, "", "human").map((e) => e.template?.id)).toEqual(["user"]);
+    });
+});
+
+describe("extractCategories", () => {
+    it("returns unique categories from the unfiltered list", () => {
+        const entries = [
+            template("a", "A", { category: { id: "c1", name: "One" } }),
+            template("b", "B", { category: { id: "c2", name: "Two" } }),
+            template("c", "C", { category: { id: "c1", name: "One" } }),
+            template("d", "D"),
+        ];
+        expect(extractCategories(entries)).toEqual([
+            { id: "c1", name: "One" },
+            { id: "c2", name: "Two" },
+        ]);
+    });
+});
+
+describe("processPaletteGroups", () => {
+    const groups = [
+        group("tasks", "Tasks", [
+            ["create.service-task", "Service Task"],
+            ["create.user-task", "User Task"],
+        ]),
+        group("gateways", "Gateways", [["create.exclusive-gateway", "Exclusive Gateway"]]),
+    ];
+
+    it("marks nothing disabled or hidden without a filter or search", () => {
+        const p = processPaletteGroups(groups, [], "", null);
+        const flags = p.groups.flatMap((g) => g.entries.map((e) => [e.disabled, e.hidden]));
+        expect(flags.every(([d, h]) => !d && !h)).toBe(true);
+    });
+
+    it("disables entries that fail the appliesTo filter but keeps them visible", () => {
+        const p = processPaletteGroups(groups, [], "", new Set(["bpmn:ServiceTask"]));
+        const service = p.groups[0].entries.find((e) => e.entry.label === "Service Task")!;
+        const user = p.groups[0].entries.find((e) => e.entry.label === "User Task")!;
+        expect(service.disabled).toBe(false);
+        expect(user.disabled).toBe(true);
+        // disabled is not hidden — the button still renders greyed out.
+        expect(user.hidden).toBe(false);
+    });
+
+    it("hides entries that fail the search but leaves them enabled", () => {
+        const p = processPaletteGroups(groups, [], "gateway", null);
+        const gateway = p.groups[1].entries[0];
+        const service = p.groups[0].entries[0];
+        expect(gateway.hidden).toBe(false);
+        expect(service.hidden).toBe(true);
+        expect(service.disabled).toBe(false);
+    });
+
+    it("resolves favourites in the given order", () => {
+        const p = processPaletteGroups(groups, ["bpmn:UserTask", "bpmn:ServiceTask"], "", null);
+        expect(p.favouriteEntries.map((e) => e.entry.label)).toEqual(["User Task", "Service Task"]);
+    });
+});
+
+describe("flattenPaletteItems", () => {
+    const groups = [group("tasks", "Tasks", [["create.service-task", "Service Task"]])];
+
+    it("namespaces favourite and group instances of the same entry distinctly", () => {
+        const processed = processPaletteGroups(groups, ["bpmn:ServiceTask"], "", null);
+        const items = flattenPaletteItems(processed);
+        expect(items.map((i) => i.key)).toEqual([
+            "fav:create.service-task",
+            "grp:tasks:create.service-task",
+        ]);
+    });
+
+    it("carries disabled/hidden flags through to the flattened items", () => {
+        const processed = processPaletteGroups(groups, [], "gateway", new Set(["bpmn:UserTask"]));
+        const item = flattenPaletteItems(processed).find((i) => i.key.startsWith("grp:"))!;
+        expect(item.disabled).toBe(true); // fails the appliesTo filter
+        expect(item.hidden).toBe(true); // fails the search
+    });
+});

--- a/libs/append-menu/src/filtering.ts
+++ b/libs/append-menu/src/filtering.ts
@@ -1,0 +1,243 @@
+/**
+ * Pure filter derivations for the append menu, extracted from the panel
+ * components so the overlay can compute the exact navigable order of both
+ * columns once and feed the components as thin renderers.
+ *
+ * Keeping these DOM-free makes the keyboard-navigation order (see
+ * {@link ./navigation}) unit-testable and prevents the two columns from each
+ * re-deriving their own — and therefore divergent — filtered lists.
+ */
+import type {
+    EnrichedTemplateEntry,
+    BpmnElementGroup,
+    BpmnElementEntry,
+    PopupMenuEntry,
+} from "./types";
+
+/** A template category surfaced as a filter chip. */
+export interface TemplateCategory {
+    id: string;
+    name: string;
+}
+
+/**
+ * Converts a BPMN type string to a human-readable label for search matching.
+ *
+ * E.g. `"bpmn:ServiceTask"` → `"service task"`. Lets a search for
+ * "service task" surface templates that apply to `bpmn:ServiceTask`.
+ *
+ * @param bpmnType The BPMN type string.
+ * @returns A lowercase, space-separated label.
+ */
+function bpmnTypeToLabel(bpmnType: string): string {
+    const shortName = bpmnType.split(":")[1] ?? bpmnType;
+    return shortName.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
+}
+
+/**
+ * Filters template entries by search query and active category.
+ *
+ * Matches against name, description, keywords, category name, and the
+ * human-readable names of the template's `appliesTo` types.
+ *
+ * @param entries All enriched template entries.
+ * @param search The raw search query.
+ * @param activeCategory The selected category id, or null for all.
+ * @returns The filtered entries in their original order.
+ */
+export function filterTemplates(
+    entries: EnrichedTemplateEntry[],
+    search: string,
+    activeCategory: string | null,
+): EnrichedTemplateEntry[] {
+    const q = search.toLowerCase().trim();
+    return entries.filter(({ entry, template }) => {
+        if (activeCategory && template?.category?.id !== activeCategory) {
+            return false;
+        }
+        if (!q) {
+            return true;
+        }
+        const appliesToLabels = (template?.appliesTo ?? []).map(bpmnTypeToLabel);
+        const haystack = [
+            entry.label,
+            entry.description ?? "",
+            template?.category?.name ?? "",
+            ...(entry.search ?? []),
+            ...appliesToLabels,
+        ]
+            .join(" ")
+            .toLowerCase();
+        return haystack.includes(q);
+    });
+}
+
+/**
+ * Extracts the unique categories from the *unfiltered* template list.
+ *
+ * The chips must keep showing every category regardless of the active
+ * search/category filter, so this deliberately reads from the full list.
+ *
+ * @param entries All enriched template entries.
+ * @returns Unique `{ id, name }` categories in first-seen order.
+ */
+export function extractCategories(entries: EnrichedTemplateEntry[]): TemplateCategory[] {
+    const seen = new Map<string, string>();
+    for (const { template } of entries) {
+        if (template?.category) {
+            seen.set(template.category.id, template.category.name);
+        }
+    }
+    return Array.from(seen.entries()).map(([id, name]) => ({ id, name }));
+}
+
+// ─── Palette processing ──────────────────────────────────────────────────
+
+/** A palette entry annotated with its filter state. */
+export interface ProcessedEntry extends BpmnElementEntry {
+    /** Greyed out (fails the selected multi-type template's `appliesTo`). */
+    disabled: boolean;
+    /** Not rendered (fails the current search). */
+    hidden: boolean;
+}
+
+/** A palette group with its entries annotated. */
+export interface ProcessedGroup {
+    id: string;
+    name: string;
+    entries: ProcessedEntry[];
+}
+
+/** The favourites row plus the categorised groups, all annotated. */
+export interface ProcessedPalette {
+    favouriteEntries: ProcessedEntry[];
+    groups: ProcessedGroup[];
+}
+
+/**
+ * Checks whether a BPMN palette entry matches any type in a filter set.
+ */
+function entryMatchesFilter(entry: BpmnElementEntry, filter: Set<string>): boolean {
+    for (const bpmnType of filter) {
+        const shortName = bpmnType.split(":")[1]?.toLowerCase() ?? "";
+        const normalizedLabel = entry.entry.label.toLowerCase().replace(/[\s-]/g, "");
+        if (normalizedLabel === shortName) {
+            return true;
+        }
+        const normalizedId = entry.id.toLowerCase().replace(/[\s-]/g, "");
+        if (normalizedId.includes(shortName)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Checks whether a BPMN palette entry matches a search query.
+ */
+function entryMatchesSearch(entry: BpmnElementEntry, query: string): boolean {
+    const haystack = [entry.entry.label, entry.entry.description ?? ""].join(" ").toLowerCase();
+    return haystack.includes(query);
+}
+
+/**
+ * Finds a favourite BPMN entry by its type string among all palette entries.
+ *
+ * Matches on the normalized label first, then on the entry id — the same
+ * fuzzy matching the palette originally used.
+ */
+function findFavouriteEntry(entries: ProcessedEntry[], type: string): ProcessedEntry | undefined {
+    const shortName = type.split(":")[1]?.toLowerCase() ?? "";
+    return entries.find((e) => {
+        const normalizedLabel = e.entry.label.toLowerCase().replace(/[\s-]/g, "");
+        if (normalizedLabel === shortName) return true;
+        const normalizedId = e.id.toLowerCase().replace(/[\s-]/g, "");
+        return normalizedId.includes(shortName);
+    });
+}
+
+/**
+ * Annotates palette groups with disabled/hidden state and resolves the
+ * favourites row, preserving the order given in `favourites`.
+ *
+ * @param groups BPMN element entries grouped by category.
+ * @param favourites Ordered BPMN type strings to pin at the top.
+ * @param search The raw search query.
+ * @param appliesToFilter Set of BPMN types to keep enabled, or null for all.
+ * @returns The favourites row plus annotated groups.
+ */
+export function processPaletteGroups(
+    groups: BpmnElementGroup[],
+    favourites: string[],
+    search: string,
+    appliesToFilter: Set<string> | null,
+): ProcessedPalette {
+    const query = search.toLowerCase().trim();
+
+    const processedGroups: ProcessedGroup[] = groups.map((group) => ({
+        ...group,
+        entries: group.entries.map((entry) => ({
+            ...entry,
+            disabled: appliesToFilter ? !entryMatchesFilter(entry, appliesToFilter) : false,
+            hidden: query ? !entryMatchesSearch(entry, query) : false,
+        })),
+    }));
+
+    if (favourites.length === 0) {
+        return { favouriteEntries: [], groups: processedGroups };
+    }
+
+    const allEntries = processedGroups.flatMap((g) => g.entries);
+    const favouriteEntries = favourites
+        .map((type) => findFavouriteEntry(allEntries, type))
+        .filter((e): e is ProcessedEntry => e !== undefined);
+
+    return { favouriteEntries, groups: processedGroups };
+}
+
+// ─── Flattened navigation order ──────────────────────────────────────────
+
+/**
+ * One navigable palette slot in render order.
+ *
+ * `key` is namespaced (`fav:{id}` vs `grp:{groupId}:{id}`) because a favourite
+ * renders twice — once in the favourites row and once in its own group — so a
+ * bare entry id would collide and highlight both instances at once.
+ */
+export interface PaletteNavItem {
+    key: string;
+    entry: PopupMenuEntry;
+    disabled: boolean;
+    hidden: boolean;
+}
+
+/**
+ * Flattens the processed palette into the exact render order: favourites
+ * first, then each group's entries. Feeds both the keyboard navigation
+ * (visible, enabled items) and the highlight→action resolution.
+ *
+ * @param processed Output of {@link processPaletteGroups}.
+ * @returns Navigable slots in render order (including hidden ones).
+ */
+export function flattenPaletteItems(processed: ProcessedPalette): PaletteNavItem[] {
+    const items: PaletteNavItem[] = [];
+    for (const e of processed.favouriteEntries) {
+        items.push({
+            key: `fav:${e.id}`,
+            entry: e.entry,
+            disabled: e.disabled || !!e.entry.disabled,
+            hidden: e.hidden,
+        });
+    }
+    for (const group of processed.groups) {
+        for (const e of group.entries) {
+            items.push({
+                key: `grp:${group.id}:${e.id}`,
+                entry: e.entry,
+                disabled: e.disabled || !!e.entry.disabled,
+                hidden: e.hidden,
+            });
+        }
+    }
+    return items;
+}

--- a/libs/append-menu/src/navigation.spec.ts
+++ b/libs/append-menu/src/navigation.spec.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import {
+    initialHighlight,
+    moveHorizontal,
+    moveVertical,
+    type NavColumns,
+    type NavItem,
+} from "./navigation";
+
+/** Builds a column where every `true` marks a disabled slot. */
+function col(...disabled: boolean[]): NavItem[] {
+    return disabled.map((d) => ({ disabled: d }));
+}
+
+const cols = (templates: NavItem[], palette: NavItem[]): NavColumns => ({ templates, palette });
+
+describe("initialHighlight", () => {
+    it("picks the first enabled template", () => {
+        expect(initialHighlight(cols(col(false, false), col(false)))).toEqual({
+            column: "templates",
+            index: 0,
+        });
+    });
+
+    it("skips leading disabled templates", () => {
+        expect(initialHighlight(cols(col(true, false), col(false)))).toEqual({
+            column: "templates",
+            index: 1,
+        });
+    });
+
+    it("falls back to the palette when templates are empty", () => {
+        expect(initialHighlight(cols(col(), col(true, false)))).toEqual({
+            column: "palette",
+            index: 1,
+        });
+    });
+
+    it("falls back to the palette when all templates are disabled", () => {
+        expect(initialHighlight(cols(col(true, true), col(false)))).toEqual({
+            column: "palette",
+            index: 0,
+        });
+    });
+
+    it("returns null when nothing is navigable", () => {
+        expect(initialHighlight(cols(col(true), col(true)))).toBeNull();
+        expect(initialHighlight(cols(col(), col()))).toBeNull();
+    });
+});
+
+describe("moveVertical", () => {
+    it("moves down within a column", () => {
+        const c = cols(col(false, false, false), col(false));
+        expect(moveVertical({ column: "templates", index: 0 }, 1, c)).toEqual({
+            column: "templates",
+            index: 1,
+        });
+    });
+
+    it("wraps around from the last item to the first", () => {
+        const c = cols(col(false, false), col(false));
+        expect(moveVertical({ column: "templates", index: 1 }, 1, c)).toEqual({
+            column: "templates",
+            index: 0,
+        });
+    });
+
+    it("wraps around from the first item to the last going up", () => {
+        const c = cols(col(false, false, false), col(false));
+        expect(moveVertical({ column: "templates", index: 0 }, -1, c)).toEqual({
+            column: "templates",
+            index: 2,
+        });
+    });
+
+    it("skips disabled items", () => {
+        const c = cols(col(false, true, false), col(false));
+        expect(moveVertical({ column: "templates", index: 0 }, 1, c)).toEqual({
+            column: "templates",
+            index: 2,
+        });
+    });
+
+    it("stays put when every other item is disabled", () => {
+        const c = cols(col(false, true, true), col(false));
+        expect(moveVertical({ column: "templates", index: 0 }, 1, c)).toEqual({
+            column: "templates",
+            index: 0,
+        });
+    });
+});
+
+describe("moveHorizontal", () => {
+    it("moves right from templates into the palette", () => {
+        const c = cols(col(false, false), col(false, false));
+        expect(moveHorizontal({ column: "templates", index: 1 }, 1, c)).toEqual({
+            column: "palette",
+            index: 1,
+        });
+    });
+
+    it("moves left from the palette into templates", () => {
+        const c = cols(col(false, false), col(false, false));
+        expect(moveHorizontal({ column: "palette", index: 0 }, -1, c)).toEqual({
+            column: "templates",
+            index: 0,
+        });
+    });
+
+    it("clamps the index to the target column length", () => {
+        const c = cols(col(false, false, false), col(false));
+        expect(moveHorizontal({ column: "templates", index: 2 }, 1, c)).toEqual({
+            column: "palette",
+            index: 0,
+        });
+    });
+
+    it("lands on the nearest enabled item when the clamped slot is disabled", () => {
+        const c = cols(col(false, false), col(true, false));
+        expect(moveHorizontal({ column: "templates", index: 0 }, 1, c)).toEqual({
+            column: "palette",
+            index: 1,
+        });
+    });
+
+    it("is a no-op when already in the target column", () => {
+        const c = cols(col(false), col(false, false));
+        const h = { column: "palette", index: 1 } as const;
+        expect(moveHorizontal(h, 1, c)).toBe(h);
+    });
+
+    it("is a no-op when the target column is empty", () => {
+        const c = cols(col(false), col());
+        const h = { column: "templates", index: 0 } as const;
+        expect(moveHorizontal(h, 1, c)).toBe(h);
+    });
+
+    it("is a no-op when the target column has no enabled item", () => {
+        const c = cols(col(false), col(true, true));
+        const h = { column: "templates", index: 0 } as const;
+        expect(moveHorizontal(h, 1, c)).toBe(h);
+    });
+});
+
+describe("palette-only mode", () => {
+    it("starts the highlight in the palette and treats horizontal as a no-op", () => {
+        const c = cols(col(), col(false, false));
+        const h = initialHighlight(c);
+        expect(h).toEqual({ column: "palette", index: 0 });
+        // ArrowLeft targets templates, which is empty → no-op.
+        expect(moveHorizontal(h!, -1, c)).toBe(h);
+    });
+});

--- a/libs/append-menu/src/navigation.ts
+++ b/libs/append-menu/src/navigation.ts
@@ -1,0 +1,115 @@
+/**
+ * Pure highlight reducer for the append menu's two-column keyboard navigation.
+ *
+ * The overlay owns a single `Highlight | null` and derives both columns'
+ * navigable items (templates on the left, palette on the right). Keeping the
+ * movement logic here — DOM-free and column-agnostic — lets it be unit-tested
+ * and keeps the components as thin renderers.
+ */
+
+/** The two navigable columns. `templates` is left, `palette` is right. */
+export type ColumnId = "templates" | "palette";
+
+/** One navigable slot. Disabled slots render but are skipped by movement. */
+export interface NavItem {
+    disabled: boolean;
+}
+
+/** The navigable slots of both columns, in render order. */
+export interface NavColumns {
+    templates: readonly NavItem[];
+    palette: readonly NavItem[];
+}
+
+/** The currently highlighted slot. */
+export interface Highlight {
+    column: ColumnId;
+    index: number;
+}
+
+function itemsOf(cols: NavColumns, column: ColumnId): readonly NavItem[] {
+    return column === "templates" ? cols.templates : cols.palette;
+}
+
+/**
+ * The first enabled index in `items`, or -1 if every item is disabled/empty.
+ */
+function firstEnabled(items: readonly NavItem[]): number {
+    for (let i = 0; i < items.length; i++) {
+        if (!items[i].disabled) return i;
+    }
+    return -1;
+}
+
+/**
+ * The enabled index nearest to `preferred`, expanding outward (down first,
+ * then up). Returns -1 when the column has no enabled item.
+ */
+function nearestEnabled(items: readonly NavItem[], preferred: number): number {
+    const len = items.length;
+    if (len === 0) return -1;
+    const start = Math.min(Math.max(preferred, 0), len - 1);
+    if (!items[start].disabled) return start;
+    for (let d = 1; d < len; d++) {
+        const down = start + d;
+        if (down < len && !items[down].disabled) return down;
+        const up = start - d;
+        if (up >= 0 && !items[up].disabled) return up;
+    }
+    return -1;
+}
+
+/**
+ * The initial highlight: first enabled item, templates preferred. Falls back
+ * to the palette when templates are empty or fully disabled, and to null when
+ * nothing is navigable.
+ */
+export function initialHighlight(cols: NavColumns): Highlight | null {
+    const t = firstEnabled(cols.templates);
+    if (t >= 0) return { column: "templates", index: t };
+    const p = firstEnabled(cols.palette);
+    if (p >= 0) return { column: "palette", index: p };
+    return null;
+}
+
+/**
+ * Moves the highlight up (`dir = -1`) or down (`dir = 1`) within its column,
+ * wrapping around and skipping disabled items.
+ *
+ * @param h The current highlight.
+ * @param dir -1 for up, 1 for down.
+ * @param cols The navigable columns.
+ * @returns The new highlight (unchanged if no other enabled item exists).
+ */
+export function moveVertical(h: Highlight, dir: -1 | 1, cols: NavColumns): Highlight {
+    const items = itemsOf(cols, h.column);
+    const len = items.length;
+    if (len === 0) return h;
+    let next = h.index;
+    for (let step = 0; step < len; step++) {
+        next = (next + dir + len) % len;
+        if (!items[next].disabled) {
+            return { column: h.column, index: next };
+        }
+    }
+    return h;
+}
+
+/**
+ * Switches columns: `dir = 1` (right) targets the palette, `dir = -1` (left)
+ * targets the templates. The index is clamped to the nearest enabled item in
+ * the target column. No-op when already in the target column or when the
+ * target column has no enabled item.
+ *
+ * @param h The current highlight.
+ * @param dir -1 to move left (templates), 1 to move right (palette).
+ * @param cols The navigable columns.
+ * @returns The new highlight, or the original when the move is a no-op.
+ */
+export function moveHorizontal(h: Highlight, dir: -1 | 1, cols: NavColumns): Highlight {
+    const target: ColumnId = dir > 0 ? "palette" : "templates";
+    if (target === h.column) return h;
+    const index = nearestEnabled(itemsOf(cols, target), h.index);
+    if (index < 0) return h;
+    return { column: target, index };
+}

--- a/libs/append-menu/vitest.config.ts
+++ b/libs/append-menu/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        name: "append-menu",
+        environment: "node",
+        include: ["src/**/*.{spec,test}.ts"],
+    },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
             "apps/vscode-plugin",
             "apps/modeler-bridge",
             "apps/bpmn-webview",
+            "libs/append-menu",
             "libs/bpmn-i18n",
             "libs/element-template-chooser",
             "libs/modeler-core",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3529,6 +3529,7 @@ __metadata:
     bpmn-js: "npm:18.19.0"
     preact: "npm:10.29.3"
     typescript: "npm:6.0.3"
+    vitest: "npm:4.1.9"
   peerDependencies:
     bpmn-js: 18.19.0
   languageName: unknown


### PR DESCRIPTION
**Issue**



**Description**

Enables fully keyboard-driven modelling in the BPMN webview. Pressing Escape now returns focus to the canvas from the properties panel or any search field, so bpmn-js's canvas-bound shortcuts (`A` = append menu, `N` = create menu, arrow keys) become reachable without the mouse; an open diagram search pad is closed explicitly because it only dismisses on keyup. The custom append menu's arrow-key navigation — previously dead code on the wrong DOM node — now works from the permanently focused search field: ↑/↓ move a highlight in the active column, ←/→ switch between the template and BPMN-element columns (auto-expanding the collapsed palette), and Enter selects. After selecting or cancelling in the menu, focus returns to the canvas so `A → ↓ → Enter → A → …` chains. The filtering logic moved out of the panel components into pure, unit-tested modules (`filtering.ts`, `navigation.ts`), and `libs/append-menu` is now wired into the root Vitest projects.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created

