### PR TITLE
fix(bpmn-webview): move focus indicator to top right corner

### DIFF
--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
@@ -33,7 +33,8 @@ const FOCUS_WEAK_SVG = `<svg class="canvas-focus-indicator__off" viewBox="0 -960
 const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80ZM338.5-338.5Q280-397 280-480t58.5-141.5Q397-680 480-680t141.5 58.5Q680-563 680-480t-58.5 141.5Q563-280 480-280t-141.5-58.5Z"/></svg>`;
 
 /**
- * Installs a focus reticle in the canvas's bottom-left corner that lights up
+ * Installs a focus reticle in the canvas's top-left corner, immediately to the
+ * right of the Token Simulation toggle, that lights up
  * brand-green with a solid center while the canvas holds keyboard focus *and*
  * no element is selected, and shows a faint hollow reticle otherwise. On
  * focus gain the glow briefly pulses (the "you're back" moment), then settles

--- a/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
+++ b/apps/bpmn-webview/src/app/canvasFocusIndicator.ts
@@ -33,8 +33,8 @@ const FOCUS_WEAK_SVG = `<svg class="canvas-focus-indicator__off" viewBox="0 -960
 const FOCUS_STRONG_SVG = `<svg class="canvas-focus-indicator__on" viewBox="0 -960 960 960" fill="currentColor" aria-hidden="true"><path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm400 0v-80h160v-160h80v160q0 33-23.5 56.5T760-120H600ZM120-600v-160q0-33 23.5-56.5T200-840h160v80H200v160h-80Zm640 0v-160H600v-80h160q33 0 56.5 23.5T840-760v160h-80ZM338.5-338.5Q280-397 280-480t58.5-141.5Q397-680 480-680t141.5 58.5Q680-563 680-480t-58.5 141.5Q563-280 480-280t-141.5-58.5Z"/></svg>`;
 
 /**
- * Installs a focus reticle in the canvas's top-left corner, immediately to the
- * right of the Token Simulation toggle, that lights up
+ * Installs a focus reticle in the canvas's top-right corner, beside the
+ * "Open minimap" control, that lights up
  * brand-green with a solid center while the canvas holds keyboard focus *and*
  * no element is selected, and shows a faint hollow reticle otherwise. On
  * focus gain the glow briefly pulses (the "you're back" moment), then settles

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -435,9 +435,9 @@ async function initializeModeler(
                 bpmnModeler.getService<{ isOpen(): boolean }>("searchPad").isOpen(),
             closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),
         });
-        // Playful counterpart to installKeyboardFocus: a focus reticle top-left on
-        // the canvas, right of the Token Simulation toggle, that lights up green
-        // while the canvas holds keyboard focus
+        // Playful counterpart to installKeyboardFocus: a focus reticle in the
+        // canvas's top-right corner, beside the "Open minimap" control, that
+        // lights up green while the canvas holds keyboard focus
         // with no element selected (a selection already marks itself).
         // diagram-js already tracks the focus half (Canvas fires a deduplicated
         // "canvas.focus.changed" from its own SVG focus listeners), so subscribe

--- a/apps/bpmn-webview/src/bootstrap.ts
+++ b/apps/bpmn-webview/src/bootstrap.ts
@@ -435,8 +435,9 @@ async function initializeModeler(
                 bpmnModeler.getService<{ isOpen(): boolean }>("searchPad").isOpen(),
             closeSearchPad: () => bpmnModeler.getService<{ close(): void }>("searchPad").close(),
         });
-        // Playful counterpart to installKeyboardFocus: a focus reticle bottom-left
-        // on the canvas that lights up green while the canvas holds keyboard focus
+        // Playful counterpart to installKeyboardFocus: a focus reticle top-left on
+        // the canvas, right of the Token Simulation toggle, that lights up green
+        // while the canvas holds keyboard focus
         // with no element selected (a selection already marks itself).
         // diagram-js already tracks the focus half (Canvas fires a deduplicated
         // "canvas.focus.changed" from its own SVG focus listeners), so subscribe

--- a/apps/bpmn-webview/src/styles/canvasFocusIndicator.css
+++ b/apps/bpmn-webview/src/styles/canvasFocusIndicator.css
@@ -1,9 +1,15 @@
 .canvas-focus-indicator {
     position: absolute;
-    left: 16px;
-    bottom: 16px; /* same baseline as the lint chip (bottom-center) */
-    width: 24px;
-    height: 24px;
+    /* Sits top-left, flush-right of the "Token Simulation" toggle
+       (.bts-toggle-mode at top:20px; left:20px), height-matched to its grey
+       pill. Moved off the bottom-left: on short viewports the palette grows
+       down far enough to overlap a bottom-left reticle; the top-left region is
+       empty apart from the toggle. `left` clears the toggle's ~180px content
+       width plus a small gap that still clears the wider Windows/Arial render. */
+    top: 20px;
+    left: 190px;
+    width: 31px;
+    height: 31px;
     z-index: 10;
     pointer-events: none;
     color: rgba(85, 85, 85, 0.55); /* theme-neutral base = light-canvas idle grey */

--- a/apps/bpmn-webview/src/styles/canvasFocusIndicator.css
+++ b/apps/bpmn-webview/src/styles/canvasFocusIndicator.css
@@ -1,18 +1,33 @@
 .canvas-focus-indicator {
     position: absolute;
-    /* Sits top-left, flush-right of the "Token Simulation" toggle
-       (.bts-toggle-mode at top:20px; left:20px), height-matched to its grey
-       pill. Moved off the bottom-left: on short viewports the palette grows
-       down far enough to overlap a bottom-left reticle; the top-left region is
-       empty apart from the toggle. `left` clears the toggle's ~180px content
-       width plus a small gap that still clears the wider Windows/Arial render. */
-    top: 20px;
-    left: 190px;
+    /* Sits in the top-right corner, right of the "Open minimap" control
+       (.djs-minimap, which we nudge left below to make room). Moved off the
+       bottom-left: on short viewports the palette grows down far enough to
+       overlap a bottom-left reticle; the top-right corner stays clear in every
+       state (the minimap even when expanded keeps its right edge left of us,
+       and simulation controls render at top-left). `top` centers the 31px box
+       on the minimap button's vertical midline (its top 20px + ~36.5px/2 ≈
+       38.25px). */
+    top: 23px;
+    right: 20px;
     width: 31px;
     height: 31px;
     z-index: 10;
     pointer-events: none;
     color: rgba(85, 85, 85, 0.55); /* theme-neutral base = light-canvas idle grey */
+}
+
+/* Nudge the minimap left so the corner reticle has room. The gap holds even
+   when the minimap is expanded — it grows leftward/down from this right edge,
+   never into the reticle.
+
+   The `.djs-container` prefix is load-bearing: diagram-js-minimap's default
+   `.djs-minimap{right:20px}` ships in lightTheme.css/darkTheme.css, which load
+   *after* this file, so a bare `.djs-minimap` (equal specificity, earlier in
+   the cascade) loses and the minimap snaps back under the reticle. The
+   descendant selector (0,2,0 > 0,1,0) wins regardless of load order. */
+.djs-container .djs-minimap {
+    right: 61px;
 }
 
 .canvas-focus-indicator svg {


### PR DESCRIPTION
**Issue**

Follow-up to the canvas focus indicator (#1277): the reticle overlapped the palette on small screens.

**Description**

Moves the canvas focus indicator from the bottom-left corner to the top-right. On short viewports (e.g. IntelliJ on a 14" MacBook) the diagram palette grows downward far enough to sit on top of a bottom-left reticle, whereas the top-right region is empty apart from the minimap. This is a pure-CSS reposition plus doc/comment updates — no behavior change.

**Checklist**

* Code is easy to understand
* No obvious errors or bugs
* CI/CD Pipelines did run successfully
* Tests were implemented
* Documentation was created
