### PR TITLE
feat(dmn-webview): integrate DMN decision-table simulation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,6 +8,7 @@ enableScripts: true
 nodeLinker: node-modules
 
 npmPreapprovedPackages:
+  - "@emaarco/dmn-js-simulation"
   - "@miragon/create-append-c7"
 
 npmScopes:

--- a/apps/dmn-webview/package.json
+++ b/apps/dmn-webview/package.json
@@ -14,6 +14,7 @@
     "dependencies": {
         "@bpmn-io/cm-theme": "0.2.2",
         "@bpmn-io/properties-panel": "3.46.0",
+        "@emaarco/dmn-js-simulation": "0.1.0",
         "@miragon/bpmn-modeler-i18n": "workspace:*",
         "@miragon/bpmn-modeler-shared": "workspace:*",
         "camunda-dmn-moddle": "1.3.1",

--- a/apps/dmn-webview/src/app/modeler.ts
+++ b/apps/dmn-webview/src/app/modeler.ts
@@ -4,6 +4,7 @@ import {
     DmnPropertiesPanelModule,
     DmnPropertiesProviderModule,
 } from "dmn-js-properties-panel";
+import DmnSimulationModule from "@emaarco/dmn-js-simulation";
 import camundaModdleDescriptors from "camunda-dmn-moddle/resources/camunda.json";
 
 import { NoModelerError } from "@miragon/bpmn-modeler-shared";
@@ -20,7 +21,11 @@ export function createModeler(): DmnModeler {
                 DmnPropertiesPanelModule,
                 DmnPropertiesProviderModule,
                 CamundaPropertiesProviderModule,
+                DmnSimulationModule.decisionRequirementsDiagram,
             ],
+        },
+        decisionTable: {
+            additionalModules: [DmnSimulationModule.decisionTable],
         },
         common: {
             expressionLanguages: {

--- a/apps/dmn-webview/src/styles.css
+++ b/apps/dmn-webview/src/styles.css
@@ -69,6 +69,10 @@ a:link {
     width: 100%;
 }
 
+.content .canvas:has(.dmn-decision-table-container) {
+    padding: 16px 20px;
+}
+
 .content .canvas,
 .content .panel-resizer,
 .content .properties-panel-parent {
@@ -89,8 +93,6 @@ a:link {
     border-left: 1px solid #e0e0e0;
     transition: background-color 0.15s ease, width 0.15s ease;
     position: relative;
-    /* Declared here (0,1,0) so a future `.collapsed` theme override (0,2,0)
-     * wins regardless of stylesheet load order. */
     --panel-resizer-accent-color: rgba(0, 120, 212, 0.4);
     --panel-resizer-accent-hover-color: rgba(0, 120, 212, 0.8);
 }
@@ -109,10 +111,6 @@ a:link {
 
 .panel-resizer.collapsed {
     width: 8px;
-    /* Draw the accent line via `::before`/`::after` instead of `border-left`:
-     * the toggle button can't reliably cover a real border (Chromium layer
-     * paint order), so two segments stop above and resume below it. Zero the
-     * border width so `:hover` can't recolor a leftover 1px border. */
     border-left-width: 0;
 }
 
@@ -160,8 +158,6 @@ a:link {
 .panel-resizer-toggle {
     display: flex;
     position: absolute;
-    /* Center via top + margin, not `transform: translateY(-50%)`: a transform
-     * isolates a layer that lets the resizer border bleed through the button. */
     top: 50%;
     margin-top: -20px;
     right: 0;

--- a/apps/dmn-webview/src/styles/dark-theme/index.css
+++ b/apps/dmn-webview/src/styles/dark-theme/index.css
@@ -11,6 +11,7 @@
 @import "dmn-js/dist/assets/dmn-js-shared.css";
 @import "dmn-js/dist/assets/dmn-font/css/dmn-embedded.css";
 @import "@bpmn-io/properties-panel/dist/assets/properties-panel.css";
+@import "@emaarco/dmn-js-simulation/assets/dmn-js-simulation.css";
 
 @import "./colors.css";
 @import "./base-layout.css";

--- a/apps/dmn-webview/src/styles/light-theme/index.css
+++ b/apps/dmn-webview/src/styles/light-theme/index.css
@@ -10,3 +10,4 @@
 @import "dmn-js/dist/assets/dmn-js-shared.css";
 @import "dmn-js/dist/assets/dmn-font/css/dmn-embedded.css";
 @import "@bpmn-io/properties-panel/dist/assets/properties-panel.css";
+@import "@emaarco/dmn-js-simulation/assets/dmn-js-simulation.css";

--- a/apps/dmn-webview/vite.config.mts
+++ b/apps/dmn-webview/vite.config.mts
@@ -11,14 +11,9 @@ export default defineConfig({
     cacheDir: "../../node_modules/.vite/dmn-webview",
     plugins: [tsconfigPaths()],
     resolve: {
-        // The dependency tree pulls in several CodeMirror/Lezer copies at
-        // overlapping ^6 ranges (feel-editor, properties-panel, feelers, …).
-        // CodeMirror identifies extensions via `instanceof` against its own
-        // `@codemirror/state`, so two copies make the FEEL editor's
-        // `EditorState.create` throw "Unrecognized extension value". Forcing a
-        // single copy of each fixes it. Mirrors the bpmn-webview config.
         dedupe: [
             "preact",
+            "inferno",
             "@bpmn-io/properties-panel",
             "@codemirror/state",
             "@codemirror/view",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2488,6 +2488,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emaarco/dmn-js-simulation@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@emaarco/dmn-js-simulation@npm:0.1.0"
+  dependencies:
+    feelin: "npm:7.0.1"
+  peerDependencies:
+    diagram-js: ">=15"
+    dmn-js: ">=17"
+    inferno: ">=5.6 <6"
+  peerDependenciesMeta:
+    diagram-js:
+      optional: true
+    dmn-js:
+      optional: true
+    inferno:
+      optional: true
+  checksum: 10c0/f175d496ff1ce351e26d155bba192f7f3dbbde78154c9a5a6cdfd44e9f298320d6f4085e7f252175976036fbc6bb28804639d15df86fa5cc656e336c26f3d14e
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
@@ -3237,7 +3257,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lezer/common@npm:^1.2.0":
+"@lezer/common@npm:^1.2.0, @lezer/common@npm:^1.5.2":
   version: 1.5.2
   resolution: "@lezer/common@npm:1.5.2"
   checksum: 10c0/e39b46d74899409eab549df7942f00cd8c7f46c81ef0e2f079654ca96d262fca009927328bcd500d69270f5f09986e74768bed19c0acaadbd22f1a6c7dd9bd85
@@ -3776,6 +3796,7 @@ __metadata:
   dependencies:
     "@bpmn-io/cm-theme": "npm:0.2.2"
     "@bpmn-io/properties-panel": "npm:3.46.0"
+    "@emaarco/dmn-js-simulation": "npm:0.1.0"
     "@miragon/bpmn-modeler-i18n": "workspace:*"
     "@miragon/bpmn-modeler-shared": "workspace:*"
     "@types/vscode-webview": "npm:1.57.5"
@@ -12823,6 +12844,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"feelin@npm:7.0.1":
+  version: 7.0.1
+  resolution: "feelin@npm:7.0.1"
+  dependencies:
+    "@lezer/common": "npm:^1.5.2"
+    lezer-feel: "npm:^3.0.1"
+    luxon: "npm:^3.7.2"
+    min-dash: "npm:^5.0.0"
+  checksum: 10c0/aae2ae7db9fc7831209a10282ffd09c68ba3a579df8e1bdd07cab77d31ee584b125a23eb666502b84e8707b91f40829e2bafdb987a99eb79063f0b0cd30d681d
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -15198,6 +15231,17 @@ __metadata:
     prelude-ls: "npm:^1.2.1"
     type-check: "npm:~0.4.0"
   checksum: 10c0/effb03cad7c89dfa5bd4f6989364bfc79994c2042ec5966cb9b95990e2edee5cd8969ddf42616a0373ac49fac1403437deaf6e9050fbbaa3546093a59b9ac94e
+  languageName: node
+  linkType: hard
+
+"lezer-feel@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "lezer-feel@npm:3.0.1"
+  dependencies:
+    "@lezer/highlight": "npm:^1.2.3"
+    "@lezer/lr": "npm:^1.4.10"
+    min-dash: "npm:^5.0.0"
+  checksum: 10c0/ffb8bf26e80cd2e845a623ada2f250695eda745d3cae5f17fbe2cdf5a29a1391ebba2186f56636a99f0dc1525dfe74ea4eeaa3bb9c3529eda362c5540d34ff5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #1294

## What

Embeds [`@emaarco/dmn-js-simulation`](https://www.npmjs.com/package/@emaarco/dmn-js-simulation) into the DMN modeler — an input form over the decision table runs the decision and highlights the matched rule(s) and output, plus chained simulation across a DRD. To DMN what the already-shipped `bpmn-js-token-simulation` is to BPMN.

## How

Drop-in dmn-js module, registered **per view** (dmn-js merges modules per view; `common.additionalModules` does not propagate):

- `apps/dmn-webview/src/app/modeler.ts` — `DmnSimulationModule.decisionTable` on the `decisionTable` view, `.decisionRequirementsDiagram` on the `drd` view.
- `styles/{light,dark}-theme/index.css` — bundle the package stylesheet into both swappable theme entries.
- `vite.config.mts` — add `inferno` to `dedupe` (the table editor and simulation UI both render through Inferno; two copies break its `instanceof` VDOM checks, same failure mode as the CodeMirror copies).
- `.yarnrc.yml` — preapprove the freshly-published package past Yarn's supply-chain quarantine gate.

Pure client-side (FEEL eval via `feelin`), so it works across all hosts (VS Code, IntelliJ, standalone) with no bridge/RPC work. Peer deps already satisfied: dmn-js 17.8.1, diagram-js 15.18.0, inferno 5.6.3.

## Layout tweak

- `apps/dmn-webview/src/styles.css` — inset the **decision-table view** from the editor edges (`padding` scoped via `:has(.dmn-decision-table-container)`), so its document-flow content (view switcher, simulation form, table) no longer sits flush in the top-left corner. The DRD diagram view carries its own padding and is deliberately left untouched.

## Ephemeral by design

The simulation modules inject only overlay/render services (`eventBus, sheet, renderer, components, simulationStore` / `canvas, elementRegistry, overlays`) — no `modeling` or `commandStack`. A run therefore cannot fire `commandStack.changed`, so it never marks the document dirty or triggers a re-sync.

## Verification

- `corepack yarn workspace @miragon/dmn-modeler-webview build` — green.
- `format:check` — green.
- Manual (VS Code + demo): input form runs and highlights the matched rule; decision-table view is inset while DRD keeps its own padding.

## Follow-up

Dark-mode polish of the simulation form (package is CSS-variable themeable) if needed — non-blocking.