### PR TITLE
feat(modeler-bridge): apply .bpmnlintrc in the IntelliJ host

### DIFF
--- a/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
+++ b/apps/modeler-bridge/src/bridge.bpmnlint.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * End-to-end coverage for the bpmnlint config path on the bridge.
+ *
+ * Same harness style as `bridge.navigate.spec.ts`: the real bridge
+ * (`createBridge`) runs against a fake transport (a frames array) over a real
+ * temp filesystem, so the `BpmnLintConfigLocator` + `BpmnLintConfigService` do an
+ * actual nearest-`.bpmnlintrc` walk and read. Covers the two branches the
+ * webview's `GetBpmnlintConfigCommand` exposes: a discovered config is parsed and
+ * pushed as `BpmnlintConfigQuery`, and no config pushes `config: null` so the
+ * webview deactivates linting.
+ */
+
+import { promises as fs } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createBridge } from "./bridge";
+import { Rpc } from "./rpc";
+
+const BPMN_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true" />
+</bpmn:definitions>`;
+
+function registerParams(editorId: string, root: string, fsPath: string) {
+    return {
+        editorId,
+        uriString: editorId,
+        path: fsPath,
+        fsPath,
+        scheme: "file",
+        workspaceRoot: root,
+        content: BPMN_XML,
+    };
+}
+
+async function waitForFrame(
+    frames: any[],
+    predicate: (frame: any) => boolean,
+    timeoutMs = 2000,
+): Promise<any> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const match = frames.find(predicate);
+        if (match) return match;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error("waitForFrame timed out");
+}
+
+const isLintConfigFrame = (frame: any): boolean =>
+    frame.method === "editor/postMessage" && frame.params?.message?.type === "BpmnlintConfigQuery";
+
+describe("bridge bpmnlint (real core + locator over a fake transport)", () => {
+    const cleanups: Array<() => Promise<void> | void> = [];
+
+    afterEach(async () => {
+        for (const cleanup of cleanups.splice(0)) {
+            await cleanup();
+        }
+    });
+
+    async function setup(): Promise<{ rpc: Rpc; frames: any[]; root: string; editorId: string }> {
+        const root = await fs.mkdtemp(join(tmpdir(), "modeler-bridge-lint-"));
+        const sourcePath = join(root, "source.bpmn");
+        await fs.writeFile(sourcePath, BPMN_XML, "utf8");
+
+        const frames: any[] = [];
+        const { rpc } = createBridge((line) => frames.push(JSON.parse(line)));
+        const editorId = `file://${sourcePath}`;
+
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "session/register",
+                params: registerParams(editorId, root, sourcePath),
+            }),
+        );
+
+        cleanups.push(() => fs.rm(root, { recursive: true, force: true }));
+        return { rpc, frames, root, editorId };
+    }
+
+    async function requestConfig(rpc: Rpc, editorId: string): Promise<void> {
+        await rpc.handleLine(
+            JSON.stringify({
+                method: "webview/message",
+                params: { editorId, message: { type: "GetBpmnlintConfigCommand" } },
+            }),
+        );
+    }
+
+    it("pushes the nearest .bpmnlintrc contents to the webview", async () => {
+        const { rpc, frames, root, editorId } = await setup();
+        await fs.writeFile(
+            join(root, ".bpmnlintrc"),
+            JSON.stringify({ extends: "bpmnlint:recommended" }),
+            "utf8",
+        );
+
+        await requestConfig(rpc, editorId);
+
+        const frame = await waitForFrame(frames, isLintConfigFrame);
+        expect(frame.params.message.config).toEqual({ extends: "bpmnlint:recommended" });
+    });
+
+    it("pushes a null config when no .bpmnlintrc exists so linting deactivates", async () => {
+        const { rpc, frames, editorId } = await setup();
+
+        await requestConfig(rpc, editorId);
+
+        const frame = await waitForFrame(frames, isLintConfigFrame);
+        expect(frame.params.message.config).toBeNull();
+    });
+});

--- a/apps/modeler-bridge/src/bridge.ts
+++ b/apps/modeler-bridge/src/bridge.ts
@@ -41,6 +41,7 @@ import * as templatesSettingsFeature from "./composition/templatesSettingsFeatur
 import * as clipboardFeature from "./composition/clipboardFeature";
 import * as navigationFeature from "./composition/navigationFeature";
 import * as codeLinkFeature from "./composition/codeLinkFeature";
+import * as bpmnlintFeature from "./composition/bpmnlintFeature";
 import * as scriptFeature from "./composition/scriptFeature";
 import * as editorSessionFeature from "./composition/editorSessionFeature";
 import * as commandsFeature from "./composition/commandsFeature";
@@ -94,12 +95,15 @@ export function createBridge(
     clipboardFeature.register(deps);
     navigationFeature.register(deps);
     const codeLink = codeLinkFeature.register(deps);
+    const bpmnlint = bpmnlintFeature.register(deps);
     const script = scriptFeature.register(deps);
     // Hook order is the per-session teardown order: script → code-link →
-    // templates, reproducing the original inline dispose sequence.
+    // bpmnlint → templates, reproducing the original inline dispose sequence
+    // (bpmnlint slots next to code-link — both are per-editor file watchers).
     const editorSession = editorSessionFeature.register(deps, [
         script.sessionHooks,
         codeLink.sessionHooks,
+        bpmnlint.sessionHooks,
         templates.sessionHooks,
     ]);
     // Portable modeler commands (change engine version, migrate all). Registered

--- a/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
+++ b/apps/modeler-bridge/src/composition/bpmnlintFeature.ts
@@ -1,0 +1,58 @@
+import { Command } from "@miragon/bpmn-modeler-shared";
+import { BpmnLintConfigLocator, BpmnLintConfigService } from "@miragon/bpmn-modeler-core";
+
+import { BridgeSharedDeps } from "./sharedDeps";
+import { RegisterParams, SessionHooks } from "./sessionHooks";
+
+/**
+ * The bpmnlint feature discovers the nearest `.bpmnlintrc` for an open BPMN
+ * document and pushes its raw contents to the webview, which owns the rule
+ * allow-list and the in-canvas violation markers. It reuses the host-agnostic
+ * core stack unchanged ({@link BpmnLintConfigLocator} + {@link BpmnLintConfigService})
+ * over the Workspace/Settings/Document/StatusBar ports the bridge already
+ * implements — the bridge analogue of the VS Code `BpmnlintParticipant`.
+ *
+ * Webview messages: GetBpmnlintConfigCommand.
+ * Session hooks: a per-editor `.bpmnlintrc` watcher that re-pushes on change.
+ */
+export function register(deps: BridgeSharedDeps): { sessionHooks: SessionHooks } {
+    const locator = new BpmnLintConfigLocator(deps.nodeWorkspace, deps.settings, deps.artifactSvc);
+    const lintSvc = new BpmnLintConfigService(
+        deps.store,
+        deps.documentPort,
+        locator,
+        deps.statusBar,
+        deps.notifier,
+    );
+
+    // The webview posts this once on load (fire-and-forget, not part of the
+    // bootstrap handshake). A missing/malformed config degrades to linting-off
+    // inside the service, so this never throws into the dispatcher.
+    deps.router.on("GetBpmnlintConfigCommand", async (_message: Command, editorId: string) => {
+        await lintSvc.setBpmnlintConfig(editorId);
+    });
+
+    // Per-editor `.bpmnlintrc` watcher so edits to the rules re-lint the open
+    // diagram without reopening it; disposed with the session.
+    const watchers = new Map<string, { dispose(): void }[]>();
+
+    return {
+        sessionHooks: {
+            onSessionRegistered: async (params: RegisterParams) => {
+                const { disposables, errors } = await locator.createWatcher(
+                    params.editorId,
+                    lintSvc,
+                );
+                watchers.set(params.editorId, disposables);
+                for (const error of errors) {
+                    deps.notifier.logError(error);
+                }
+            },
+            onSessionDisposed: (editorId: string) => {
+                watchers.get(editorId)?.forEach((disposable) => disposable.dispose());
+                watchers.delete(editorId);
+                deps.statusBar.hideBpmnlintStatus();
+            },
+        },
+    };
+}


### PR DESCRIPTION
## What & why

BPMN linting was inert in the IntelliJ host. The bridge never answered the webview's `GetBpmnlintConfigCommand`, so the modeler received no `.bpmnlintrc` and kept linting off — whereas the VS Code host wires this via `BpmnlintParticipant`. This PR makes `.bpmnlintrc`-based linting work in the IntelliJ modeler.

## How

A small, bridge-only feature that reuses the host-agnostic core stack unchanged — no Kotlin or protocol changes.

- **`composition/bpmnlintFeature.ts`** (new): constructs `BpmnLintConfigLocator` + `BpmnLintConfigService` over the Workspace/Settings/Document/StatusBar ports the bridge already provides. Answers `GetBpmnlintConfigCommand` by discovering the nearest `.bpmnlintrc`, parsing it, and pushing `BpmnlintConfigQuery` to the webview (which owns the rule allow-list and in-canvas violation markers). Installs a per-editor `.bpmnlintrc` watcher that re-pushes on create/change/delete and tears down with the session.
- **`bridge.ts`**: registers the feature and slots its session hook next to code-link (both are per-editor file watchers).
- **`bridge.bpmnlint.spec.ts`** (new): two fs-backed end-to-end tests over the real bridge — a discovered config is parsed and pushed, and a missing config pushes `config: null` so the webview deactivates linting.

## Verification

| Gate | Result |
|---|---|
| Bridge bundle (typecheck + compile) | ✅ |
| Bridge unit tests | ✅ 168 passed (+2 new) |
| Prettier `format:check` | ✅ |

## Deliberate omission

The status-bar **indicator** (`showBpmnlintActive` / `showBpmnlintNoConfig`) stays a no-op in `RpcStatusBar` — that is IntelliJ UI work (a dedicated widget). The actual linting (rule evaluation, in-canvas markers, lint button) works without it; only the small "bpmnlint active (path)" status text is absent. Can follow up separately.

## Manual smoke test (not automated)

The fs-backed tests exercise the discovery + push path directly, but the in-IDE render was not driven headlessly:

```bash
corepack yarn intellij:build
cd apps/intellij-plugin && ./gradlew runIde
# open a .bpmn in a project that has a .bpmnlintrc; violations should appear in-canvas
```
