### PR TITLE
fix(release): sync intellij manifest to released 1.6.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
   ".": "1.5.0",
-  "apps/intellij-plugin": "1.5.0"
+  "apps/intellij-plugin": "1.6.0"
 }


### PR DESCRIPTION
## Problem

Release-please re-proposed IntelliJ **1.6.0** in PR #1279, even though `intellij-v1.6.0` is already tagged and deployed.

Root cause: the 1.6.0 release PR (#1255) bumped `apps/intellij-plugin/gradle.properties` and the changelog, but left `.release-please-manifest.json` at `1.5.0`. Release-please treats the **manifest** as its source of truth, so it never recognised 1.6.0 as released — it saw the feats since 1.5.0 (already shipped in 1.6.0) and computed a fresh minor bump back to 1.6.0.

State before this fix:
- Tag `intellij-v1.6.0` ✅ (deployed)
- `gradle.properties` = `1.6.0` ✅
- Manifest = `1.5.0` ❌ ← the only outlier

## Fix

Set `apps/intellij-plugin` in the manifest to the real released version `1.6.0`. The `.` (vscode) line is a separate release line and stays untouched.

## Effect

Once merged, release-please recognises 1.6.0 as released. The duplicate PR #1279 becomes obsolete (only a `chore` dependency bump has landed since the 1.6.0 tag), and the next real `feat`/`fix` cuts 1.7.0 / 1.6.1 as expected.