### PR TITLE
fix(demo-webapp): make the Netlify monorepo build install cleanly

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,12 @@
 # Netlify config for the static BPMN/DMN modeler demo.
 
 [build]
-  command = "corepack enable && yarn build:demo"
+  command = "corepack enable && YARN_ENABLE_SCRIPTS=true corepack yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-demo-webapp && corepack yarn build:demo"
   publish = "dist/demo"
 
 [build.environment]
   NODE_VERSION = "22"
+  YARN_ENABLE_SCRIPTS = "false"
 
 [[redirects]]
   from = "/"


### PR DESCRIPTION
## Problem

The Netlify build for the demo fails during dependency install: a full monorepo `yarn install` tries to compile `apps/standalone`'s native `native-keymap`, which needs X11/`libxkbfile` that the Netlify build image lacks. Netlify's automatic install cannot be disabled.

## Fix (keeps the Netlify git integration)

Two-step install, entirely in `netlify.toml`:

1. **`YARN_ENABLE_SCRIPTS = "false"`** in `[build.environment]` → Netlify's automatic install runs with all build scripts off, so no native build runs (including the one that fails) and the install goes green.
2. **Build command re-installs only the demo's workspaces, with scripts on:**
   `YARN_ENABLE_SCRIPTS=true corepack yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-demo-webapp && corepack yarn build:demo`
   → `esbuild`/Vite get built, `apps/standalone` is skipped entirely, output to `dist/demo`.

This keeps Netlify's git integration (branch deploy previews + automatic PR comments), unlike a GitHub-Actions-only deploy.

## Verification

Reproduced the mechanic in an isolated worktree: a scripts-off focused install followed by a scripts-on `focus` rebuilds the "never built" packages, and `build:demo` then emits both `/bpmn/` and `/dmn/` pages.

## Follow-up on the Netlify side

The earlier build log showed a UI publish override (`apps/demo-webapp/dist/demo`). Clear the Publish/Base directory overrides in the Netlify UI so `netlify.toml` (`publish = "dist/demo"`) is authoritative.