### PR TITLE
fix(demo-webapp): point the Netlify publish dir at the repo-root dist/demo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,9 @@
 # Netlify config for the static BPMN/DMN modeler demo.
 
 [build]
-  command = "corepack enable && YARN_ENABLE_SCRIPTS=true corepack yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-demo-webapp && corepack yarn build:demo"
-  publish = "dist/demo"
+  base = "apps/demo-webapp"
+  command = "cd ../.. && corepack enable && YARN_ENABLE_SCRIPTS=true corepack yarn workspaces focus bpmn-modeler @miragon/bpmn-modeler-demo-webapp && corepack yarn build:demo"
+  publish = "../../dist/demo"
 
 [build.environment]
   NODE_VERSION = "22"


### PR DESCRIPTION
Follow-up to #1272. The install now succeeds on Netlify, but the deploy fails:

> Deploy directory 'apps/demo-webapp/dist/demo' does not exist

The Netlify site's **base directory is `apps/demo-webapp`**, so `publish = "dist/demo"` resolves *relative to the base* → `apps/demo-webapp/dist/demo`. But `build:demo` (a repo-root script) writes to the **repo-root `dist/demo`**.

Fix, entirely in `netlify.toml`:
- pin `base = "apps/demo-webapp"` (matches the site setting),
- run the build from the repo root (`cd ../..`),
- point `publish = "../../dist/demo"` back up out of the base to where the build actually writes ([Netlify supports `../` traversal in publish](https://github.com/netlify/build/issues/1406)).

No Netlify UI change needed; the git integration (branch deploy previews + PR comments) is untouched.