### PR TITLE
feat(docs): make live demo a prominent CTA in hero and nav

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -14,6 +14,15 @@ const showSiteFooter = computed(() =>
     <Layout>
         <template #nav-bar-content-after>
             <div class="nav-extras">
+                <a
+                    class="demo-btn"
+                    href="https://miragon-bpmn-modeler-demo.netlify.app"
+                    target="_blank"
+                    rel="noopener"
+                >
+                    <svg class="play-ico" width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z" /></svg>
+                    Live demo
+                </a>
                 <a class="install-btn" :href="withBase('/download')">
                     <span class="ico">↓</span> Install
                 </a>
@@ -37,11 +46,14 @@ const showSiteFooter = computed(() =>
                     Download
                 </a>
                 <a
-                    class="btn btn-secondary"
+                    class="btn btn-demo"
                     href="https://miragon-bpmn-modeler-demo.netlify.app"
                     target="_blank"
                     rel="noopener"
-                >Live demo</a>
+                >
+                    <svg class="play-ico" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5v14l11-7z" /></svg>
+                    Live demo
+                </a>
                 <a
                     class="btn btn-tertiary"
                     :href="withBase('/vscode/getting-started')"

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -85,6 +85,31 @@
   gap: 12px;
   margin-left: 16px;
 }
+/* Live demo in the nav: outlined sibling of Install — present but lets the
+ * solid Install button stay the primary nav CTA. */
+.demo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 14px;
+  background: transparent;
+  color: var(--miragon-fg) !important;
+  border: 1px solid var(--miragon-border);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+.demo-btn:hover {
+  border-color: var(--miragon-blue);
+  color: var(--miragon-blue) !important;
+  transform: translateY(-1px);
+}
+.demo-btn:focus-visible {
+  outline: 2px solid var(--miragon-blue);
+  outline-offset: 2px;
+}
 .install-btn {
   display: inline-flex;
   align-items: center;
@@ -210,6 +235,18 @@
   background: #383E6E;
   transform: translateY(-1px);
 }
+/* Live demo: solid brand-blue CTA, on par with Download. The play glyph
+ * reads as "launch it" — this opens the hosted, running modeler. */
+.hero-actions .btn-demo {
+  background: var(--miragon-blue);
+  color: #fff;
+  box-shadow: 0 8px 24px -8px rgba(51,93,228,0.5);
+}
+.hero-actions .btn-demo:hover {
+  background: var(--miragon-blue-hover);
+  transform: translateY(-1px);
+}
+.play-ico { flex-shrink: 0; display: block; }
 .hero-actions .btn-secondary {
   background: var(--miragon-card-glass);
   backdrop-filter: blur(20px);


### PR DESCRIPTION
## What

Promote the **Live demo** link on the docs landing page to a proper call-to-action, matching the Download button, and surface it in the site header.

- **Hero:** the Live demo action moves from the subtle glass secondary button to a solid brand-blue CTA sitting next to navy Download. A play/launch glyph signals "run the hosted modeler".
- **Nav bar:** adds a "▶ Live demo" button next to Install, so the demo is reachable from the header on every docs page — not just the landing hero.

Both link to the existing hosted demo (`https://miragon-bpmn-modeler-demo.netlify.app`, opens in a new tab).

## Why

The old glass secondary button read as a low-priority link. A green live-dot iteration read as a status indicator ("something is live") rather than an action, so it was replaced with a play icon that reads as "press me".

## Verification

- `vitepress build` succeeds.
- `corepack yarn format:check` passes.
- Rendered light + dark mode; play icon uses `currentColor`, legible in both.

## Files

- `docs/.vitepress/theme/Layout.vue`
- `docs/.vitepress/theme/custom.css`