### PR TITLE
fix(intellij): theme properties-panel input text for JCEF dark mode

### DIFF
--- a/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
+++ b/apps/bpmn-webview/src/styles/dark-theme/properties-panel.css
@@ -105,12 +105,14 @@
 }
 
 .bio-properties-panel-textarea textarea,
-.bio-properties-panel-textfield input {
+.bio-properties-panel-textfield input,
+.bio-properties-panel-numberfield input {
     color: var(--dt-surface-a60) !important;
 }
 
 .bio-properties-panel-textarea > textarea:focus,
-.bio-properties-panel-textfield > input:focus {
+.bio-properties-panel-textfield > input:focus,
+.bio-properties-panel-numberfield > input:focus {
     color: var(--dt-surface-a70) !important;
 }
 

--- a/apps/dmn-webview/src/styles/dark-theme/properties-panel.css
+++ b/apps/dmn-webview/src/styles/dark-theme/properties-panel.css
@@ -111,12 +111,14 @@
 }
 
 .bio-properties-panel-textarea textarea,
-.bio-properties-panel-textfield input {
+.bio-properties-panel-textfield input,
+.bio-properties-panel-numberfield input {
     color: var(--dt-surface-a60) !important;
 }
 
 .bio-properties-panel-textarea > textarea:focus,
-.bio-properties-panel-textfield > input:focus {
+.bio-properties-panel-textfield > input:focus,
+.bio-properties-panel-numberfield > input:focus {
     color: var(--dt-surface-a70) !important;
 }
 

--- a/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
+++ b/apps/intellij-plugin/src/main/kotlin/io/miragon/intellij/bpmn/IdeThemeSignal.kt
@@ -66,6 +66,12 @@ class IdeThemeSignal : Disposable {
      * they're inert under a light LaF. The `.bio-properties-panel` block applies
      * to both stylesheets, which is why it overrides directly with `!important`
      * instead of riding the dark-only `--vscode-*` mapping.
+     *
+     * `color-scheme` is the other signal VS Code injects that JCEF does not:
+     * without it Chromium treats the page as light and paints native form
+     * controls (`<input>`/`<select>`/`<textarea>`) with the light-scheme system
+     * text color (black), unreadable on a dark panel. Setting it to match the
+     * LaF makes their default text follow the theme, mirroring VS Code.
      */
     fun themeVarsCss(): String {
         val scheme = EditorColorsManager.getInstance().globalScheme
@@ -86,6 +92,7 @@ class IdeThemeSignal : Disposable {
             ColorUtil.toHtmlColor(if (isDark()) ColorUtil.brighter(panelBg, 2) else ColorUtil.darker(panelBg, 1))
         return listOf(
             ":root {",
+            "  color-scheme: ${if (isDark()) "dark" else "light"};",
             "  --vscode-editor-background: $editorBackground;",
             "  --vscode-editor-foreground: $editorForeground;",
             "  --vscode-editorWidget-background: $widgetBackground;",
@@ -143,6 +150,7 @@ class IdeThemeSignal : Disposable {
 
         return listOf(
             ":root {",
+            "  color-scheme: ${if (isDark()) "dark" else "light"};",
             "  --vscode-foreground: $foreground;",
             "  --vscode-descriptionForeground: $descriptionForeground;",
             "  --vscode-icon-foreground: $foreground;",


### PR DESCRIPTION
## Problem

Fixes #1283. In the IntelliJ/JetBrains plugin with a dark IDE theme, the **values** inside properties-panel input controls (the `GET` method dropdown, the URL text field, the `20` timeout number fields) rendered in near-black text on the dark panel background — unreadable. Labels rendered correctly (light). VS Code was unaffected.

## Root cause

The properties panel is `@bpmn-io/properties-panel`. Native form controls (`<input>`/`<select>`/`<textarea>`) do **not** inherit the panel's text `color`, so the dark theme must set it explicitly, and the host must tell the browser it's in dark mode. Two gaps made IntelliJ differ from VS Code:

1. **Missing `color-scheme` (primary, host-specific).** VS Code auto-decorates every webview with `color-scheme` (plus the body class and `--vscode-*` vars). The JCEF host reproduces the body class and color variables in `IdeThemeSignal` but never set `color-scheme`, so Chromium treated the page as light and painted native-control text with the light-scheme system color (black) wherever the stylesheet didn't force a color.
2. **Number fields had no dark text override.** The dark stylesheet recolored only `-textfield`/`-textarea`/`-select`; number fields live in a `.bio-properties-panel-numberfield` container the existing selectors never matched.

## Changes

- `IdeThemeSignal.kt` — emit `color-scheme: dark|light` (driven by `isDark()`) in the injected `:root` block of both `themeVarsCss()` (modeler webview) and `deploymentThemeVarsCss()` (deployment form). Updates live on theme change via the existing `applyJs()` rewrite.
- `dark-theme/properties-panel.css` (bpmn + dmn twin) — add `.bio-properties-panel-numberfield input` to the input text-color rules (base + `:focus`), matching the `--dt-surface-a60`/`a70` tone used by the other controls.

## Verification

- `corepack yarn format:check` — clean.
- `corepack yarn workspace @miragon/bpmn-modeler-webview build` — clean; confirmed the number-field rule is in the compiled `darkTheme.css` and absent from `lightTheme.css`.
- Pending manual JCEF check: `corepack yarn intellij:run` under a dark IDE theme with a Camunda 8 REST-connector template; confirm dropdown/URL/timeout values are legible and re-theme on light↔dark toggle.