### PR TITLE
feat(intellij-plugin): add visual DMN editor

### DIFF
--- a/apps/intellij-plugin/build.gradle.kts
+++ b/apps/intellij-plugin/build.gradle.kts
@@ -146,6 +146,7 @@ intellijPlatform {
 // already-built artefacts so `runIde` and the distributable zip carry them. See
 // apps/modeler-bridge/README.md.
 val webviewDist = layout.projectDirectory.dir("../../dist/webview-staging/bpmn-webview")
+val dmnWebviewDist = layout.projectDirectory.dir("../../dist/webview-staging/dmn-webview")
 val deploymentWebviewDist =
     layout.projectDirectory.dir("../../dist/webview-staging/deployment-webview")
 val bridgeBinary = layout.projectDirectory.file("../../apps/modeler-bridge/dist/modeler-bridge")
@@ -215,6 +216,22 @@ val copyWebview =
         from(webviewDist)
         // Nest under `webview/` so the served classpath path is `/webview/...`.
         into(stagedResourcesRoot.map { it.dir("webview") })
+    }
+
+val copyDmnWebview =
+    tasks.register<Copy>("copyDmnWebview") {
+        description = "Stages the pre-built dmn-webview bundle into plugin resources (served from the classpath at runtime)."
+        doFirst {
+            if (!dmnWebviewDist.asFile.exists()) {
+                throw GradleException(
+                    "DMN webview bundle not found at ${dmnWebviewDist.asFile}.\n" +
+                        "Run `corepack yarn build:dmn-webview` from the repo root first.",
+                )
+            }
+        }
+        from(dmnWebviewDist)
+        // Nest under `webview-dmn/` so the served classpath path is `/webview-dmn/...`.
+        into(stagedResourcesRoot.map { it.dir("webview-dmn") })
     }
 
 val copyDeploymentWebview =
@@ -306,12 +323,12 @@ sourceSets.named("main") {
 }
 
 tasks.named<ProcessResources>("processResources") {
-    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema, writeBridgeVersion)
+    dependsOn(copyWebview, copyDmnWebview, copyDeploymentWebview, copyBridge, copySchema, writeBridgeVersion)
 }
 
 // The sandbox for `runIde` is assembled from the jar, which already contains the
 // staged resources, so no extra sandbox wiring is needed — but make the
 // dependency explicit so a clean `runIde` always stages the bundles first.
 tasks.withType<PrepareSandboxTask>().configureEach {
-    dependsOn(copyWebview, copyDeploymentWebview, copyBridge, copySchema, writeBridgeVersion)
+    dependsOn(copyWebview, copyDmnWebview, copyDeploymentWebview, copyBridge, copySchema, writeBridgeVersion)
 }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BrowserPrewarmService.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/BrowserPrewarmService.kt
@@ -3,6 +3,7 @@ package io.miragon.intellij.bpmn
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
@@ -59,7 +60,7 @@ class BrowserPrewarmService(private val project: Project) : Disposable {
     fun take(): WarmBrowser {
         val ready = synchronized(lock) { warm.also { warm = null } }
         ensureWarm()
-        return ready ?: WarmBrowser()
+        return ready ?: WarmBrowser(service<WebviewServer>().ensureStarted())
     }
 
     private fun ensureWarm() {
@@ -72,7 +73,7 @@ class BrowserPrewarmService(private val project: Project) : Disposable {
                 // the user through BpmnFileEditor). Nothing here has a caller to throw
                 // to — this runs from an invokeLater.
                 warm =
-                    runCatching { WarmBrowser() }
+                    runCatching { WarmBrowser(service<WebviewServer>().ensureStarted()) }
                         .onFailure { log.warn("Failed to pre-warm a JCEF browser; will retry on next open", it) }
                         .getOrNull()
             }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreSession.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/CoreSession.kt
@@ -4,16 +4,30 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 
 /**
- * One open BPMN editor as the host tracks it.
+ * Which modeler a [CoreSession] drives. [wire] is the discriminator the bridge's
+ * `session/register` reads to route the session to the BPMN or DMN service (see
+ * the bridge `RegisterParams.kind`); an older bridge that predates DMN treats an
+ * absent value as BPMN, so the wire strings must stay stable.
+ */
+enum class ModelerKind(val wire: String) {
+    BPMN("bpmn"),
+    DMN("dmn"),
+}
+
+/**
+ * One open modeler editor as the host tracks it.
  *
  * [editorId] is the [VirtualFile.getUrl] (e.g. `file:///path`) — the same
  * scheme-qualified key the core's `EditorSessionStore` uses, so core→host
  * messages route back to the correct editor when several are open at once.
+ * [kind] tells the bridge which modeler (BPMN/DMN) owns this session, so a `.dmn`
+ * tab renders through the DMN service instead of the BPMN one.
  * [postToWebview] pushes a complete JSON message into this editor's JCEF browser.
  */
 class CoreSession(
     val editorId: String,
     val file: VirtualFile,
     val project: Project,
+    val kind: ModelerKind = ModelerKind.BPMN,
     val postToWebview: (String) -> Unit,
 )

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DmnFileEditor.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DmnFileEditor.kt
@@ -1,0 +1,144 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.editor.event.DocumentListener
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.ui.jcef.JBCefApp
+import java.beans.PropertyChangeListener
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.SwingConstants
+
+/**
+ * JCEF-backed editor that renders a `.dmn` file with the dmn-js webview, driven
+ * by the out-of-process modeler core ([CoreProcess]). The DMN twin of
+ * [BpmnFileEditor]: the wiring is identical (register session → mirror the
+ * Document → follow the IDE theme → bind the JS↔JVM pipes), only the session
+ * [ModelerKind] and the loaded shell differ.
+ *
+ * Unlike BPMN it does **not** draw from [BrowserPrewarmService]: a `.dmn` tab is
+ * opened rarely enough that keeping a second warm browser per project isn't
+ * worth the idle cost, so the DMN browser is built cold here on the open path.
+ */
+class DmnFileEditor(
+    private val project: Project,
+    private val file: VirtualFile,
+) : UserDataHolderBase(), FileEditor {
+    private val log = Logger.getInstance(DmnFileEditor::class.java)
+
+    private val component: JComponent
+
+    private val coreProcess: CoreProcess? =
+        if (JBCefApp.isSupported()) project.service<CoreProcess>() else null
+    private var session: CoreSession? = null
+
+    init {
+        component =
+            if (!JBCefApp.isSupported()) {
+                unavailableLabel(
+                    "JCEF (embedded Chromium) is not available in this IDE.<br>" +
+                        "Use an IntelliJ 2024.2+ build that bundles JCEF.",
+                )
+            } else {
+                try {
+                    buildBrowserEditor()
+                } catch (e: Throwable) {
+                    // A throwing JCEF ctor (e.g. ide.browser.jcef.osr.enabled=false)
+                    // must surface as the unavailable label, not a silent drop to the
+                    // plain-text tab — see BpmnFileEditor for the full rationale.
+                    log.warn("Failed to create the DMN modeler browser", e)
+                    unavailableLabel(
+                        "The DMN modeler could not start in this IDE.<br>" +
+                            "Details: ${e.message ?: e.javaClass.simpleName}",
+                    )
+                }
+            }
+    }
+
+    /**
+     * Builds the JCEF-backed DMN editor and wires it to the core. Extracted so its
+     * failure (a throwing browser ctor) is caught in [init] and turned into the
+     * unavailable-editor label rather than a silent XML-tab fallback.
+     */
+    private fun buildBrowserEditor(): JComponent {
+        // Cold-build a browser loaded with the DMN shell (dedicated loopback
+        // origin). Parented to this editor, disposed on close.
+        val warm = WarmBrowser(service<WebviewServer>().dmnUrl())
+        Disposer.register(this, warm)
+
+        // The editor id must match the core's session key (scheme-qualified URI).
+        val editorId = file.url
+        val coreSession =
+            CoreSession(editorId, file, project, ModelerKind.DMN) { json ->
+                warm.browser.cefBrowser.executeJavaScript(
+                    "window.postMessage($json, '*');",
+                    warm.browser.cefBrowser.url,
+                    0,
+                )
+            }
+        // Publish before registering so dispose() can tear it down even if a later
+        // wiring step throws after registration.
+        session = coreSession
+
+        // Register before binding the browser so the core has the session ready
+        // when bind() flushes the webview's first (buffered) GetDmnFileCommand.
+        coreProcess!!.registerSession(coreSession)
+
+        // Mirror the live IntelliJ Document into the core so external edits
+        // (git revert/checkout, the plain-text tab, another tool) re-render the
+        // diagram. The core's own write-backs also fire this — that echo is
+        // filtered in the bridge, not here. Parented to this editor.
+        FileDocumentManager.getInstance().getDocument(file)?.addDocumentListener(
+            object : DocumentListener {
+                override fun documentChanged(event: DocumentEvent) {
+                    coreProcess.notifyDocumentChanged(editorId, event.document.text)
+                }
+            },
+            this,
+        )
+
+        // Follow the IDE color theme live, same as the BPMN editor.
+        service<IdeThemeSignal>().follow(this, warm.browser.cefBrowser)
+
+        // Wire the JS→JVM forwarder and inject the sink; this flushes the buffered
+        // GetDmnFileCommand, which now reaches the registered session.
+        warm.bind { request -> coreProcess.forwardWebviewMessage(editorId, request) }
+
+        maybeNotifyOutOfProcessJcef(project)
+
+        return warm.browser.component
+    }
+
+    private fun unavailableLabel(htmlBody: String): JComponent =
+        JLabel("<html><center>$htmlBody</center></html>", SwingConstants.CENTER)
+
+    override fun getComponent(): JComponent = component
+
+    override fun getPreferredFocusedComponent(): JComponent = component
+
+    override fun getName(): String = "DMN Modeler"
+
+    override fun getFile(): VirtualFile = file
+
+    override fun setState(state: FileEditorState) = Unit
+
+    override fun isModified(): Boolean = false
+
+    override fun isValid(): Boolean = true
+
+    override fun addPropertyChangeListener(listener: PropertyChangeListener) = Unit
+
+    override fun removePropertyChangeListener(listener: PropertyChangeListener) = Unit
+
+    override fun dispose() {
+        session?.let { coreProcess?.disposeSession(it.editorId) }
+    }
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DmnFileEditorProvider.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DmnFileEditorProvider.kt
@@ -1,0 +1,28 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Binds the JCEF DMN editor to `.dmn` files — the DMN twin of
+ * [BpmnFileEditorProvider].
+ *
+ * Placed before the default text editor rather than hiding it, so the
+ * round-tripped XML stays reachable on the plain-text tab for inspection and
+ * source edits.
+ */
+class DmnFileEditorProvider : FileEditorProvider, DumbAware {
+    override fun accept(project: Project, file: VirtualFile): Boolean =
+        file.name.endsWith(".dmn", ignoreCase = true)
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor =
+        DmnFileEditor(project, file)
+
+    override fun getEditorTypeId(): String = "dmn-modeler-editor"
+
+    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.PLACE_BEFORE_DEFAULT_EDITOR
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DmnFileType.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/DmnFileType.kt
@@ -1,0 +1,29 @@
+package io.miragon.intellij.bpmn
+
+import com.intellij.lang.xml.XMLLanguage
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.util.IconLoader
+import javax.swing.Icon
+
+/**
+ * Registers `.dmn` as a first-class XML-derived file type — the DMN twin of
+ * [BpmnFileType]. The two reasons a real `FileType` is needed rather than just
+ * [DmnFileEditorProvider.accept] are identical to BPMN's: the Marketplace Feature
+ * Extractor only reads the static `extensions` attribute to offer the
+ * "Plugins supporting *.dmn files found" banner, and basing the type on
+ * `XMLLanguage` keeps the secondary plain-text tab (the JCEF editor opens with
+ * `PLACE_BEFORE_DEFAULT_EDITOR`) lexing/folding the round-tripped XML.
+ */
+object DmnFileType : LanguageFileType(XMLLanguage.INSTANCE) {
+    override fun getName(): String = "DMN"
+
+    override fun getDescription(): String = "DMN 1.3 decision model"
+
+    override fun getDefaultExtension(): String = "dmn"
+
+    // A dedicated 16×16 decision-table glyph, not the marketplace badge, for the
+    // same downscaling reason documented on BpmnFileType; IconLoader substitutes
+    // the sibling `dmn_dark.svg` under dark themes.
+    override fun getIcon(): Icon =
+        IconLoader.getIcon("/icons/dmn.svg", DmnFileType::class.java)
+}

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/NewDmnModelAction.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/NewDmnModelAction.kt
@@ -4,13 +4,15 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 
 /**
- * Tools ▸ New DMN Model (also Project view ▸ New) — creates a `.dmn` file seeded
- * with a minimal decision table and opens it. The IntelliJ counterpart of the VS
- * Code `miragon.dmnModeler.newDiagram` command.
+ * Tools ▸ New DMN Model (also Project view ▸ New) — creates a `.dmn` file and
+ * opens it in the DMN modeler. The IntelliJ counterpart of the VS Code
+ * `miragon.dmnModeler.newDiagram` command.
  *
- * Unlike BPMN, the DMN scaffold is replicated here as a Kotlin constant rather
- * than deferred to the core: there is no IntelliJ DMN editor or bridge session, so
- * no `display()` empty branch would fire. The file opens in the plain XML editor.
+ * Like [NewBpmnModelAction] the file is created **empty**: opening an empty `.dmn`
+ * triggers the core's `DmnModelerService.display()` empty branch over the bridge,
+ * which writes the decision-table scaffold. That keeps the seed XML single-sourced
+ * in the core (`libs/modeler-core/src/modeler/dmn/domain/emptyDmn.ts`) instead of
+ * replicated here in Kotlin.
  */
 class NewDmnModelAction : DumbAwareAction() {
     override fun actionPerformed(event: AnActionEvent) {
@@ -20,36 +22,7 @@ class NewDmnModelAction : DumbAwareAction() {
             dialogDescription = "Create a new empty DMN decision",
             extension = "dmn",
             defaultName = "decision.dmn",
-            content = EMPTY_DMN_DIAGRAM,
+            content = "", // empty → the core scaffolds it via display()'s empty branch
         )
-    }
-
-    private companion object {
-        // Host-replicated mirror of EMPTY_DMN_DIAGRAM in
-        // libs/modeler-core/src/modeler/dmn/domain/emptyDmn.ts — keep byte-identical.
-        // A full decision table + DMNDI so DMN-js could render it without errors.
-        val EMPTY_DMN_DIAGRAM =
-            """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_1y42u6n" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" exporter="Camunda Modeler" exporterVersion="5.8.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.18.0">
-              <decision id="Decision_16wqg49" name="Decision 1">
-                <decisionTable id="DecisionTable_1wi1sbd">
-                  <input id="Input_1">
-                    <inputExpression id="InputExpression_1" typeRef="string">
-                      <text></text>
-                    </inputExpression>
-                  </input>
-                  <output id="Output_1" typeRef="string" />
-                </decisionTable>
-              </decision>
-              <dmndi:DMNDI>
-                <dmndi:DMNDiagram>
-                  <dmndi:DMNShape dmnElementRef="Decision_16wqg49">
-                    <dc:Bounds height="80" width="180" x="160" y="100" />
-                  </dmndi:DMNShape>
-                </dmndi:DMNDiagram>
-              </dmndi:DMNDI>
-            </definitions>
-            """.trimIndent()
     }
 }

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WarmBrowser.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WarmBrowser.kt
@@ -13,13 +13,17 @@ import org.cef.browser.CefFrame
 import org.cef.handler.CefLoadHandlerAdapter
 
 /**
- * A JCEF browser pre-loaded with the bpmn-webview, ready to be handed to a
- * [BpmnFileEditor] the moment a `.bpmn` tab opens.
+ * A JCEF browser pre-loaded with a modeler webview ([shellUrl] selects the BPMN
+ * or DMN shell), ready to be handed to a [BpmnFileEditor] / [DmnFileEditor] the
+ * moment a modeler tab opens.
  *
- * **Why it exists.** The first `.bpmn` open otherwise pays, serially, for
- * `JBCefBrowser()` init + the loopback fetch of the heavy bpmn-js bundle + bpmn-js
+ * **Why it exists.** The first modeler open otherwise pays, serially, for
+ * `JBCefBrowser()` init + the loopback fetch of the heavy modeler bundle + its
  * init — the most perceptible startup latency. Building this ahead of time (at
  * project open, via [BrowserPrewarmService]) moves all of that off the open path.
+ * The BPMN path pre-warms one of these per project; the DMN path builds one
+ * inline on open (a `.dmn` tab is opened rarely enough not to justify a second
+ * always-warm browser).
  *
  * **The forwarder indirection.** The JS→JVM [JBCefJSQuery] must be created *before*
  * the browser's CEF process starts: its handler registers a `CefMessageRouter` on
@@ -36,7 +40,7 @@ import org.cef.handler.CefLoadHandlerAdapter
  * now-set forwarder. The sink is deliberately *not* injected during pre-warm, so
  * nothing flushes to a null forwarder.
  */
-class WarmBrowser : Disposable {
+class WarmBrowser(private val shellUrl: String) : Disposable {
     val browser = createModelerBrowser()
 
     // Set by bind() once the owning editor is known; read from the CEF query
@@ -105,7 +109,7 @@ class WarmBrowser : Disposable {
         // pre-warm instead of waiting for the component to be shown in a tab. Order
         // matters: jsQuery.create() above ran before this, so its router is bound.
         browser.createImmediately()
-        browser.loadURL(service<WebviewServer>().ensureStarted())
+        browser.loadURL(shellUrl)
     }
 
     /**

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/WebviewServer.kt
@@ -44,6 +44,17 @@ class WebviewServer : Disposable {
     @Volatile
     private var origin: String? = null
 
+    // The DMN bundle gets its OWN loopback origin rather than a path prefix on the
+    // bpmn server. The dmn-webview is built with Vite `base: "/"`, so its emitted
+    // assets reference each other and their fonts with absolute paths
+    // (`/index.js`, `url(/dmn.eot)`); the bpmn server already claims `/` as the
+    // bpmn bundle's catch-all, so those DMN roots would 404 against it. A separate
+    // origin lets the DMN bundle own its own `/` and resolve every absolute URL.
+    private var dmnServer: HttpServer? = null
+
+    @Volatile
+    private var dmnBaseUrl: String? = null
+
     /**
      * Starts the server on first call and returns the URL of the synthesised
      * bpmn editor shell. Idempotent — later calls return the already-bound URL.
@@ -83,6 +94,32 @@ class WebviewServer : Disposable {
         return "${origin}/deployment.html"
     }
 
+    /**
+     * Starts the dedicated DMN server on first call and returns the DMN editor
+     * shell URL. Idempotent. Kept on its own origin (not a path on the bpmn
+     * server) so the `base: "/"` dmn bundle's absolute asset/font URLs resolve —
+     * see [dmnServer].
+     */
+    @Synchronized
+    fun dmnUrl(): String {
+        dmnBaseUrl?.let { return it }
+
+        // Same loopback/IPv4 rationale as [ensureStarted]; a distinct ephemeral port.
+        val httpServer = HttpServer.create(InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0), 0)
+        httpServer.createContext("/") { exchange -> handleDmn(exchange) }
+        httpServer.executor =
+            Executors.newCachedThreadPool { runnable ->
+                Thread(runnable, "modeler-dmn-webview-http").apply { isDaemon = true }
+            }
+        httpServer.start()
+
+        val url = "http://127.0.0.1:${httpServer.address.port}/index.html"
+        dmnServer = httpServer
+        dmnBaseUrl = url
+        log.info("Miragon DMN webview server started at $url")
+        return url
+    }
+
     private fun handle(exchange: HttpExchange) {
         try {
             val path = exchange.requestURI.path
@@ -117,6 +154,75 @@ class WebviewServer : Disposable {
         } finally {
             exchange.close()
         }
+    }
+
+    /**
+     * Serves the DMN bundle on its own origin: the synthesised shell at `/` and
+     * every other request straight from the `/webview-dmn/...` classpath root
+     * (staged by the Gradle `copyDmnWebview` task). Because this origin only ever
+     * serves the DMN bundle, the bundle's absolute `/…` asset and font URLs map
+     * 1:1 onto the classpath — no path rewriting needed.
+     */
+    private fun handleDmn(exchange: HttpExchange) {
+        try {
+            val path = exchange.requestURI.path
+            if (path == "/" || path == "/index.html") {
+                respond(exchange, 200, "text/html; charset=utf-8", dmnHtml().toByteArray(StandardCharsets.UTF_8))
+                return
+            }
+            val decoded = URLDecoder.decode(path, StandardCharsets.UTF_8)
+            val bytes = javaClass.getResourceAsStream("/webview-dmn$decoded")?.use { it.readBytes() }
+            if (bytes == null) {
+                respond(exchange, 404, "text/plain; charset=utf-8", "Not found: $path".toByteArray())
+                return
+            }
+            respond(exchange, 200, mimeType(path), bytes)
+        } catch (e: Exception) {
+            log.warn("Error serving DMN ${exchange.requestURI}", e)
+            runCatching { respond(exchange, 500, "text/plain; charset=utf-8", (e.message ?: "error").toByteArray()) }
+        } finally {
+            exchange.close()
+        }
+    }
+
+    /**
+     * Synthesises the DMN editor shell, mirroring [indexHtml]: same DOM skeleton
+     * (dmn-js reuses the bpmn-js `#js-canvas` / properties-panel layout), the same
+     * `#theme-link` swap contract, `#ide-theme-vars` block, and shim. It carries
+     * no bpmn icon-font link — the dmn bundle's own stylesheets pull the dmn font
+     * from this origin (`url(/dmn.eot)` → `/webview-dmn/dmn.eot`). Assets are
+     * root-absolute because this shell is served on the dedicated DMN origin.
+     *
+     * The off-EDT palette read on the HTTP pool thread is safe for the same reason
+     * documented on [indexHtml].
+     */
+    private fun dmnHtml(): String {
+        val signal = service<IdeThemeSignal>()
+        return listOf(
+            "<!DOCTYPE html>",
+            "<html lang=\"en\">",
+            "<head>",
+            "  <meta charset=\"UTF-8\"/>",
+            "  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"/>",
+            "  <link href=\"/index.css\" rel=\"stylesheet\"/>",
+            "  <link href=\"/lightTheme.css\" rel=\"stylesheet\" id=\"theme-link\"/>",
+            "  <title>DMN Modeler</title>",
+            "  <style>html, body { margin: 0; height: 100%; } #app { height: 100vh; }</style>",
+            "  <style id=\"ide-theme-vars\">${signal.themeVarsCss()}</style>",
+            "  <script>$SHIM</script>",
+            "</head>",
+            "<body class=\"${signal.bodyClass()}\">",
+            "  <div id=\"app\">",
+            "    <div class=\"content with-diagram\" id=\"js-drop-zone\">",
+            "      <div class=\"canvas\" id=\"js-canvas\"></div>",
+            "      <div id=\"js-panel-resizer\" class=\"panel-resizer\"></div>",
+            "      <div class=\"properties-panel-parent\" id=\"js-properties-panel\"></div>",
+            "    </div>",
+            "  </div>",
+            "  <script type=\"module\" src=\"/index.js\"></script>",
+            "</body>",
+            "</html>",
+        ).joinToString("\n")
     }
 
     /**
@@ -221,6 +327,9 @@ class WebviewServer : Disposable {
         server = null
         baseUrl = null
         origin = null
+        dmnServer?.stop(0)
+        dmnServer = null
+        dmnBaseUrl = null
     }
 
     private companion object {

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/bridge/EditorSessionRouter.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.text.StringUtil
 import com.intellij.util.concurrency.AppExecutorUtil
 import io.miragon.intellij.bpmn.CoreSession
+import io.miragon.intellij.bpmn.ModelerKind
 import io.miragon.intellij.bpmn.ModelerSettingsStore
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -117,6 +118,8 @@ internal class EditorSessionRouter(
                 // very first discovery uses the configured folder, not the default.
                 "settings" to ModelerSettingsStore.getInstance().snapshotMap(deps.project),
                 "content" to content,
+                // Routes the session to the BPMN or DMN service in the bridge.
+                "kind" to session.kind.wire,
             ),
         )
     }
@@ -283,7 +286,9 @@ internal class EditorSessionRouter(
         if (!deps.isProcessAlive()) return
         sessions.values.forEach { session ->
             sendRegister(session)
-            forwardWebviewMessage(session.editorId, GET_BPMN_FILE_COMMAND)
+            val replay =
+                if (session.kind == ModelerKind.DMN) GET_DMN_FILE_COMMAND else GET_BPMN_FILE_COMMAND
+            forwardWebviewMessage(session.editorId, replay)
         }
     }
 
@@ -427,6 +432,9 @@ internal class EditorSessionRouter(
 
     private companion object {
         const val GET_BPMN_FILE_COMMAND = "{\"type\":\"GetBpmnFileCommand\"}"
+
+        // The DMN twin, replayed on respawn so a live `.dmn` page re-renders.
+        const val GET_DMN_FILE_COMMAND = "{\"type\":\"GetDmnFileCommand\"}"
 
         // Posted into the webview to request an SVG export; the webview echoes the
         // same command back with the rendered `svg` field populated.

--- a/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/apps/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -110,6 +110,21 @@
         <fileEditorProvider implementation="io.miragon.intellij.bpmn.BpmnFileEditorProvider"/>
 
         <!--
+            The DMN twin of the BPMN registration above: `.dmn` becomes a real file
+            type (Marketplace indexing + project-tree icon + XML highlighting on the
+            secondary text tab) and the JCEF DMN editor binds ahead of the plain XML
+            editor. Same rationale as BPMN; see the comment on the BPMN fileType.
+        -->
+        <fileType
+            name="DMN"
+            implementationClass="io.miragon.intellij.bpmn.DmnFileType"
+            fieldName="INSTANCE"
+            language="XML"
+            extensions="dmn"/>
+
+        <fileEditorProvider implementation="io.miragon.intellij.bpmn.DmnFileEditorProvider"/>
+
+        <!--
             Pre-warms the out-of-process bridge + asset server off the EDT after a
             project opens, so the first `.bpmn` tab renders against a live process
             instead of a cold spawn. The spawn itself is already moved off the EDT

--- a/apps/intellij-plugin/src/main/resources/icons/dmn.svg
+++ b/apps/intellij-plugin/src/main/resources/icons/dmn.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#00B45A" stroke-width="1.6" stroke-linejoin="round">
+  <rect x="3.5" y="4.5" width="17" height="15" rx="2"/>
+  <path d="M3.5 9.5h17M3.5 14.5h17M12 9.5v10"/>
+</svg>

--- a/apps/intellij-plugin/src/main/resources/icons/dmn_dark.svg
+++ b/apps/intellij-plugin/src/main/resources/icons/dmn_dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#00E676" stroke-width="1.6" stroke-linejoin="round">
+  <rect x="3.5" y="4.5" width="17" height="15" rx="2"/>
+  <path d="M3.5 9.5h17M3.5 14.5h17M12 9.5v10"/>
+</svg>

--- a/apps/modeler-bridge/src/composition/editorSessionFeature.ts
+++ b/apps/modeler-bridge/src/composition/editorSessionFeature.ts
@@ -1,7 +1,12 @@
 import { basename } from "node:path";
 
 import { Command, Query, SyncDocumentCommand } from "@miragon/bpmn-modeler-shared";
-import { BpmnModelerService, registerWebviewLogHandlers } from "@miragon/bpmn-modeler-core";
+import {
+    BpmnModelerService,
+    DmnModelerService,
+    DmnSettingsBroadcaster,
+    registerWebviewLogHandlers,
+} from "@miragon/bpmn-modeler-core";
 
 import { RpcEditorHandle } from "../adapters";
 import { METHODS } from "../protocol/descriptor";
@@ -27,8 +32,14 @@ function query(type: string, fields: Record<string, unknown>): Query {
  * so this module drives the lifecycle without importing any of them — hooks flow
  * backward, handles flow forward.
  *
- * Webview messages: GetBpmnFileCommand, SyncDocumentCommand,
- * GetPropertiesPanelStateCommand.
+ * Both the BPMN and the DMN modeler ride this one lifecycle hub. The session's
+ * {@link RegisterParams.kind} (from `session/register`) decides which service a
+ * given editor's render/sync routes to; the DMN path additionally skips the
+ * BPMN-only session hooks (template watcher, script tabs, code-link) since none
+ * of them apply to a decision table.
+ *
+ * Webview messages: GetBpmnFileCommand, GetDmnFileCommand,
+ * GetDmnModelerSettingCommand, SyncDocumentCommand, GetPropertiesPanelStateCommand.
  * RPC (Host → Core): session/register, session/setActive, session/dispose,
  * webview/message, document/didChange.
  */
@@ -43,8 +54,16 @@ export function register(
         deps.statusBar,
         deps.notifier,
     );
+    const dmnService = new DmnModelerService(deps.store, deps.documentPort, deps.notifier);
+    const dmnSettings = new DmnSettingsBroadcaster(deps.store, deps.settings, deps.notifier);
 
     const handles = new Map<string, RpcEditorHandle>();
+
+    // Which modeler owns each open editor. Seeded on register, read by the shared
+    // SyncDocumentCommand / document/didChange paths to pick the right service.
+    // Absent ⇒ bpmn (see RegisterParams.kind).
+    const sessionKinds = new Map<string, "bpmn" | "dmn">();
+    const kindOf = (editorId: string): "bpmn" | "dmn" => sessionKinds.get(editorId) ?? "bpmn";
 
     deps.router
         .on("GetBpmnFileCommand", async (_message: Command, editorId: string) => {
@@ -52,8 +71,27 @@ export function register(
                 deps.notifier.logDebug("BPMN modeler is ready");
             }
         })
+        .on("GetDmnFileCommand", async (_message: Command, editorId: string) => {
+            if (await dmnService.display(editorId)) {
+                deps.notifier.logDebug("DMN modeler is ready");
+            }
+        })
+        // The DMN webview asks for its color-theme preference during bootstrap;
+        // without a reply its `Promise.all` over file+settings+panel-state never
+        // resolves and the editor stays blank (same handshake contract as BPMN).
+        .on("GetDmnModelerSettingCommand", async (_message: Command, editorId: string) => {
+            await dmnSettings.setSettings(editorId);
+        })
+        // Both modelers emit SyncDocumentCommand; route to the service that owns
+        // this editor so a DMN write can't run through the BPMN service (its
+        // session guard / status bar) and vice versa.
         .on("SyncDocumentCommand", async (message: Command, editorId: string) => {
-            await bpmnService.sync(editorId, (message as SyncDocumentCommand).content);
+            const content = (message as SyncDocumentCommand).content;
+            if (kindOf(editorId) === "dmn") {
+                await dmnService.sync(editorId, content);
+            } else {
+                await bpmnService.sync(editorId, content);
+            }
         })
         // The remaining handshake reply is a bridge-level stub because its real
         // service (properties panel) is not wired on this host path. It must still
@@ -84,6 +122,9 @@ export function register(
             deps.settings.apply(params.settings);
         }
 
+        const kind = params.kind ?? "bpmn";
+        sessionKinds.set(params.editorId, kind);
+
         deps.mirror.register(params, params.content);
         const handle = new RpcEditorHandle(params, deps.mirror, deps.rpc, deps.settings);
         handles.set(params.editorId, handle);
@@ -100,6 +141,17 @@ export function register(
                 deps.notifier.logError(error instanceof Error ? error : new Error(String(error)));
             }),
         );
+
+        if (kind === "dmn") {
+            // The DMN surface only needs render-guard tracking and the theme
+            // broadcaster; element templates, script tabs and code-link are BPMN
+            // concepts, so their hooks stay out of the DMN path entirely.
+            dmnService.registerSession(params.editorId);
+            dmnSettings.subscribe(params.editorId);
+            deps.log(`session registered (dmn): ${params.editorId}`);
+            return;
+        }
+
         bpmnService.registerSession(params.editorId);
 
         // Seed discovery with the host's authoritative root before the hooks run.
@@ -137,7 +189,11 @@ export function register(
             return; // our own write echoed back — re-rendering would loop
         }
         deps.mirror.setContent(params.editorId, params.content);
-        await bpmnService.display(params.editorId);
+        if (kindOf(params.editorId) === "dmn") {
+            await dmnService.display(params.editorId);
+        } else {
+            await bpmnService.display(params.editorId);
+        }
     });
 
     // The host reports which editor tab is focused so the store's active-editor
@@ -148,6 +204,21 @@ export function register(
     });
 
     deps.rpc.on(METHODS.sessionDispose, (params: EditorRefParams) => {
+        const kind = kindOf(params.editorId);
+        sessionKinds.delete(params.editorId);
+
+        if (kind === "dmn") {
+            // Mirror of the DMN register branch: only the render-guard session was
+            // created (the theme subscription is torn down with the store handle
+            // below), so no BPMN hooks / workspace-root unregister run here.
+            dmnService.disposeSession(params.editorId);
+            handles.get(params.editorId)?.dispose();
+            handles.delete(params.editorId);
+            deps.mirror.remove(params.editorId);
+            deps.log(`session disposed (dmn): ${params.editorId}`);
+            return;
+        }
+
         bpmnService.disposeSession(params.editorId);
 
         // Per-session teardown owned by sibling features (script tabs, code-link

--- a/apps/modeler-bridge/src/composition/sessionHooks.ts
+++ b/apps/modeler-bridge/src/composition/sessionHooks.ts
@@ -10,6 +10,13 @@ export interface RegisterParams extends SessionMeta {
     content: string;
     /** Full `miragon.bpmnModeler.*` snapshot; seeds settings before template discovery. */
     settings?: Partial<SettingsSnapshot>;
+    /**
+     * Which modeler drives this session. Absent means `bpmn` so an older host that
+     * predates DMN support keeps registering BPMN sessions unchanged. Only `dmn`
+     * routes document sync/render to {@link DmnModelerService} and skips the
+     * BPMN-only session hooks (template watcher, script tabs, code-link).
+     */
+    kind?: "bpmn" | "dmn";
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "demo:app": "npm-run-all -s build:demo preview:demo",
         "build:bridge": "corepack yarn workspace @miragon/bpmn-modeler-bridge build",
         "build:bridge:compile": "corepack yarn workspace @miragon/bpmn-modeler-bridge compile",
-        "intellij:build": "npm-run-all -s build:libs -p build:bpmn-webview build:deployment-webview build:bridge:compile",
+        "intellij:build": "npm-run-all -s build:libs -p build:bpmn-webview build:dmn-webview build:deployment-webview build:bridge:compile",
         "intellij:runide": "cd apps/intellij-plugin && ./gradlew runIde",
         "intellij:run": "npm-run-all -s intellij:build intellij:runide",
         "dev:libs": "npm-run-all dev:lib:shared dev:lib:modeler-core",


### PR DESCRIPTION
## What & why

Adds a **visual DMN editor** to the IntelliJ host so `.dmn` files open in the dmn-js webview — on par with the VS Code DMN editor — instead of falling back to the plain XML editor.

Closes #1286.

## How

The DMN path mirrors the existing BPMN editor across every layer and reuses the host-agnostic `modeler-core` unchanged (no engine changes).

**Bridge (`apps/modeler-bridge`)**
- `RegisterParams.kind: "bpmn" | "dmn"` discriminator on `session/register` (defaults to `bpmn`, so an older host keeps registering BPMN sessions unchanged).
- `editorSessionFeature` now also wires `DmnModelerService` + `DmnSettingsBroadcaster`, tracks each session's kind, handles `GetDmnFileCommand` / `GetDmnModelerSettingCommand`, and routes the shared `SyncDocumentCommand` + `document/didChange` to the correct service by kind. DMN sessions skip the BPMN-only hooks (element templates, script tabs, code-link).

**IntelliJ host (`apps/intellij-plugin`)**
- New `DmnFileType`, `DmnFileEditorProvider`, `DmnFileEditor` (mirrors the BPMN trio) + a 16×16 decision-table file icon.
- `WebviewServer` serves the DMN bundle on its **own loopback origin**. The `dmn-webview` is built with Vite `base: "/"`, so its assets and fonts use absolute URLs (`/index.js`, `url(/dmn.eot)`); the bpmn bundle already claims `/` as its catch-all, so a shared path prefix would 404. A dedicated origin lets the DMN bundle own its own root.
- `WarmBrowser` is parametrized by shell URL; `CoreSession` / `EditorSessionRouter` carry the modeler kind, send it on register, and replay `GetDmnFileCommand` on bridge respawn.
- `New DMN Model` now creates an empty file and lets the core scaffold it via `display()`, single-sourcing the seed XML in `modeler-core` (drops the duplicated Kotlin constant).

**Staging & registration**
- `copyDmnWebview` Gradle task stages the bundle to classpath `/webview-dmn`; `intellij:build` now builds `dmn-webview`; `plugin.xml` registers the `.dmn` fileType + fileEditorProvider.

## Verification

| Gate | Result |
|---|---|
| Bridge unit tests | ✅ 166 passed |
| `./gradlew test` (plugin) | ✅ |
| `./gradlew verifyPlugin` | ✅ Compatible against IC-242 (floor) and IU-261 (latest) |
| Prettier `format:check` | ✅ |

## Not yet verified — needs a manual smoke test

The interactive check (open a `.dmn` in the sandbox IDE, confirm it renders and round-trips edits) could not be automated — the JCEF UI can't be driven headlessly. To try it:

```bash
corepack yarn intellij:build
cd apps/intellij-plugin && ./gradlew runIde
# then open a .dmn, or Tools ▸ New DMN Model
```
