### PR TITLE
feat(bpmn-webview): add canvas focus indicator

### DIFF
--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.spec.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.spec.ts
@@ -3,16 +3,21 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { installCanvasFocusIndicator } from "./canvasFocusIndicator";
 
 let parent: HTMLElement;
-// Captured listener the module registers via onFocusChanged, so tests can
-// drive focus-change events the way diagram-js's eventBus would.
-let emit: (focused: boolean) => void;
+// Captured listeners the module registers via onFocusChanged/onSelectionChanged,
+// so tests can drive events the way diagram-js's eventBus would.
+let emitFocus: (focused: boolean) => void;
+let emitSelection: (hasSelection: boolean) => void;
 
-function install(isFocused: boolean): HTMLElement {
+function install(isFocused: boolean, hasSelection = false): HTMLElement {
     installCanvasFocusIndicator({
         parent,
         isFocused: () => isFocused,
         onFocusChanged: (listener) => {
-            emit = listener;
+            emitFocus = listener;
+        },
+        hasSelection: () => hasSelection,
+        onSelectionChanged: (listener) => {
+            emitSelection = listener;
         },
     });
     return parent.querySelector(".canvas-focus-indicator") as HTMLElement;
@@ -46,17 +51,36 @@ describe("installCanvasFocusIndicator", () => {
 
     it("toggles is-focused when the focus signal fires", () => {
         const root = install(false);
-        emit(true);
+        emitFocus(true);
         expect(root.classList.contains("is-focused")).toBe(true);
-        emit(false);
+        emitFocus(false);
         expect(root.classList.contains("is-focused")).toBe(false);
     });
 
     it("is idempotent for repeated same-value signals", () => {
         const root = install(false);
-        emit(true);
-        emit(true);
+        emitFocus(true);
+        emitFocus(true);
         expect(parent.querySelectorAll(".canvas-focus-indicator")).toHaveLength(1);
         expect(root.classList.contains("is-focused")).toBe(true);
+    });
+
+    it("stays idle when focused with an element selected", () => {
+        expect(install(true, true).classList.contains("is-focused")).toBe(false);
+    });
+
+    it("turns off while a selection exists and back on once it clears", () => {
+        const root = install(true);
+        emitSelection(true);
+        expect(root.classList.contains("is-focused")).toBe(false);
+        emitSelection(false);
+        expect(root.classList.contains("is-focused")).toBe(true);
+    });
+
+    it("ignores a selection change while the canvas is not focused", () => {
+        const root = install(false);
+        emitSelection(true);
+        emitSelection(false);
+        expect(root.classList.contains("is-focused")).toBe(false);
     });
 });

--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.spec.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { installCanvasFocusIndicator } from "./canvasFocusIndicator";
+
+let parent: HTMLElement;
+// Captured listener the module registers via onFocusChanged, so tests can
+// drive focus-change events the way diagram-js's eventBus would.
+let emit: (focused: boolean) => void;
+
+function install(isFocused: boolean): HTMLElement {
+    installCanvasFocusIndicator({
+        parent,
+        isFocused: () => isFocused,
+        onFocusChanged: (listener) => {
+            emit = listener;
+        },
+    });
+    return parent.querySelector(".canvas-focus-indicator") as HTMLElement;
+}
+
+beforeEach(() => {
+    parent = document.createElement("div");
+});
+
+describe("installCanvasFocusIndicator", () => {
+    it("appends exactly one aria-hidden indicator", () => {
+        install(false);
+        const roots = parent.querySelectorAll(".canvas-focus-indicator");
+        expect(roots).toHaveLength(1);
+        expect(roots[0].getAttribute("aria-hidden")).toBe("true");
+    });
+
+    it("renders both the idle and focused glyphs", () => {
+        const root = install(false);
+        expect(root.querySelector("svg.canvas-focus-indicator__off")).not.toBeNull();
+        expect(root.querySelector("svg.canvas-focus-indicator__on")).not.toBeNull();
+    });
+
+    it("honors the initial focused state", () => {
+        expect(install(true).classList.contains("is-focused")).toBe(true);
+    });
+
+    it("honors the initial unfocused state", () => {
+        expect(install(false).classList.contains("is-focused")).toBe(false);
+    });
+
+    it("toggles is-focused when the focus signal fires", () => {
+        const root = install(false);
+        emit(true);
+        expect(root.classList.contains("is-focused")).toBe(true);
+        emit(false);
+        expect(root.classList.contains("is-focused")).toBe(false);
+    });
+
+    it("is idempotent for repeated same-value signals", () => {
+        const root = install(false);
+        emit(true);
+        emit(true);
+        expect(parent.querySelectorAll(".canvas-focus-indicator")).toHaveLength(1);
+        expect(root.classList.contains("is-focused")).toBe(true);
+    });
+});

--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
@@ -16,6 +16,13 @@ export interface CanvasFocusIndicatorDeps {
      * `canvas.focus.changed` `{ focused }` event.
      */
     onFocusChanged: (listener: (focused: boolean) => void) => void;
+    /** Initial selection state (`selection.get().length > 0`). */
+    hasSelection: () => boolean;
+    /**
+     * Subscribes to selection changes — production adapts the eventBus
+     * `selection.changed` `{ newSelection }` event.
+     */
+    onSelectionChanged: (listener: (hasSelection: boolean) => void) => void;
 }
 
 // Material Symbols "center_focus_weak" (idle) / "center_focus_strong" filled
@@ -27,11 +34,17 @@ const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -96
 
 /**
  * Installs a focus reticle in the canvas's bottom-left corner that lights up
- * brand-green with a solid center while the canvas holds keyboard focus and
- * shows a faint hollow reticle otherwise. On focus gain the glow briefly
- * pulses (the "you're back" moment), then settles to a steady glow —
- * canvas-focused is the normal state users sit in for minutes, so a perpetual
- * pulse would be an attention magnet.
+ * brand-green with a solid center while the canvas holds keyboard focus *and*
+ * no element is selected, and shows a faint hollow reticle otherwise. On
+ * focus gain the glow briefly pulses (the "you're back" moment), then settles
+ * to a steady glow — canvas-focused is the normal state users sit in for
+ * minutes, so a perpetual pulse would be an attention magnet.
+ *
+ * Selection gates the green state because clicking an element also puts DOM
+ * focus on the canvas SVG — without the gate the reticle would light on every
+ * selection, where the selection outline already shows that keystrokes target
+ * the diagram. Green is reserved for the bare "canvas focus" state Escape
+ * creates, which has no other visual marker.
  *
  * A reticle (not a bulb or keyboard) because a bulb collides with the IDE-wide
  * "quick fix available" affordance (VS Code/IntelliJ lightbulb); the
@@ -57,14 +70,24 @@ export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): voi
     root.setAttribute("aria-hidden", "true");
     root.innerHTML = FOCUS_WEAK_SVG + FOCUS_STRONG_SVG;
 
-    const render = (focused: boolean): void => {
-        root.classList.toggle("is-focused", focused);
+    let focused = deps.isFocused();
+    let hasSelection = deps.hasSelection();
+
+    const render = (): void => {
+        root.classList.toggle("is-focused", focused && !hasSelection);
     };
 
     // Render the initial state before subscribing so the glyph is correct even
     // if the canvas already has focus at install time.
-    render(deps.isFocused());
-    deps.onFocusChanged(render);
+    render();
+    deps.onFocusChanged((nowFocused) => {
+        focused = nowFocused;
+        render();
+    });
+    deps.onSelectionChanged((nowHasSelection) => {
+        hasSelection = nowHasSelection;
+        render();
+    });
 
     deps.parent.append(root);
 }

--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
@@ -1,0 +1,70 @@
+/**
+ * Injected dependencies for the canvas focus indicator.
+ *
+ * Closures rather than a live modeler handle so this stays testable under
+ * jsdom (same rationale as {@link KeyboardFocusDeps}) and so the real bpmn-js
+ * services are resolved lazily at the call site — they don't exist until the
+ * modeler is created.
+ */
+export interface CanvasFocusIndicatorDeps {
+    /** Host element — production passes `canvas.getContainer()` (`.djs-container`). */
+    parent: HTMLElement;
+    /** Initial focus state (`canvas.isFocused()`). */
+    isFocused: () => boolean;
+    /**
+     * Subscribes to focus changes — production adapts the eventBus
+     * `canvas.focus.changed` `{ focused }` event.
+     */
+    onFocusChanged: (listener: (focused: boolean) => void) => void;
+}
+
+// Material Symbols "center_focus_weak" (idle) / "center_focus_strong" filled
+// (focused), viewBox 0 -960 960 960, fill=currentColor so CSS `color` recolors
+// them. Two static SVGs rather than innerHTML swapping: re-parsing would
+// restart the CSS glow animation mid-toggle.
+const FOCUS_WEAK_SVG = `<svg class="canvas-focus-indicator__off" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M367-367q-47-47-47-113t47-113q47-47 113-47t113 47q47 47 47 113t-47 113q-47 47-113 47t-113-47Zm169.5-56.5Q560-447 560-480t-23.5-56.5Q513-560 480-560t-56.5 23.5Q400-513 400-480t23.5 56.5Q447-400 480-400t56.5-23.5ZM480-480ZM200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80Z"/></svg>`;
+const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80ZM338.5-338.5Q280-397 280-480t58.5-141.5Q397-680 480-680t141.5 58.5Q680-563 680-480t-58.5 141.5Q563-280 480-280t-141.5-58.5Z"/></svg>`;
+
+/**
+ * Installs a focus reticle in the canvas's bottom-left corner that lights up
+ * brand-green with a solid center while the canvas holds keyboard focus and
+ * shows a faint hollow reticle otherwise. On focus gain the glow briefly
+ * pulses (the "you're back" moment), then settles to a steady glow —
+ * canvas-focused is the normal state users sit in for minutes, so a perpetual
+ * pulse would be an attention magnet.
+ *
+ * A reticle (not a bulb or keyboard) because a bulb collides with the IDE-wide
+ * "quick fix available" affordance (VS Code/IntelliJ lightbulb); the
+ * weak/strong reticle pair literally depicts focus snapping onto the canvas.
+ *
+ * It is the visual counterpart to {@link installKeyboardFocus}. It subscribes
+ * to diagram-js's own
+ * deduplicated `canvas.focus.changed` signal (fired from the canvas SVG's
+ * `focusin`/`focusout` listeners) rather than observing a container-level
+ * `focusin` — the latter would false-positive when another floating widget
+ * inside the same `.djs-container` (e.g. the bpmnlint chip) takes focus.
+ *
+ * Purely decorative: `aria-hidden` + `pointer-events: none`. The focus move
+ * itself already conveys the state to assistive tech, and a clickable glyph
+ * would need a tab stop and would steal canvas clicks. There is no dispose
+ * API — the indicator lives as long as the webview document.
+ *
+ * @param deps Injected parent/focus closures (see {@link CanvasFocusIndicatorDeps}).
+ */
+export function installCanvasFocusIndicator(deps: CanvasFocusIndicatorDeps): void {
+    const root = document.createElement("div");
+    root.className = "canvas-focus-indicator";
+    root.setAttribute("aria-hidden", "true");
+    root.innerHTML = FOCUS_WEAK_SVG + FOCUS_STRONG_SVG;
+
+    const render = (focused: boolean): void => {
+        root.classList.toggle("is-focused", focused);
+    };
+
+    // Render the initial state before subscribing so the glyph is correct even
+    // if the canvas already has focus at install time.
+    render(deps.isFocused());
+    deps.onFocusChanged(render);
+
+    deps.parent.append(root);
+}

--- a/apps/bpmn-webview/src/app/index.ts
+++ b/apps/bpmn-webview/src/app/index.ts
@@ -4,5 +4,6 @@ export * from "./selection";
 export * from "./state";
 export * from "./propertiesPanelClipboard";
 export * from "./keyboardFocus";
+export * from "./canvasFocusIndicator";
 export * from "./host";
 export * from "./webviewState";

--- a/apps/bpmn-webview/src/app/keyboardFocus.spec.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.spec.ts
@@ -3,6 +3,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { installKeyboardFocus } from "./keyboardFocus";
 
 const focusCanvas = vi.fn();
+const isCanvasFocused = vi.fn<() => boolean>();
+const hasSelection = vi.fn<() => boolean>();
+const clearSelection = vi.fn();
 const isSearchPadOpen = vi.fn<() => boolean>();
 const closeSearchPad = vi.fn();
 
@@ -22,6 +25,9 @@ function dispatchKeydown(key: string, defaultPrevented = false): void {
 beforeAll(() => {
     installKeyboardFocus({
         focusCanvas: () => focusCanvas(),
+        isCanvasFocused: () => isCanvasFocused(),
+        hasSelection: () => hasSelection(),
+        clearSelection: () => clearSelection(),
         isSearchPadOpen: () => isSearchPadOpen(),
         closeSearchPad: () => closeSearchPad(),
     });
@@ -29,8 +35,13 @@ beforeAll(() => {
 
 beforeEach(() => {
     focusCanvas.mockReset();
+    isCanvasFocused.mockReset();
+    hasSelection.mockReset();
+    clearSelection.mockReset();
     isSearchPadOpen.mockReset();
     closeSearchPad.mockReset();
+    isCanvasFocused.mockReturnValue(false);
+    hasSelection.mockReturnValue(false);
     isSearchPadOpen.mockReturnValue(false);
 });
 
@@ -56,6 +67,32 @@ describe("installKeyboardFocus", () => {
         isSearchPadOpen.mockReturnValue(true);
         dispatchKeydown("Escape");
         expect(closeSearchPad).toHaveBeenCalledTimes(1);
+        expect(focusCanvas).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the selection when Escape only re-homes focus onto the canvas", () => {
+        // Focus sits e.g. in the properties panel of the selected element —
+        // clearing the selection here would blank that panel mid-edit.
+        isCanvasFocused.mockReturnValue(false);
+        hasSelection.mockReturnValue(true);
+        dispatchKeydown("Escape");
+        expect(focusCanvas).toHaveBeenCalledTimes(1);
+        expect(clearSelection).not.toHaveBeenCalled();
+    });
+
+    it("clears the selection when Escape hits the already-focused canvas", () => {
+        isCanvasFocused.mockReturnValue(true);
+        hasSelection.mockReturnValue(true);
+        dispatchKeydown("Escape");
+        expect(clearSelection).toHaveBeenCalledTimes(1);
+        expect(focusCanvas).not.toHaveBeenCalled();
+    });
+
+    it("leaves an empty selection alone on the focused canvas", () => {
+        isCanvasFocused.mockReturnValue(true);
+        hasSelection.mockReturnValue(false);
+        dispatchKeydown("Escape");
+        expect(clearSelection).not.toHaveBeenCalled();
         expect(focusCanvas).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/bpmn-webview/src/app/keyboardFocus.ts
+++ b/apps/bpmn-webview/src/app/keyboardFocus.ts
@@ -8,6 +8,12 @@
 export interface KeyboardFocusDeps {
     /** Moves DOM focus onto the canvas SVG (`canvas.focus()`). */
     focusCanvas: () => void;
+    /** Whether the canvas SVG currently holds DOM focus (`canvas.isFocused()`). */
+    isCanvasFocused: () => boolean;
+    /** Whether any element is currently selected (`selection.get().length > 0`). */
+    hasSelection: () => boolean;
+    /** Clears the current selection (`selection.select(null)`). */
+    clearSelection: () => void;
     /** Whether the diagram-js SearchPad is currently open. */
     isSearchPadOpen: () => boolean;
     /** Closes the SearchPad (restores the cached selection). */
@@ -23,10 +29,18 @@ export interface KeyboardFocusDeps {
  * or a search field, keystrokes like `A`/`N`/arrows never reach the modeler.
  * Escape re-homes focus so the next keystroke drives the diagram again.
  *
+ * Escape is staged, one layer per press (mirroring the append-menu's
+ * template-then-close staging): while focus is elsewhere it only re-homes
+ * focus and *keeps* the selection — selection anchors the keyboard-modelling
+ * flow (`A`/`R`/arrows) and drives the properties panel, so clearing it here
+ * would blank the panel the user just escaped from. Only a further Escape on
+ * the already-focused canvas clears the selection, reaching the neutral state
+ * the focus reticle marks. bpmn-js has no deselect-on-Escape of its own.
+ *
  * The listener runs in the **bubble** phase and stays deliberately passive
  * (no preventDefault/stopPropagation) so host Escape behaviour is untouched.
  *
- * @param deps Injected focus/search-pad closures (see {@link KeyboardFocusDeps}).
+ * @param deps Injected focus/selection/search-pad closures (see {@link KeyboardFocusDeps}).
  */
 export function installKeyboardFocus(deps: KeyboardFocusDeps): void {
     document.addEventListener("keydown", (e: KeyboardEvent) => {
@@ -56,7 +70,17 @@ export function installKeyboardFocus(deps: KeyboardFocusDeps): void {
         }
 
         // Label direct-editing needs no guard: its keydown handler stops
-        // propagation for every key, so we never see its Escape.
+        // propagation for every key, so we never see its Escape. Drag cancel
+        // and the popup menu preventDefault theirs, caught above — so reaching
+        // this point means there is no more transient UI layer to peel.
+
+        // Final layer: Escape on the already-focused canvas drops the
+        // selection (Figma/vim-visual convention), reaching the bare
+        // canvas-focus state the reticle lights up for.
+        if (deps.isCanvasFocused() && deps.hasSelection()) {
+            deps.clearSelection();
+            return;
+        }
 
         deps.focusCanvas();
     });

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -3,6 +3,7 @@ import { ImportXMLResult } from "bpmn-js/lib/BaseViewer";
 // css
 import "./styles/default.css";
 import "./styles/diff.css";
+import "./styles/canvasFocusIndicator.css";
 
 import {
     BpmnFileQuery,
@@ -47,6 +48,7 @@ import { VsCodeClipboardModule, LabelClipboardModule } from "@miragon/bpmn-model
 import { TranslateModule, i18n, type SupportedLocale } from "@miragon/bpmn-modeler-i18n";
 import {
     BpmnModeler,
+    installCanvasFocusIndicator,
     installContentEditableClipboardPolyfill,
     installKeyboardFocus,
     UnsupportedEngineError,
@@ -370,6 +372,24 @@ async function initializeModeler(
             isSearchPadOpen: () =>
                 bpmnModeler.getService<{ isOpen(): boolean }>("searchPad").isOpen(),
             closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),
+        });
+        // Playful counterpart to installKeyboardFocus: a focus reticle bottom-left
+        // on the canvas that lights up green while keystrokes drive the diagram.
+        // diagram-js already tracks exactly this state (Canvas fires a deduplicated
+        // "canvas.focus.changed" from its own SVG focus listeners), so subscribe
+        // instead of re-observing DOM focus — a container-level focusin would
+        // false-positive on the lint chip inside the same .djs-container.
+        installCanvasFocusIndicator({
+            parent: bpmnModeler
+                .getService<{ getContainer(): HTMLElement }>("canvas")
+                .getContainer(),
+            isFocused: () => bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
+            onFocusChanged: (listener) =>
+                bpmnModeler
+                    .getService<{
+                        on(event: string, cb: (e: { focused: boolean }) => void): void;
+                    }>("eventBus")
+                    .on("canvas.focus.changed", (e) => listener(e.focused)),
         });
         // Forward the modeler's non-fatal warnings (element-not-found, missing
         // inline script) to the output channel — they were console-only before.

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -374,8 +374,9 @@ async function initializeModeler(
             closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),
         });
         // Playful counterpart to installKeyboardFocus: a focus reticle bottom-left
-        // on the canvas that lights up green while keystrokes drive the diagram.
-        // diagram-js already tracks exactly this state (Canvas fires a deduplicated
+        // on the canvas that lights up green while the canvas holds keyboard focus
+        // with no element selected (a selection already marks itself).
+        // diagram-js already tracks the focus half (Canvas fires a deduplicated
         // "canvas.focus.changed" from its own SVG focus listeners), so subscribe
         // instead of re-observing DOM focus — a container-level focusin would
         // false-positive on the lint chip inside the same .djs-container.
@@ -390,6 +391,14 @@ async function initializeModeler(
                         on(event: string, cb: (e: { focused: boolean }) => void): void;
                     }>("eventBus")
                     .on("canvas.focus.changed", (e) => listener(e.focused)),
+            hasSelection: () =>
+                bpmnModeler.getService<{ get(): unknown[] }>("selection").get().length > 0,
+            onSelectionChanged: (listener) =>
+                bpmnModeler
+                    .getService<{
+                        on(event: string, cb: (e: { newSelection: unknown[] }) => void): void;
+                    }>("eventBus")
+                    .on("selection.changed", (e) => listener(e.newSelection.length > 0)),
         });
         // Forward the modeler's non-fatal warnings (element-not-found, missing
         // inline script) to the output channel — they were console-only before.

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -364,11 +364,18 @@ async function initializeModeler(
         );
         // Escape re-homes focus on the canvas so keyboard-driven modelling
         // (A/N/arrows, all owned by bpmn-js's canvas-scoped Keyboard service)
-        // works even when focus sits in the properties panel or a search field.
+        // works even when focus sits in the properties panel or a search field;
+        // a further Escape on the focused canvas clears the selection.
         // Services are resolved lazily inside the closures because the modeler
         // exists by the time an Escape can fire.
         installKeyboardFocus({
             focusCanvas: () => bpmnModeler.getService<{ focus(): void }>("canvas").focus(),
+            isCanvasFocused: () =>
+                bpmnModeler.getService<{ isFocused(): boolean }>("canvas").isFocused(),
+            hasSelection: () =>
+                bpmnModeler.getService<{ get(): unknown[] }>("selection").get().length > 0,
+            clearSelection: () =>
+                bpmnModeler.getService<{ select(elements: null): void }>("selection").select(null),
             isSearchPadOpen: () =>
                 bpmnModeler.getService<{ isOpen(): boolean }>("searchPad").isOpen(),
             closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),

--- a/apps/bpmn-webview/src/styles/canvasFocusIndicator.css
+++ b/apps/bpmn-webview/src/styles/canvasFocusIndicator.css
@@ -1,0 +1,57 @@
+.canvas-focus-indicator {
+    position: absolute;
+    left: 16px;
+    bottom: 16px; /* same baseline as the lint chip (bottom-center) */
+    width: 24px;
+    height: 24px;
+    z-index: 10;
+    pointer-events: none;
+    color: rgba(85, 85, 85, 0.55); /* theme-neutral base = light-canvas idle grey */
+}
+
+.canvas-focus-indicator svg {
+    display: none;
+    width: 100%;
+    height: 100%;
+}
+
+/* The __on glyph is display:none while unfocused, and display:none terminates a
+   CSS animation — so re-displaying on each focus gain restarts the finite pulse
+   automatically, no JS timer needed. */
+.canvas-focus-indicator:not(.is-focused) .canvas-focus-indicator__off {
+    display: block;
+}
+
+.canvas-focus-indicator.is-focused .canvas-focus-indicator__on {
+    display: block;
+    color: #00e676; /* fill="currentColor" → reticle in the Miragon komet green */
+    /* Steady glow the greeting pulse settles into: the animation runs a finite
+       2 iterations with no fill-mode, so it reverts to this static filter. */
+    filter: drop-shadow(0 0 3px rgba(0, 230, 118, 0.55));
+    animation: canvas-focus-pulse 1.1s ease-in-out 2;
+}
+
+/* drop-shadow (not box-shadow) so the glow hugs the glyph silhouette, not a square.
+   Keyframes start and end at the steady-state glow so the settle is seamless. */
+@keyframes canvas-focus-pulse {
+    0%,
+    100% {
+        filter: drop-shadow(0 0 3px rgba(0, 230, 118, 0.55));
+    }
+    50% {
+        filter: drop-shadow(0 0 9px rgba(0, 230, 118, 0.95));
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .canvas-focus-indicator.is-focused .canvas-focus-indicator__on {
+        animation: none; /* the static filter above keeps "on" distinguishable */
+    }
+}
+
+/* dark theme recolors the canvas (--canvas-fill-color) → lighter idle outline;
+   the green + glow already read on dark */
+body.vscode-dark .canvas-focus-indicator,
+body.vscode-high-contrast .canvas-focus-indicator {
+    color: rgba(190, 190, 190, 0.6);
+}


### PR DESCRIPTION
**Issue**

Follow-up to #1269 (Escape-to-focus): there was no visual cue showing whether the canvas holds keyboard focus.

**Description**

Adds a decorative focus reticle (Material Symbols `center_focus_weak`/`center_focus_strong`) to the canvas's bottom-left corner: a faint grey hollow reticle while focus is elsewhere, and a brand-green solid one with a brief pulsating glow that settles into a steady glow while keystrokes drive the diagram. It subscribes to diagram-js's own deduplicated `canvas.focus.changed` signal instead of DOM focus listeners, so other floating widgets inside the canvas container (e.g. the bpmnlint chip) cannot false-positive it. The glow is pure CSS (finite 2-iteration animation restarted via the `display` toggle), respects `prefers-reduced-motion`, and includes a dark-theme variant for the idle state. Verified in a real browser (Escape → green pulse → steady glow; panel focus → grey outline) plus a jsdom spec covering mounting and state toggling.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created